### PR TITLE
Backfill performance stats Nov 2025 until Mar 2026

### DIFF
--- a/performance-results/2025-11-30T22-53-14Z-aa0b31ebf28fdbf17d659800f6e8e6e1381dde50-jdk17.json
+++ b/performance-results/2025-11-30T22-53-14Z-aa0b31ebf28fdbf17d659800f6e8e6e1381dde50-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3102124969742373,
+            "scoreError" : 0.05903662064864365,
+            "scoreConfidence" : [
+                3.251175876325594,
+                3.3692491176228807
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.2967444144505405,
+                "50.0" : 3.3136385418481105,
+                "90.0" : 3.316828489750187,
+                "95.0" : 3.316828489750187,
+                "99.0" : 3.316828489750187,
+                "99.9" : 3.316828489750187,
+                "99.99" : 3.316828489750187,
+                "99.999" : 3.316828489750187,
+                "99.9999" : 3.316828489750187,
+                "100.0" : 3.316828489750187
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.2967444144505405,
+                    3.3126998329663473
+                ],
+                [
+                    3.316828489750187,
+                    3.3145772507298736
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6722899284716028,
+            "scoreError" : 0.022415988369652855,
+            "scoreConfidence" : [
+                1.64987394010195,
+                1.6947059168412557
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6676016708141779,
+                "50.0" : 1.673025295863826,
+                "90.0" : 1.6755074513445807,
+                "95.0" : 1.6755074513445807,
+                "99.0" : 1.6755074513445807,
+                "99.9" : 1.6755074513445807,
+                "99.99" : 1.6755074513445807,
+                "99.999" : 1.6755074513445807,
+                "99.9999" : 1.6755074513445807,
+                "100.0" : 1.6755074513445807
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6676016708141779,
+                    1.6755074513445807
+                ],
+                [
+                    1.671866409029942,
+                    1.6741841826977102
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8388798959474355,
+            "scoreError" : 0.029530422704090443,
+            "scoreConfidence" : [
+                0.809349473243345,
+                0.868410318651526
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8348201079825024,
+                "50.0" : 0.8376296529242124,
+                "90.0" : 0.8454401699588148,
+                "95.0" : 0.8454401699588148,
+                "99.0" : 0.8454401699588148,
+                "99.9" : 0.8454401699588148,
+                "99.99" : 0.8454401699588148,
+                "99.999" : 0.8454401699588148,
+                "99.9999" : 0.8454401699588148,
+                "100.0" : 0.8454401699588148
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8375761450163725,
+                    0.8454401699588148
+                ],
+                [
+                    0.8348201079825024,
+                    0.8376831608320525
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.776354651322412,
+            "scoreError" : 0.2711495340075292,
+            "scoreConfidence" : [
+                15.505205117314883,
+                16.04750418532994
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.63867515494796,
+                "50.0" : 15.791575822370978,
+                "90.0" : 15.90125847419491,
+                "95.0" : 15.90125847419491,
+                "99.0" : 15.90125847419491,
+                "99.9" : 15.90125847419491,
+                "99.99" : 15.90125847419491,
+                "99.999" : 15.90125847419491,
+                "99.9999" : 15.90125847419491,
+                "100.0" : 15.90125847419491
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.776530893401938,
+                    15.692954453910955,
+                    15.63867515494796
+                ],
+                [
+                    15.842088180138692,
+                    15.806620751340018,
+                    15.90125847419491
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2609.6300977652754,
+            "scoreError" : 113.10655353137335,
+            "scoreConfidence" : [
+                2496.523544233902,
+                2722.7366512966487
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2562.9804600813536,
+                "50.0" : 2608.592708541192,
+                "90.0" : 2652.914744655164,
+                "95.0" : 2652.914744655164,
+                "99.0" : 2652.914744655164,
+                "99.9" : 2652.914744655164,
+                "99.99" : 2652.914744655164,
+                "99.999" : 2652.914744655164,
+                "99.9999" : 2652.914744655164,
+                "100.0" : 2652.914744655164
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2578.3261917856994,
+                    2562.9804600813536,
+                    2578.9905003197196
+                ],
+                [
+                    2646.3737729870504,
+                    2652.914744655164,
+                    2638.1949167626653
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73185.39453075598,
+            "scoreError" : 1026.0563931677875,
+            "scoreConfidence" : [
+                72159.33813758819,
+                74211.45092392377
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72811.03194225354,
+                "50.0" : 73190.10313042848,
+                "90.0" : 73590.24393584537,
+                "95.0" : 73590.24393584537,
+                "99.0" : 73590.24393584537,
+                "99.9" : 73590.24393584537,
+                "99.99" : 73590.24393584537,
+                "99.999" : 73590.24393584537,
+                "99.9999" : 73590.24393584537,
+                "100.0" : 73590.24393584537
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73459.36162965657,
+                    73496.7495614386,
+                    73590.24393584537
+                ],
+                [
+                    72834.1354841414,
+                    72920.8446312004,
+                    72811.03194225354
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 336.8971688028646,
+            "scoreError" : 10.591733600737738,
+            "scoreConfidence" : [
+                326.3054352021269,
+                347.4889024036023
+            ],
+            "scorePercentiles" : {
+                "0.0" : 333.3843523387155,
+                "50.0" : 336.57701067031064,
+                "90.0" : 340.8361298996114,
+                "95.0" : 340.8361298996114,
+                "99.0" : 340.8361298996114,
+                "99.9" : 340.8361298996114,
+                "99.99" : 340.8361298996114,
+                "99.999" : 340.8361298996114,
+                "99.9999" : 340.8361298996114,
+                "100.0" : 340.8361298996114
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    333.48929285936777,
+                    333.3843523387155,
+                    333.5323583036066
+                ],
+                [
+                    339.62166303701474,
+                    340.5192163788716,
+                    340.8361298996114
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 108.9071675624378,
+            "scoreError" : 2.4346494082415555,
+            "scoreConfidence" : [
+                106.47251815419625,
+                111.34181697067936
+            ],
+            "scorePercentiles" : {
+                "0.0" : 107.25940458926235,
+                "50.0" : 109.10355411101719,
+                "90.0" : 109.86802218701352,
+                "95.0" : 109.86802218701352,
+                "99.0" : 109.86802218701352,
+                "99.9" : 109.86802218701352,
+                "99.99" : 109.86802218701352,
+                "99.999" : 109.86802218701352,
+                "99.9999" : 109.86802218701352,
+                "100.0" : 109.86802218701352
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    108.98456401486958,
+                    107.25940458926235,
+                    109.08683263023264
+                ],
+                [
+                    109.86802218701352,
+                    109.12390636144708,
+                    109.12027559180176
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06267579956013052,
+            "scoreError" : 9.759341967618675E-4,
+            "scoreConfidence" : [
+                0.06169986536336865,
+                0.06365173375689238
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06230262186544057,
+                "50.0" : 0.06269798460307827,
+                "90.0" : 0.06311700669662582,
+                "95.0" : 0.06311700669662582,
+                "99.0" : 0.06311700669662582,
+                "99.9" : 0.06311700669662582,
+                "99.99" : 0.06311700669662582,
+                "99.999" : 0.06311700669662582,
+                "99.9999" : 0.06311700669662582,
+                "100.0" : 0.06311700669662582
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06231028412362141,
+                    0.0625068865268619,
+                    0.06230262186544057
+                ],
+                [
+                    0.06311700669662582,
+                    0.06292891546893878,
+                    0.06288908267929465
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.829850245805691E-4,
+            "scoreError" : 2.783427693871197E-5,
+            "scoreConfidence" : [
+                3.551507476418571E-4,
+                4.108193015192811E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.706339589186961E-4,
+                "50.0" : 3.8447831063946755E-4,
+                "90.0" : 3.9217642659648263E-4,
+                "95.0" : 3.9217642659648263E-4,
+                "99.0" : 3.9217642659648263E-4,
+                "99.9" : 3.9217642659648263E-4,
+                "99.99" : 3.9217642659648263E-4,
+                "99.999" : 3.9217642659648263E-4,
+                "99.9999" : 3.9217642659648263E-4,
+                "100.0" : 3.9217642659648263E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.917451146582464E-4,
+                    3.915726149434953E-4,
+                    3.9217642659648263E-4
+                ],
+                [
+                    3.773840063354398E-4,
+                    3.743980260310542E-4,
+                    3.706339589186961E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.456743288364549,
+            "scoreError" : 0.09879667427396843,
+            "scoreConfidence" : [
+                2.3579466140905807,
+                2.5555399626385173
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.3439863665338647,
+                "50.0" : 2.4513986392504252,
+                "90.0" : 2.582160326736673,
+                "95.0" : 2.5906342444962447,
+                "99.0" : 2.5906342444962447,
+                "99.9" : 2.5906342444962447,
+                "99.99" : 2.5906342444962447,
+                "99.999" : 2.5906342444962447,
+                "99.9999" : 2.5906342444962447,
+                "100.0" : 2.5906342444962447
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.5906342444962447,
+                    2.505895066900526,
+                    2.456869154998772,
+                    2.403393242249459,
+                    2.3439863665338647
+                ],
+                [
+                    2.490592936005976,
+                    2.4459281235020787,
+                    2.463825756590293,
+                    2.425935170991996,
+                    2.440372821376281
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013973616567857975,
+            "scoreError" : 4.7632899137701345E-4,
+            "scoreConfidence" : [
+                0.013497287576480962,
+                0.014449945559234989
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013792034047887989,
+                "50.0" : 0.013979415627778326,
+                "90.0" : 0.0141424327650042,
+                "95.0" : 0.0141424327650042,
+                "99.0" : 0.0141424327650042,
+                "99.9" : 0.0141424327650042,
+                "99.99" : 0.0141424327650042,
+                "99.999" : 0.0141424327650042,
+                "99.9999" : 0.0141424327650042,
+                "100.0" : 0.0141424327650042
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01412062602744175,
+                    0.014120568423148395,
+                    0.0141424327650042
+                ],
+                [
+                    0.013827775311257253,
+                    0.013838262832408257,
+                    0.013792034047887989
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0213717321598252,
+            "scoreError" : 0.025633395265410454,
+            "scoreConfidence" : [
+                0.9957383368944148,
+                1.0470051274252357
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0117384613050076,
+                "50.0" : 1.0214770838881368,
+                "90.0" : 1.0308491702917224,
+                "95.0" : 1.0308491702917224,
+                "99.0" : 1.0308491702917224,
+                "99.9" : 1.0308491702917224,
+                "99.99" : 1.0308491702917224,
+                "99.999" : 1.0308491702917224,
+                "99.9999" : 1.0308491702917224,
+                "100.0" : 1.0308491702917224
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0308491702917224,
+                    1.0296327350972923,
+                    1.0284684398395723
+                ],
+                [
+                    1.0130558584886549,
+                    1.0117384613050076,
+                    1.0144857279367012
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.0104923538790782,
+            "scoreError" : 0.0010711978502591076,
+            "scoreConfidence" : [
+                0.009421156028819093,
+                0.011563551729337308
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010139702577632132,
+                "50.0" : 0.01047707757135314,
+                "90.0" : 0.010909468911046626,
+                "95.0" : 0.010909468911046626,
+                "99.0" : 0.010909468911046626,
+                "99.9" : 0.010909468911046626,
+                "99.99" : 0.010909468911046626,
+                "99.999" : 0.010909468911046626,
+                "99.9999" : 0.010909468911046626,
+                "100.0" : 0.010909468911046626
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010139702577632132,
+                    0.01014158954638109,
+                    0.010155074633261641
+                ],
+                [
+                    0.010799080509444638,
+                    0.010809207096703063,
+                    0.010909468911046626
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.204880874255654,
+            "scoreError" : 0.10646033650662153,
+            "scoreConfidence" : [
+                3.0984205377490324,
+                3.3113412107622753
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1616388855878634,
+                "50.0" : 3.203174305109492,
+                "90.0" : 3.245609118754056,
+                "95.0" : 3.245609118754056,
+                "99.0" : 3.245609118754056,
+                "99.9" : 3.245609118754056,
+                "99.99" : 3.245609118754056,
+                "99.999" : 3.245609118754056,
+                "99.9999" : 3.245609118754056,
+                "100.0" : 3.245609118754056
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.1768291834920634,
+                    3.1741809517766497,
+                    3.1616388855878634
+                ],
+                [
+                    3.2415076791963706,
+                    3.2295194267269207,
+                    3.245609118754056
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.9339090960305003,
+            "scoreError" : 0.09968571650555424,
+            "scoreConfidence" : [
+                2.8342233795249463,
+                3.0335948125360543
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.895894061088593,
+                "50.0" : 2.9383914946758747,
+                "90.0" : 2.9684344401899674,
+                "95.0" : 2.9684344401899674,
+                "99.0" : 2.9684344401899674,
+                "99.9" : 2.9684344401899674,
+                "99.99" : 2.9684344401899674,
+                "99.999" : 2.9684344401899674,
+                "99.9999" : 2.9684344401899674,
+                "100.0" : 2.9684344401899674
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9644939072317724,
+                    2.964814004150608,
+                    2.9684344401899674
+                ],
+                [
+                    2.8975290814020855,
+                    2.9122890821199765,
+                    2.895894061088593
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18164124430281733,
+            "scoreError" : 0.005179354963950698,
+            "scoreConfidence" : [
+                0.17646188933886664,
+                0.18682059926676803
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17979934759704416,
+                "50.0" : 0.1815786216182263,
+                "90.0" : 0.18352517682143513,
+                "95.0" : 0.18352517682143513,
+                "99.0" : 0.18352517682143513,
+                "99.9" : 0.18352517682143513,
+                "99.99" : 0.18352517682143513,
+                "99.999" : 0.18352517682143513,
+                "99.9999" : 0.18352517682143513,
+                "100.0" : 0.18352517682143513
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1801941743157288,
+                    0.17991215551237766,
+                    0.17979934759704416
+                ],
+                [
+                    0.1834535426495946,
+                    0.18352517682143513,
+                    0.18296306892072378
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.33679117083369864,
+            "scoreError" : 0.018782028478199566,
+            "scoreConfidence" : [
+                0.3180091423554991,
+                0.3555731993118982
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.331036258002582,
+                "50.0" : 0.3349514146744863,
+                "90.0" : 0.3472769126962078,
+                "95.0" : 0.3472769126962078,
+                "99.0" : 0.3472769126962078,
+                "99.9" : 0.3472769126962078,
+                "99.99" : 0.3472769126962078,
+                "99.999" : 0.3472769126962078,
+                "99.9999" : 0.3472769126962078,
+                "100.0" : 0.3472769126962078
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3472769126962078,
+                    0.3412651689189189,
+                    0.33840982139352305
+                ],
+                [
+                    0.3314930079554495,
+                    0.3312658560355108,
+                    0.331036258002582
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14942750476861308,
+            "scoreError" : 0.0019205283153328242,
+            "scoreConfidence" : [
+                0.14750697645328026,
+                0.1513480330839459
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14850388255123256,
+                "50.0" : 0.1492495397555943,
+                "90.0" : 0.1505226035191234,
+                "95.0" : 0.1505226035191234,
+                "99.0" : 0.1505226035191234,
+                "99.9" : 0.1505226035191234,
+                "99.99" : 0.1505226035191234,
+                "99.999" : 0.1505226035191234,
+                "99.9999" : 0.1505226035191234,
+                "100.0" : 0.1505226035191234
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14984208861385398,
+                    0.1505226035191234,
+                    0.14929849593168212
+                ],
+                [
+                    0.14919737441628,
+                    0.14850388255123256,
+                    0.14920058357950647
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.39427350125113314,
+            "scoreError" : 0.019948695693402137,
+            "scoreConfidence" : [
+                0.374324805557731,
+                0.41422219694453527
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.38772373359956575,
+                "50.0" : 0.394149812250175,
+                "90.0" : 0.40100205345256235,
+                "95.0" : 0.40100205345256235,
+                "99.0" : 0.40100205345256235,
+                "99.9" : 0.40100205345256235,
+                "99.99" : 0.40100205345256235,
+                "99.999" : 0.40100205345256235,
+                "99.9999" : 0.40100205345256235,
+                "100.0" : 0.40100205345256235
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40100205345256235,
+                    0.40088715349154175,
+                    0.4004050499299299
+                ],
+                [
+                    0.38772844246277915,
+                    0.38772373359956575,
+                    0.3878945745704201
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16069661535962754,
+            "scoreError" : 0.003482763653376293,
+            "scoreConfidence" : [
+                0.15721385170625124,
+                0.16417937901300383
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1593037178290375,
+                "50.0" : 0.1606308612403632,
+                "90.0" : 0.16204770991055223,
+                "95.0" : 0.16204770991055223,
+                "99.0" : 0.16204770991055223,
+                "99.9" : 0.16204770991055223,
+                "99.99" : 0.16204770991055223,
+                "99.999" : 0.16204770991055223,
+                "99.9999" : 0.16204770991055223,
+                "100.0" : 0.16204770991055223
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16204748267759916,
+                    0.16204770991055223,
+                    0.1612337340663947
+                ],
+                [
+                    0.16002798841433166,
+                    0.15951905925985005,
+                    0.1593037178290375
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.046819348958386166,
+            "scoreError" : 1.319808726640931E-4,
+            "scoreConfidence" : [
+                0.046687368085722075,
+                0.046951329831050256
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04676350735813323,
+                "50.0" : 0.04680777295422918,
+                "90.0" : 0.046879666615099735,
+                "95.0" : 0.046879666615099735,
+                "99.0" : 0.046879666615099735,
+                "99.9" : 0.046879666615099735,
+                "99.99" : 0.046879666615099735,
+                "99.999" : 0.046879666615099735,
+                "99.9999" : 0.046879666615099735,
+                "100.0" : 0.046879666615099735
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04687201748300914,
+                    0.04681557990805588,
+                    0.046879666615099735
+                ],
+                [
+                    0.046785356385616574,
+                    0.046799966000402475,
+                    0.04676350735813323
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 9397659.075972728,
+            "scoreError" : 463410.58262846817,
+            "scoreConfidence" : [
+                8934248.49334426,
+                9861069.658601196
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9198989.924632354,
+                "50.0" : 9427477.829907374,
+                "90.0" : 9560990.657743786,
+                "95.0" : 9560990.657743786,
+                "99.0" : 9560990.657743786,
+                "99.9" : 9560990.657743786,
+                "99.99" : 9560990.657743786,
+                "99.999" : 9560990.657743786,
+                "99.9999" : 9560990.657743786,
+                "100.0" : 9560990.657743786
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    9549476.454198474,
+                    9560990.657743786,
+                    9512795.087452471
+                ],
+                [
+                    9198989.924632354,
+                    9221541.759447005,
+                    9342160.572362278
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2025-12-04T01-19-40Z-7defb76b60135e43d93db0cf08d534737b8f20f0-jdk17.json
+++ b/performance-results/2025-12-04T01-19-40Z-7defb76b60135e43d93db0cf08d534737b8f20f0-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3352646114968607,
+            "scoreError" : 0.06138035118705301,
+            "scoreConfidence" : [
+                3.2738842603098077,
+                3.3966449626839137
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3261288628892793,
+                "50.0" : 3.335288543331317,
+                "90.0" : 3.3443524964355302,
+                "95.0" : 3.3443524964355302,
+                "99.0" : 3.3443524964355302,
+                "99.9" : 3.3443524964355302,
+                "99.99" : 3.3443524964355302,
+                "99.999" : 3.3443524964355302,
+                "99.9999" : 3.3443524964355302,
+                "100.0" : 3.3443524964355302
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3280559120660134,
+                    3.3443524964355302
+                ],
+                [
+                    3.3261288628892793,
+                    3.3425211745966203
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6860873387644093,
+            "scoreError" : 0.030913311492141042,
+            "scoreConfidence" : [
+                1.6551740272722684,
+                1.7170006502565502
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.682046268897834,
+                "50.0" : 1.6852863537420646,
+                "90.0" : 1.691730378675674,
+                "95.0" : 1.691730378675674,
+                "99.0" : 1.691730378675674,
+                "99.9" : 1.691730378675674,
+                "99.99" : 1.691730378675674,
+                "99.999" : 1.691730378675674,
+                "99.9999" : 1.691730378675674,
+                "100.0" : 1.691730378675674
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.682046268897834,
+                    1.691730378675674
+                ],
+                [
+                    1.682188054720343,
+                    1.6883846527637862
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8447199125058826,
+            "scoreError" : 0.007270232719892229,
+            "scoreConfidence" : [
+                0.8374496797859904,
+                0.8519901452257749
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8434931408130768,
+                "50.0" : 0.8448116760856812,
+                "90.0" : 0.8457631570390917,
+                "95.0" : 0.8457631570390917,
+                "99.0" : 0.8457631570390917,
+                "99.9" : 0.8457631570390917,
+                "99.99" : 0.8457631570390917,
+                "99.999" : 0.8457631570390917,
+                "99.9999" : 0.8457631570390917,
+                "100.0" : 0.8457631570390917
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8440412142912856,
+                    0.8457631570390917
+                ],
+                [
+                    0.8455821378800766,
+                    0.8434931408130768
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.24861355099623,
+            "scoreError" : 0.2903338383761642,
+            "scoreConfidence" : [
+                15.958279712620065,
+                16.538947389372392
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.121576269601004,
+                "50.0" : 16.248132801738286,
+                "90.0" : 16.389538065680544,
+                "95.0" : 16.389538065680544,
+                "99.0" : 16.389538065680544,
+                "99.9" : 16.389538065680544,
+                "99.99" : 16.389538065680544,
+                "99.999" : 16.389538065680544,
+                "99.9999" : 16.389538065680544,
+                "100.0" : 16.389538065680544
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.389538065680544,
+                    16.312605001219897,
+                    16.309730462132435
+                ],
+                [
+                    16.121576269601004,
+                    16.17169636599936,
+                    16.186535141344137
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2768.109368990776,
+            "scoreError" : 332.5027912752142,
+            "scoreConfidence" : [
+                2435.606577715562,
+                3100.6121602659905
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2645.6871939242214,
+                "50.0" : 2765.5632439887704,
+                "90.0" : 2885.253802186437,
+                "95.0" : 2885.253802186437,
+                "99.0" : 2885.253802186437,
+                "99.9" : 2885.253802186437,
+                "99.99" : 2885.253802186437,
+                "99.999" : 2885.253802186437,
+                "99.9999" : 2885.253802186437,
+                "100.0" : 2885.253802186437
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2881.450858880729,
+                    2885.253802186437,
+                    2860.763596775686
+                ],
+                [
+                    2665.1378709757296,
+                    2645.6871939242214,
+                    2670.3628912018544
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73782.92037075105,
+            "scoreError" : 1472.3754265764533,
+            "scoreConfidence" : [
+                72310.54494417459,
+                75255.2957973275
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73261.84591588714,
+                "50.0" : 73794.7789610104,
+                "90.0" : 74299.89701059888,
+                "95.0" : 74299.89701059888,
+                "99.0" : 74299.89701059888,
+                "99.9" : 74299.89701059888,
+                "99.99" : 74299.89701059888,
+                "99.999" : 74299.89701059888,
+                "99.9999" : 74299.89701059888,
+                "100.0" : 74299.89701059888
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74225.96334999109,
+                    74256.51530010469,
+                    74299.89701059888
+                ],
+                [
+                    73363.5945720297,
+                    73289.70607589473,
+                    73261.84591588714
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 354.8887150239807,
+            "scoreError" : 14.195218236222486,
+            "scoreConfidence" : [
+                340.6934967877582,
+                369.0839332602032
+            ],
+            "scorePercentiles" : {
+                "0.0" : 349.47275982152655,
+                "50.0" : 355.24164339209295,
+                "90.0" : 360.5509118226224,
+                "95.0" : 360.5509118226224,
+                "99.0" : 360.5509118226224,
+                "99.9" : 360.5509118226224,
+                "99.99" : 360.5509118226224,
+                "99.999" : 360.5509118226224,
+                "99.9999" : 360.5509118226224,
+                "100.0" : 360.5509118226224
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    349.47275982152655,
+                    349.6579470233352,
+                    352.0154394143686
+                ],
+                [
+                    358.4678473698173,
+                    360.5509118226224,
+                    359.1673846922141
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 116.82177994375179,
+            "scoreError" : 0.5368586442990152,
+            "scoreConfidence" : [
+                116.28492129945278,
+                117.35863858805081
+            ],
+            "scorePercentiles" : {
+                "0.0" : 116.64963269497599,
+                "50.0" : 116.77661038723579,
+                "90.0" : 117.15719884338935,
+                "95.0" : 117.15719884338935,
+                "99.0" : 117.15719884338935,
+                "99.9" : 117.15719884338935,
+                "99.99" : 117.15719884338935,
+                "99.999" : 117.15719884338935,
+                "99.9999" : 117.15719884338935,
+                "100.0" : 117.15719884338935
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    116.74827138606115,
+                    116.64963269497599,
+                    116.65729675658972
+                ],
+                [
+                    117.15719884338935,
+                    116.80494938841044,
+                    116.91333059308405
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06162212206430657,
+            "scoreError" : 8.89607425755814E-4,
+            "scoreConfidence" : [
+                0.060732514638550755,
+                0.06251172949006238
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061159767199359054,
+                "50.0" : 0.061657655808316086,
+                "90.0" : 0.061963880839224966,
+                "95.0" : 0.061963880839224966,
+                "99.0" : 0.061963880839224966,
+                "99.9" : 0.061963880839224966,
+                "99.99" : 0.061963880839224966,
+                "99.999" : 0.061963880839224966,
+                "99.9999" : 0.061963880839224966,
+                "100.0" : 0.061963880839224966
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06135629365892567,
+                    0.06165640941852507,
+                    0.061159767199359054
+                ],
+                [
+                    0.061963880839224966,
+                    0.0616589021981071,
+                    0.061937479071697554
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.601173806332691E-4,
+            "scoreError" : 6.984190030567535E-6,
+            "scoreConfidence" : [
+                3.531331906027016E-4,
+                3.6710157066383665E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5664468380769453E-4,
+                "50.0" : 3.597465300425796E-4,
+                "90.0" : 3.6362896341854753E-4,
+                "95.0" : 3.6362896341854753E-4,
+                "99.0" : 3.6362896341854753E-4,
+                "99.9" : 3.6362896341854753E-4,
+                "99.99" : 3.6362896341854753E-4,
+                "99.999" : 3.6362896341854753E-4,
+                "99.9999" : 3.6362896341854753E-4,
+                "100.0" : 3.6362896341854753E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.5664468380769453E-4,
+                    3.590916595675064E-4,
+                    3.588492832851753E-4
+                ],
+                [
+                    3.6362896341854753E-4,
+                    3.620882932030382E-4,
+                    3.604014005176528E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.252568233766232,
+            "scoreError" : 0.07798408673861082,
+            "scoreConfidence" : [
+                2.174584147027621,
+                2.3305523205048426
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.183890616375546,
+                "50.0" : 2.244687567193419,
+                "90.0" : 2.3431691823237153,
+                "95.0" : 2.347328260032856,
+                "99.0" : 2.347328260032856,
+                "99.9" : 2.347328260032856,
+                "99.99" : 2.347328260032856,
+                "99.999" : 2.347328260032856,
+                "99.9999" : 2.347328260032856,
+                "100.0" : 2.347328260032856
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.305737482941448,
+                    2.347328260032856,
+                    2.2950271161083067,
+                    2.2413540856118335,
+                    2.2404209637096772
+                ],
+                [
+                    2.256912089596028,
+                    2.219164315509208,
+                    2.2480210487750054,
+                    2.1878263590024063,
+                    2.183890616375546
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013604543861229017,
+            "scoreError" : 2.722610051209343E-4,
+            "scoreConfidence" : [
+                0.013332282856108083,
+                0.013876804866349951
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013501168762471547,
+                "50.0" : 0.013606059850447381,
+                "90.0" : 0.01370801840415951,
+                "95.0" : 0.01370801840415951,
+                "99.0" : 0.01370801840415951,
+                "99.9" : 0.01370801840415951,
+                "99.99" : 0.01370801840415951,
+                "99.999" : 0.01370801840415951,
+                "99.9999" : 0.01370801840415951,
+                "100.0" : 0.01370801840415951
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013677319959406358,
+                    0.013691223019041517,
+                    0.01370801840415951
+                ],
+                [
+                    0.013514733280806764,
+                    0.013534799741488404,
+                    0.013501168762471547
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0102503675958305,
+            "scoreError" : 0.007510316079033799,
+            "scoreConfidence" : [
+                1.0027400515167968,
+                1.0177606836748643
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0068936274667741,
+                "50.0" : 1.0102910917768044,
+                "90.0" : 1.0131726496808835,
+                "95.0" : 1.0131726496808835,
+                "99.0" : 1.0131726496808835,
+                "99.9" : 1.0131726496808835,
+                "99.99" : 1.0131726496808835,
+                "99.999" : 1.0131726496808835,
+                "99.9999" : 1.0131726496808835,
+                "100.0" : 1.0131726496808835
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0131726496808835,
+                    1.0120477681643392,
+                    1.0126427535439448
+                ],
+                [
+                    1.0068936274667741,
+                    1.0082109913297712,
+                    1.00853441538927
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010462602990512125,
+            "scoreError" : 6.931047113452303E-4,
+            "scoreConfidence" : [
+                0.009769498279166894,
+                0.011155707701857356
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01022293278226664,
+                "50.0" : 0.010463070665092023,
+                "90.0" : 0.010699923844007328,
+                "95.0" : 0.010699923844007328,
+                "99.0" : 0.010699923844007328,
+                "99.9" : 0.010699923844007328,
+                "99.99" : 0.010699923844007328,
+                "99.999" : 0.010699923844007328,
+                "99.9999" : 0.010699923844007328,
+                "100.0" : 0.010699923844007328
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010682904610414722,
+                    0.010681304053029252,
+                    0.010699923844007328
+                ],
+                [
+                    0.01022293278226664,
+                    0.010243715376200018,
+                    0.010244837277154794
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0313359199475602,
+            "scoreError" : 0.3579742185642711,
+            "scoreConfidence" : [
+                2.673361701383289,
+                3.3893101385118314
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9131393174140943,
+                "50.0" : 3.0278563999674235,
+                "90.0" : 3.163000795066414,
+                "95.0" : 3.163000795066414,
+                "99.0" : 3.163000795066414,
+                "99.9" : 3.163000795066414,
+                "99.99" : 3.163000795066414,
+                "99.999" : 3.163000795066414,
+                "99.9999" : 3.163000795066414,
+                "100.0" : 3.163000795066414
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.140584496547395,
+                    3.163000795066414,
+                    3.1392480646578784
+                ],
+                [
+                    2.9131393174140943,
+                    2.9155781107226106,
+                    2.916464735276968
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7850191944747618,
+            "scoreError" : 0.22509647395656157,
+            "scoreConfidence" : [
+                2.5599227205182,
+                3.0101156684313235
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7065752947225983,
+                "50.0" : 2.7864280799616385,
+                "90.0" : 2.859452837621498,
+                "95.0" : 2.859452837621498,
+                "99.0" : 2.859452837621498,
+                "99.9" : 2.859452837621498,
+                "99.99" : 2.859452837621498,
+                "99.999" : 2.859452837621498,
+                "99.9999" : 2.859452837621498,
+                "100.0" : 2.859452837621498
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8573903934285716,
+                    2.8578921005714286,
+                    2.859452837621498
+                ],
+                [
+                    2.7133387740097668,
+                    2.7065752947225983,
+                    2.7154657664947055
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17992147896727848,
+            "scoreError" : 0.006161173563851715,
+            "scoreConfidence" : [
+                0.17376030540342677,
+                0.18608265253113018
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1777449342717998,
+                "50.0" : 0.17992804130074652,
+                "90.0" : 0.18206493726218437,
+                "95.0" : 0.18206493726218437,
+                "99.0" : 0.18206493726218437,
+                "99.9" : 0.18206493726218437,
+                "99.99" : 0.18206493726218437,
+                "99.999" : 0.18206493726218437,
+                "99.9999" : 0.18206493726218437,
+                "100.0" : 0.18206493726218437
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18206493726218437,
+                    0.18190281595605354,
+                    0.18180320130531213
+                ],
+                [
+                    0.1780528812961809,
+                    0.17796010371214008,
+                    0.1777449342717998
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32489801167848104,
+            "scoreError" : 0.01230943750509706,
+            "scoreConfidence" : [
+                0.312588574173384,
+                0.3372074491835781
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3204718255087326,
+                "50.0" : 0.3248022771832343,
+                "90.0" : 0.32925047479669445,
+                "95.0" : 0.32925047479669445,
+                "99.0" : 0.32925047479669445,
+                "99.9" : 0.32925047479669445,
+                "99.99" : 0.32925047479669445,
+                "99.999" : 0.32925047479669445,
+                "99.9999" : 0.32925047479669445,
+                "100.0" : 0.32925047479669445
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.32925047479669445,
+                    0.3282769483964153,
+                    0.3291300294233807
+                ],
+                [
+                    0.32132760597005333,
+                    0.32093118597560977,
+                    0.3204718255087326
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14421813153612092,
+            "scoreError" : 6.209482884136219E-4,
+            "scoreConfidence" : [
+                0.14359718324770732,
+                0.14483907982453453
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14388094820441988,
+                "50.0" : 0.14417790327404362,
+                "90.0" : 0.14453192694030928,
+                "95.0" : 0.14453192694030928,
+                "99.0" : 0.14453192694030928,
+                "99.9" : 0.14453192694030928,
+                "99.99" : 0.14453192694030928,
+                "99.999" : 0.14453192694030928,
+                "99.9999" : 0.14453192694030928,
+                "100.0" : 0.14453192694030928
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14388094820441988,
+                    0.1441657219963671,
+                    0.14419008455172017
+                ],
+                [
+                    0.14453192694030928,
+                    0.144160316712076,
+                    0.14437979081183316
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4193762235278183,
+            "scoreError" : 0.05364378858342027,
+            "scoreConfidence" : [
+                0.365732434944398,
+                0.47302001211123856
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3979007418135519,
+                "50.0" : 0.42113050761361936,
+                "90.0" : 0.4371617340881273,
+                "95.0" : 0.4371617340881273,
+                "99.0" : 0.4371617340881273,
+                "99.9" : 0.4371617340881273,
+                "99.99" : 0.4371617340881273,
+                "99.999" : 0.4371617340881273,
+                "99.9999" : 0.4371617340881273,
+                "100.0" : 0.4371617340881273
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40586478425324674,
+                    0.40243772956658214,
+                    0.3979007418135519
+                ],
+                [
+                    0.436396230973992,
+                    0.4371617340881273,
+                    0.43649612047140984
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1579561198194358,
+            "scoreError" : 0.00298276415489671,
+            "scoreConfidence" : [
+                0.1549733556645391,
+                0.1609388839743325
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15662317588372565,
+                "50.0" : 0.15832364516553926,
+                "90.0" : 0.15889393733316384,
+                "95.0" : 0.15889393733316384,
+                "99.0" : 0.15889393733316384,
+                "99.9" : 0.15889393733316384,
+                "99.99" : 0.15889393733316384,
+                "99.999" : 0.15889393733316384,
+                "99.9999" : 0.15889393733316384,
+                "100.0" : 0.15889393733316384
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15886765772792985,
+                    0.15889393733316384,
+                    0.15873208833193123
+                ],
+                [
+                    0.15791520199914727,
+                    0.15670465764071706,
+                    0.15662317588372565
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04737439331739481,
+            "scoreError" : 0.00257703833966439,
+            "scoreConfidence" : [
+                0.04479735497773042,
+                0.0499514316570592
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04653456819313438,
+                "50.0" : 0.0472996646752495,
+                "90.0" : 0.0484942340541091,
+                "95.0" : 0.0484942340541091,
+                "99.0" : 0.0484942340541091,
+                "99.9" : 0.0484942340541091,
+                "99.99" : 0.0484942340541091,
+                "99.999" : 0.0484942340541091,
+                "99.9999" : 0.0484942340541091,
+                "100.0" : 0.0484942340541091
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0484942340541091,
+                    0.04806418774482238,
+                    0.0480424504427032
+                ],
+                [
+                    0.04655687890779581,
+                    0.04653456819313438,
+                    0.04655404056180403
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8725429.499461884,
+            "scoreError" : 262522.5029839349,
+            "scoreConfidence" : [
+                8462906.996477949,
+                8987952.002445819
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8654959.773356402,
+                "50.0" : 8681658.324398797,
+                "90.0" : 8893862.29688889,
+                "95.0" : 8893862.29688889,
+                "99.0" : 8893862.29688889,
+                "99.9" : 8893862.29688889,
+                "99.99" : 8893862.29688889,
+                "99.999" : 8893862.29688889,
+                "99.9999" : 8893862.29688889,
+                "100.0" : 8893862.29688889
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8893862.29688889,
+                    8776781.718421053,
+                    8691691.570807993
+                ],
+                [
+                    8663656.55930736,
+                    8671625.0779896,
+                    8654959.773356402
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2025-12-04T01-19-52Z-9d4369e64438505a7da404c8605f064a093a458f-jdk17.json
+++ b/performance-results/2025-12-04T01-19-52Z-9d4369e64438505a7da404c8605f064a093a458f-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.352964088007376,
+            "scoreError" : 0.034078432074493556,
+            "scoreConfidence" : [
+                3.3188856559328825,
+                3.3870425200818697
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.347046950572927,
+                "50.0" : 3.353117648731752,
+                "90.0" : 3.3585741039930737,
+                "95.0" : 3.3585741039930737,
+                "99.0" : 3.3585741039930737,
+                "99.9" : 3.3585741039930737,
+                "99.99" : 3.3585741039930737,
+                "99.999" : 3.3585741039930737,
+                "99.9999" : 3.3585741039930737,
+                "100.0" : 3.3585741039930737
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.347046950572927,
+                    3.3585741039930737
+                ],
+                [
+                    3.3502105032099685,
+                    3.3560247942535355
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6934486944725309,
+            "scoreError" : 0.026315242595684053,
+            "scoreConfidence" : [
+                1.6671334518768468,
+                1.719763937068215
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.688476914832891,
+                "50.0" : 1.6934651067228064,
+                "90.0" : 1.69838764961162,
+                "95.0" : 1.69838764961162,
+                "99.0" : 1.69838764961162,
+                "99.9" : 1.69838764961162,
+                "99.99" : 1.69838764961162,
+                "99.999" : 1.69838764961162,
+                "99.9999" : 1.69838764961162,
+                "100.0" : 1.69838764961162
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.688476914832891,
+                    1.6940302563497622
+                ],
+                [
+                    1.6928999570958505,
+                    1.69838764961162
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8471348945485867,
+            "scoreError" : 0.038824486026443505,
+            "scoreConfidence" : [
+                0.8083104085221432,
+                0.8859593805750302
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8391372696140444,
+                "50.0" : 0.8487287774736527,
+                "90.0" : 0.8519447536329969,
+                "95.0" : 0.8519447536329969,
+                "99.0" : 0.8519447536329969,
+                "99.9" : 0.8519447536329969,
+                "99.99" : 0.8519447536329969,
+                "99.999" : 0.8519447536329969,
+                "99.9999" : 0.8519447536329969,
+                "100.0" : 0.8519447536329969
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8458901789966976,
+                    0.8519447536329969
+                ],
+                [
+                    0.8391372696140444,
+                    0.8515673759506078
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.061060608172728,
+            "scoreError" : 0.18284965677810275,
+            "scoreConfidence" : [
+                15.878210951394625,
+                16.24391026495083
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.985806992946465,
+                "50.0" : 16.059726883301664,
+                "90.0" : 16.141231771466913,
+                "95.0" : 16.141231771466913,
+                "99.0" : 16.141231771466913,
+                "99.9" : 16.141231771466913,
+                "99.99" : 16.141231771466913,
+                "99.999" : 16.141231771466913,
+                "99.9999" : 16.141231771466913,
+                "100.0" : 16.141231771466913
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.099142098183243,
+                    16.141231771466913,
+                    16.11495986937149
+                ],
+                [
+                    16.004911248648163,
+                    16.02031166842009,
+                    15.985806992946465
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2723.4004644659462,
+            "scoreError" : 326.00074959094445,
+            "scoreConfidence" : [
+                2397.399714875002,
+                3049.4012140568907
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2612.9680590471794,
+                "50.0" : 2724.6647058418694,
+                "90.0" : 2830.4302031727807,
+                "95.0" : 2830.4302031727807,
+                "99.0" : 2830.4302031727807,
+                "99.9" : 2830.4302031727807,
+                "99.99" : 2830.4302031727807,
+                "99.999" : 2830.4302031727807,
+                "99.9999" : 2830.4302031727807,
+                "100.0" : 2830.4302031727807
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2620.832860251382,
+                    2618.102581365658,
+                    2612.9680590471794
+                ],
+                [
+                    2829.5725315263226,
+                    2828.4965514323567,
+                    2830.4302031727807
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73067.69925207105,
+            "scoreError" : 1790.8257502545155,
+            "scoreConfidence" : [
+                71276.87350181653,
+                74858.52500232556
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72475.89091817074,
+                "50.0" : 73051.3360789835,
+                "90.0" : 73728.57376654429,
+                "95.0" : 73728.57376654429,
+                "99.0" : 73728.57376654429,
+                "99.9" : 73728.57376654429,
+                "99.99" : 73728.57376654429,
+                "99.999" : 73728.57376654429,
+                "99.9999" : 73728.57376654429,
+                "100.0" : 73728.57376654429
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73599.32331489981,
+                    73619.81258162572,
+                    73728.57376654429
+                ],
+                [
+                    72503.3488430672,
+                    72475.89091817074,
+                    72479.2460881186
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 358.94781498890796,
+            "scoreError" : 4.947436578819071,
+            "scoreConfidence" : [
+                354.0003784100889,
+                363.89525156772703
+            ],
+            "scorePercentiles" : {
+                "0.0" : 357.043972695509,
+                "50.0" : 358.89677130085033,
+                "90.0" : 360.7829415691916,
+                "95.0" : 360.7829415691916,
+                "99.0" : 360.7829415691916,
+                "99.9" : 360.7829415691916,
+                "99.99" : 360.7829415691916,
+                "99.999" : 360.7829415691916,
+                "99.9999" : 360.7829415691916,
+                "100.0" : 360.7829415691916
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    360.0646684743736,
+                    360.7829415691916,
+                    360.73964035796996
+                ],
+                [
+                    357.043972695509,
+                    357.3267927090764,
+                    357.728874127327
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 115.54187586762885,
+            "scoreError" : 5.303271952680539,
+            "scoreConfidence" : [
+                110.2386039149483,
+                120.84514782030939
+            ],
+            "scorePercentiles" : {
+                "0.0" : 113.69028955320286,
+                "50.0" : 115.5591660852709,
+                "90.0" : 117.44379748211377,
+                "95.0" : 117.44379748211377,
+                "99.0" : 117.44379748211377,
+                "99.9" : 117.44379748211377,
+                "99.99" : 117.44379748211377,
+                "99.999" : 117.44379748211377,
+                "99.9999" : 117.44379748211377,
+                "100.0" : 117.44379748211377
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    117.03726092398301,
+                    117.29715785467603,
+                    117.44379748211377
+                ],
+                [
+                    113.70167814523857,
+                    113.69028955320286,
+                    114.0810712465588
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06099926986472623,
+            "scoreError" : 0.0012242582157745195,
+            "scoreConfidence" : [
+                0.05977501164895171,
+                0.06222352808050075
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06056382230283797,
+                "50.0" : 0.06099786015133431,
+                "90.0" : 0.061430544155588865,
+                "95.0" : 0.061430544155588865,
+                "99.0" : 0.061430544155588865,
+                "99.9" : 0.061430544155588865,
+                "99.99" : 0.061430544155588865,
+                "99.999" : 0.061430544155588865,
+                "99.9999" : 0.061430544155588865,
+                "100.0" : 0.061430544155588865
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06056382230283797,
+                    0.06061588785035399,
+                    0.060625012894738435
+                ],
+                [
+                    0.061370707407930186,
+                    0.061389644576907966,
+                    0.061430544155588865
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.686108115841653E-4,
+            "scoreError" : 2.0193338004617504E-5,
+            "scoreConfidence" : [
+                3.4841747357954776E-4,
+                3.888041495887828E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.617971152120339E-4,
+                "50.0" : 3.684183078610536E-4,
+                "90.0" : 3.764159581848955E-4,
+                "95.0" : 3.764159581848955E-4,
+                "99.0" : 3.764159581848955E-4,
+                "99.9" : 3.764159581848955E-4,
+                "99.99" : 3.764159581848955E-4,
+                "99.999" : 3.764159581848955E-4,
+                "99.9999" : 3.764159581848955E-4,
+                "100.0" : 3.764159581848955E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.619748294906879E-4,
+                    3.617971152120339E-4,
+                    3.624404522909564E-4
+                ],
+                [
+                    3.7464035089526725E-4,
+                    3.743961634311508E-4,
+                    3.764159581848955E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2289591178321606,
+            "scoreError" : 0.052431023243365286,
+            "scoreConfidence" : [
+                2.1765280945887953,
+                2.281390141075526
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1902902071835304,
+                "50.0" : 2.2259171891076353,
+                "90.0" : 2.2820963770844065,
+                "95.0" : 2.282133845504336,
+                "99.0" : 2.282133845504336,
+                "99.9" : 2.282133845504336,
+                "99.99" : 2.282133845504336,
+                "99.999" : 2.282133845504336,
+                "99.9999" : 2.282133845504336,
+                "100.0" : 2.282133845504336
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.282133845504336,
+                    2.2218836065318817,
+                    2.2350022484916203,
+                    2.191594285996055,
+                    2.1902902071835304
+                ],
+                [
+                    2.2817591613050423,
+                    2.2299507716833893,
+                    2.254876091093574,
+                    2.2006071511551153,
+                    2.2014938093770637
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013629531414765118,
+            "scoreError" : 3.581520128568429E-4,
+            "scoreConfidence" : [
+                0.013271379401908276,
+                0.013987683427621961
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013510207977800715,
+                "50.0" : 0.013627130124708096,
+                "90.0" : 0.01375067378483514,
+                "95.0" : 0.01375067378483514,
+                "99.0" : 0.01375067378483514,
+                "99.9" : 0.01375067378483514,
+                "99.99" : 0.01375067378483514,
+                "99.999" : 0.01375067378483514,
+                "99.9999" : 0.01375067378483514,
+                "100.0" : 0.01375067378483514
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013510207977800715,
+                    0.01351200449133351,
+                    0.013516898294729558
+                ],
+                [
+                    0.013737361954686635,
+                    0.01375067378483514,
+                    0.013750041985205148
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.110101371393146,
+            "scoreError" : 0.26941562465260016,
+            "scoreConfidence" : [
+                0.8406857467405459,
+                1.379516996045746
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0219183767627222,
+                "50.0" : 1.1098708879517318,
+                "90.0" : 1.1985179666826462,
+                "95.0" : 1.1985179666826462,
+                "99.0" : 1.1985179666826462,
+                "99.9" : 1.1985179666826462,
+                "99.99" : 1.1985179666826462,
+                "99.999" : 1.1985179666826462,
+                "99.9999" : 1.1985179666826462,
+                "100.0" : 1.1985179666826462
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0219183767627222,
+                    1.0226262299826159,
+                    1.0226478505982206
+                ],
+                [
+                    1.1978038790274284,
+                    1.197093925305243,
+                    1.1985179666826462
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010274158679678543,
+            "scoreError" : 0.0011272228888951645,
+            "scoreConfidence" : [
+                0.009146935790783378,
+                0.011401381568573708
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.009899267796335012,
+                "50.0" : 0.010274790230620019,
+                "90.0" : 0.010646250366222373,
+                "95.0" : 0.010646250366222373,
+                "99.0" : 0.010646250366222373,
+                "99.9" : 0.010646250366222373,
+                "99.99" : 0.010646250366222373,
+                "99.999" : 0.010646250366222373,
+                "99.9999" : 0.010646250366222373,
+                "100.0" : 0.010646250366222373
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010641895343862867,
+                    0.010635070975274667,
+                    0.010646250366222373
+                ],
+                [
+                    0.009914509485965372,
+                    0.00990795811041097,
+                    0.009899267796335012
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0055089150449334,
+            "scoreError" : 0.11205126944851332,
+            "scoreConfidence" : [
+                2.89345764559642,
+                3.117560184493447
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9653553272080617,
+                "50.0" : 3.003715570104643,
+                "90.0" : 3.0531242942612944,
+                "95.0" : 3.0531242942612944,
+                "99.0" : 3.0531242942612944,
+                "99.9" : 3.0531242942612944,
+                "99.99" : 3.0531242942612944,
+                "99.999" : 3.0531242942612944,
+                "99.9999" : 3.0531242942612944,
+                "100.0" : 3.0531242942612944
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.033749600970285,
+                    3.0531242942612944,
+                    3.0373787012750455
+                ],
+                [
+                    2.9653553272080617,
+                    2.973681539239001,
+                    2.9697640273159145
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.778952051676462,
+            "scoreError" : 0.17279841356310333,
+            "scoreConfidence" : [
+                2.6061536381133585,
+                2.9517504652395656
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.717496108394458,
+                "50.0" : 2.7776890410481605,
+                "90.0" : 2.8433614724275156,
+                "95.0" : 2.8433614724275156,
+                "99.0" : 2.8433614724275156,
+                "99.9" : 2.8433614724275156,
+                "99.99" : 2.8433614724275156,
+                "99.999" : 2.8433614724275156,
+                "99.9999" : 2.8433614724275156,
+                "100.0" : 2.8433614724275156
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8433614724275156,
+                    2.835164072562358,
+                    2.826112570500141
+                ],
+                [
+                    2.72926551159618,
+                    2.7223125745781167,
+                    2.717496108394458
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17747148523449896,
+            "scoreError" : 0.004467846967392862,
+            "scoreConfidence" : [
+                0.1730036382671061,
+                0.18193933220189182
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1766360617504195,
+                "50.0" : 0.1768848752430956,
+                "90.0" : 0.18071340831631638,
+                "95.0" : 0.18071340831631638,
+                "99.0" : 0.18071340831631638,
+                "99.9" : 0.18071340831631638,
+                "99.99" : 0.18071340831631638,
+                "99.999" : 0.18071340831631638,
+                "99.9999" : 0.18071340831631638,
+                "100.0" : 0.18071340831631638
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18071340831631638,
+                    0.17696359318704655,
+                    0.17696329900902494
+                ],
+                [
+                    0.17680645147716625,
+                    0.17674609766702015,
+                    0.1766360617504195
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32481146640829545,
+            "scoreError" : 0.021535706996429926,
+            "scoreConfidence" : [
+                0.3032757594118655,
+                0.3463471734047254
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.31767321016518424,
+                "50.0" : 0.32435295217825055,
+                "90.0" : 0.33352467169156885,
+                "95.0" : 0.33352467169156885,
+                "99.0" : 0.33352467169156885,
+                "99.9" : 0.33352467169156885,
+                "99.99" : 0.33352467169156885,
+                "99.999" : 0.33352467169156885,
+                "99.9999" : 0.33352467169156885,
+                "100.0" : 0.33352467169156885
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.33352467169156885,
+                    0.3306208532416438,
+                    0.33114640286102187
+                ],
+                [
+                    0.31767321016518424,
+                    0.3178186093754966,
+                    0.31808505111485735
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14708732755996254,
+            "scoreError" : 0.0036558761364474347,
+            "scoreConfidence" : [
+                0.1434314514235151,
+                0.15074320369640998
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14556523645176786,
+                "50.0" : 0.14731913210536374,
+                "90.0" : 0.14829153465508038,
+                "95.0" : 0.14829153465508038,
+                "99.0" : 0.14829153465508038,
+                "99.9" : 0.14829153465508038,
+                "99.99" : 0.14829153465508038,
+                "99.999" : 0.14829153465508038,
+                "99.9999" : 0.14829153465508038,
+                "100.0" : 0.14829153465508038
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1457488036669436,
+                    0.14647958471386094,
+                    0.14556523645176786
+                ],
+                [
+                    0.14815867949686654,
+                    0.14828012637525578,
+                    0.14829153465508038
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3925797542626464,
+            "scoreError" : 0.047961433572667835,
+            "scoreConfidence" : [
+                0.34461832068997855,
+                0.44054118783531426
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.37684795937747295,
+                "50.0" : 0.39247315616282946,
+                "90.0" : 0.4085746135397941,
+                "95.0" : 0.4085746135397941,
+                "99.0" : 0.4085746135397941,
+                "99.9" : 0.4085746135397941,
+                "99.99" : 0.4085746135397941,
+                "99.999" : 0.4085746135397941,
+                "99.9999" : 0.4085746135397941,
+                "100.0" : 0.4085746135397941
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4085746135397941,
+                    0.40812692396849365,
+                    0.40787316334937596
+                ],
+                [
+                    0.37707314897628297,
+                    0.37698271636445885,
+                    0.37684795937747295
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16308990877498727,
+            "scoreError" : 0.023103813107778027,
+            "scoreConfidence" : [
+                0.13998609566720924,
+                0.1861937218827653
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15547049301949567,
+                "50.0" : 0.1627646769423651,
+                "90.0" : 0.171996799834887,
+                "95.0" : 0.171996799834887,
+                "99.0" : 0.171996799834887,
+                "99.9" : 0.171996799834887,
+                "99.99" : 0.171996799834887,
+                "99.999" : 0.171996799834887,
+                "99.9999" : 0.171996799834887,
+                "100.0" : 0.171996799834887
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.171996799834887,
+                    0.16980277637410218,
+                    0.16993159694467103
+                ],
+                [
+                    0.15561120896613967,
+                    0.15547049301949567,
+                    0.15572657751062802
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04697422070808496,
+            "scoreError" : 8.628828458924732E-5,
+            "scoreConfidence" : [
+                0.04688793242349572,
+                0.04706050899267421
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04692262863644895,
+                "50.0" : 0.046973423230516655,
+                "90.0" : 0.047007192003234055,
+                "95.0" : 0.047007192003234055,
+                "99.0" : 0.047007192003234055,
+                "99.9" : 0.047007192003234055,
+                "99.99" : 0.047007192003234055,
+                "99.999" : 0.047007192003234055,
+                "99.9999" : 0.047007192003234055,
+                "100.0" : 0.047007192003234055
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.047007192003234055,
+                    0.04700337704108971,
+                    0.04696821756773894
+                ],
+                [
+                    0.046965280106703734,
+                    0.04697862889329437,
+                    0.04692262863644895
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8543397.819518974,
+            "scoreError" : 360265.40477619617,
+            "scoreConfidence" : [
+                8183132.414742778,
+                8903663.224295171
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8406309.315966386,
+                "50.0" : 8524535.308187947,
+                "90.0" : 8719104.50130776,
+                "95.0" : 8719104.50130776,
+                "99.0" : 8719104.50130776,
+                "99.9" : 8719104.50130776,
+                "99.99" : 8719104.50130776,
+                "99.999" : 8719104.50130776,
+                "99.9999" : 8719104.50130776,
+                "100.0" : 8719104.50130776
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8436308.642495785,
+                    8455961.923076924,
+                    8406309.315966386
+                ],
+                [
+                    8719104.50130776,
+                    8593108.69329897,
+                    8649593.84096802
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2025-12-04T01-20-30Z-7defb76b60135e43d93db0cf08d534737b8f20f0-jdk17.json
+++ b/performance-results/2025-12-04T01-20-30Z-7defb76b60135e43d93db0cf08d534737b8f20f0-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3415825489423754,
+            "scoreError" : 0.060387064516208,
+            "scoreConfidence" : [
+                3.2811954844261675,
+                3.4019696134585833
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.329627919037276,
+                "50.0" : 3.3421198811913952,
+                "90.0" : 3.3524625143494355,
+                "95.0" : 3.3524625143494355,
+                "99.0" : 3.3524625143494355,
+                "99.9" : 3.3524625143494355,
+                "99.99" : 3.3524625143494355,
+                "99.999" : 3.3524625143494355,
+                "99.9999" : 3.3524625143494355,
+                "100.0" : 3.3524625143494355
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.342365687644578,
+                    3.3524625143494355
+                ],
+                [
+                    3.329627919037276,
+                    3.3418740747382123
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6816118235148252,
+            "scoreError" : 0.035529882708068616,
+            "scoreConfidence" : [
+                1.6460819408067566,
+                1.7171417062228937
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6740493946922814,
+                "50.0" : 1.6832940342085463,
+                "90.0" : 1.6858098309499274,
+                "95.0" : 1.6858098309499274,
+                "99.0" : 1.6858098309499274,
+                "99.9" : 1.6858098309499274,
+                "99.99" : 1.6858098309499274,
+                "99.999" : 1.6858098309499274,
+                "99.9999" : 1.6858098309499274,
+                "100.0" : 1.6858098309499274
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6740493946922814,
+                    1.6810334730601864
+                ],
+                [
+                    1.6855545953569062,
+                    1.6858098309499274
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8477165969877756,
+            "scoreError" : 0.05293434833737389,
+            "scoreConfidence" : [
+                0.7947822486504017,
+                0.9006509453251494
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8362970070808161,
+                "50.0" : 0.8499947035171245,
+                "90.0" : 0.8545799738360371,
+                "95.0" : 0.8545799738360371,
+                "99.0" : 0.8545799738360371,
+                "99.9" : 0.8545799738360371,
+                "99.99" : 0.8545799738360371,
+                "99.999" : 0.8545799738360371,
+                "99.9999" : 0.8545799738360371,
+                "100.0" : 0.8545799738360371
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8474046431034374,
+                    0.8545799738360371
+                ],
+                [
+                    0.8362970070808161,
+                    0.8525847639308115
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.354317344450724,
+            "scoreError" : 0.25053060008971356,
+            "scoreConfidence" : [
+                16.10378674436101,
+                16.604847944540438
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.245724329552996,
+                "50.0" : 16.360628823109028,
+                "90.0" : 16.452634238953873,
+                "95.0" : 16.452634238953873,
+                "99.0" : 16.452634238953873,
+                "99.9" : 16.452634238953873,
+                "99.99" : 16.452634238953873,
+                "99.999" : 16.452634238953873,
+                "99.9999" : 16.452634238953873,
+                "100.0" : 16.452634238953873
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.2788856494011,
+                    16.300048426682586,
+                    16.245724329552996
+                ],
+                [
+                    16.42120921953547,
+                    16.4274022025783,
+                    16.452634238953873
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2768.892601001029,
+            "scoreError" : 104.40719007403524,
+            "scoreConfidence" : [
+                2664.485410926994,
+                2873.299791075064
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2733.7850575112775,
+                "50.0" : 2767.8511078140373,
+                "90.0" : 2806.3719775921177,
+                "95.0" : 2806.3719775921177,
+                "99.0" : 2806.3719775921177,
+                "99.9" : 2806.3719775921177,
+                "99.99" : 2806.3719775921177,
+                "99.999" : 2806.3719775921177,
+                "99.9999" : 2806.3719775921177,
+                "100.0" : 2806.3719775921177
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2734.884674963189,
+                    2736.2409187678436,
+                    2733.7850575112775
+                ],
+                [
+                    2802.6116803115187,
+                    2799.4612968602305,
+                    2806.3719775921177
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73618.34049890722,
+            "scoreError" : 397.89653804442975,
+            "scoreConfidence" : [
+                73220.44396086279,
+                74016.23703695164
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73464.66353114104,
+                "50.0" : 73579.0415290853,
+                "90.0" : 73844.38332549096,
+                "95.0" : 73844.38332549096,
+                "99.0" : 73844.38332549096,
+                "99.9" : 73844.38332549096,
+                "99.99" : 73844.38332549096,
+                "99.999" : 73844.38332549096,
+                "99.9999" : 73844.38332549096,
+                "100.0" : 73844.38332549096
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73464.66353114104,
+                    73539.5671597377,
+                    73522.12752537358
+                ],
+                [
+                    73844.38332549096,
+                    73720.78555326711,
+                    73618.5158984329
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 360.69172710833953,
+            "scoreError" : 3.74517823954857,
+            "scoreConfidence" : [
+                356.94654886879096,
+                364.4369053478881
+            ],
+            "scorePercentiles" : {
+                "0.0" : 358.9048903835008,
+                "50.0" : 360.6565495152811,
+                "90.0" : 362.96319375363373,
+                "95.0" : 362.96319375363373,
+                "99.0" : 362.96319375363373,
+                "99.9" : 362.96319375363373,
+                "99.99" : 362.96319375363373,
+                "99.999" : 362.96319375363373,
+                "99.9999" : 362.96319375363373,
+                "100.0" : 362.96319375363373
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    358.9048903835008,
+                    360.84655018210873,
+                    362.96319375363373
+                ],
+                [
+                    360.034113433211,
+                    360.93506604912943,
+                    360.4665488484535
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 115.02221026333963,
+            "scoreError" : 2.0509684187599344,
+            "scoreConfidence" : [
+                112.9712418445797,
+                117.07317868209957
+            ],
+            "scorePercentiles" : {
+                "0.0" : 113.67761135359257,
+                "50.0" : 115.2341014049674,
+                "90.0" : 115.64618027994125,
+                "95.0" : 115.64618027994125,
+                "99.0" : 115.64618027994125,
+                "99.9" : 115.64618027994125,
+                "99.99" : 115.64618027994125,
+                "99.999" : 115.64618027994125,
+                "99.9999" : 115.64618027994125,
+                "100.0" : 115.64618027994125
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    113.67761135359257,
+                    114.81487919930403,
+                    115.02146073562255
+                ],
+                [
+                    115.52638793726511,
+                    115.44674207431225,
+                    115.64618027994125
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06161785881006179,
+            "scoreError" : 3.832022169679344E-4,
+            "scoreConfidence" : [
+                0.06123465659309386,
+                0.06200106102702973
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061357856302268365,
+                "50.0" : 0.061638756668446405,
+                "90.0" : 0.061755075475659685,
+                "95.0" : 0.061755075475659685,
+                "99.0" : 0.061755075475659685,
+                "99.9" : 0.061755075475659685,
+                "99.99" : 0.061755075475659685,
+                "99.999" : 0.061755075475659685,
+                "99.9999" : 0.061755075475659685,
+                "100.0" : 0.061755075475659685
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.061755075475659685,
+                    0.06169499000555247,
+                    0.061357856302268365
+                ],
+                [
+                    0.06162171773999741,
+                    0.06164595957341881,
+                    0.061631553763474
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.686627820983506E-4,
+            "scoreError" : 2.4689260724545368E-5,
+            "scoreConfidence" : [
+                3.4397352137380526E-4,
+                3.9335204282289597E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6012340903562363E-4,
+                "50.0" : 3.68823676781516E-4,
+                "90.0" : 3.770662611238034E-4,
+                "95.0" : 3.770662611238034E-4,
+                "99.0" : 3.770662611238034E-4,
+                "99.9" : 3.770662611238034E-4,
+                "99.99" : 3.770662611238034E-4,
+                "99.999" : 3.770662611238034E-4,
+                "99.9999" : 3.770662611238034E-4,
+                "100.0" : 3.770662611238034E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.770662611238034E-4,
+                    3.760589566773345E-4,
+                    3.7691497748978584E-4
+                ],
+                [
+                    3.6012340903562363E-4,
+                    3.6158839688569746E-4,
+                    3.6022469137785907E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2669251784766997,
+            "scoreError" : 0.057737832921756146,
+            "scoreConfidence" : [
+                2.209187345554944,
+                2.3246630113984557
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2193962567687526,
+                "50.0" : 2.2584978450076068,
+                "90.0" : 2.3305498367530095,
+                "95.0" : 2.3327881905761605,
+                "99.0" : 2.3327881905761605,
+                "99.9" : 2.3327881905761605,
+                "99.99" : 2.3327881905761605,
+                "99.999" : 2.3327881905761605,
+                "99.9999" : 2.3327881905761605,
+                "100.0" : 2.3327881905761605
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.310404652344652,
+                    2.2622999271657998,
+                    2.2546957628494138,
+                    2.2239321102957526,
+                    2.2193962567687526
+                ],
+                [
+                    2.3327881905761605,
+                    2.284543647327547,
+                    2.2985307949896576,
+                    2.2412986510533393,
+                    2.241361791395922
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.014007143465245392,
+            "scoreError" : 8.518396760156854E-4,
+            "scoreConfidence" : [
+                0.013155303789229706,
+                0.014858983141261078
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013715809006994924,
+                "50.0" : 0.014005247306424762,
+                "90.0" : 0.014297832383256341,
+                "95.0" : 0.014297832383256341,
+                "99.0" : 0.014297832383256341,
+                "99.9" : 0.014297832383256341,
+                "99.99" : 0.014297832383256341,
+                "99.999" : 0.014297832383256341,
+                "99.9999" : 0.014297832383256341,
+                "100.0" : 0.014297832383256341
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013715809006994924,
+                    0.013734243445764897,
+                    0.013740086785370297
+                ],
+                [
+                    0.014297832383256341,
+                    0.014284481342606679,
+                    0.01427040782747923
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0994036641134153,
+            "scoreError" : 0.2752708623254079,
+            "scoreConfidence" : [
+                0.8241328017880074,
+                1.3746745264388232
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0086388905698436,
+                "50.0" : 1.0993494017013306,
+                "90.0" : 1.189715402569593,
+                "95.0" : 1.189715402569593,
+                "99.0" : 1.189715402569593,
+                "99.9" : 1.189715402569593,
+                "99.99" : 1.189715402569593,
+                "99.999" : 1.189715402569593,
+                "99.9999" : 1.189715402569593,
+                "100.0" : 1.189715402569593
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.189715402569593,
+                    1.1890555649744383,
+                    1.188265314163498
+                ],
+                [
+                    1.0104334892391633,
+                    1.010313323163956,
+                    1.0086388905698436
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.011361131871082288,
+            "scoreError" : 5.389887088753839E-4,
+            "scoreConfidence" : [
+                0.010822143162206904,
+                0.011900120579957672
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.011175285508027008,
+                "50.0" : 0.011362474256172452,
+                "90.0" : 0.01154893465311317,
+                "95.0" : 0.01154893465311317,
+                "99.0" : 0.01154893465311317,
+                "99.9" : 0.01154893465311317,
+                "99.99" : 0.01154893465311317,
+                "99.999" : 0.01154893465311317,
+                "99.9999" : 0.01154893465311317,
+                "100.0" : 0.01154893465311317
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01154893465311317,
+                    0.011527915495652935,
+                    0.011532241271466726
+                ],
+                [
+                    0.01118538128154193,
+                    0.011197033016691971,
+                    0.011175285508027008
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.974496828763094,
+            "scoreError" : 0.2312968150533349,
+            "scoreConfidence" : [
+                2.743200013709759,
+                3.205793643816429
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8953606508396064,
+                "50.0" : 2.9698823802461423,
+                "90.0" : 3.056585097799511,
+                "95.0" : 3.056585097799511,
+                "99.0" : 3.056585097799511,
+                "99.9" : 3.056585097799511,
+                "99.99" : 3.056585097799511,
+                "99.999" : 3.056585097799511,
+                "99.9999" : 3.056585097799511,
+                "100.0" : 3.056585097799511
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.054104081196581,
+                    3.056585097799511,
+                    3.037921642162819
+                ],
+                [
+                    2.8953606508396064,
+                    2.901843118329466,
+                    2.90116638225058
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.865792507511747,
+            "scoreError" : 0.03000928680282314,
+            "scoreConfidence" : [
+                2.835783220708924,
+                2.89580179431457
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8503367637503563,
+                "50.0" : 2.8657987436191736,
+                "90.0" : 2.8811422178046673,
+                "95.0" : 2.8811422178046673,
+                "99.0" : 2.8811422178046673,
+                "99.9" : 2.8811422178046673,
+                "99.99" : 2.8811422178046673,
+                "99.999" : 2.8811422178046673,
+                "99.9999" : 2.8811422178046673,
+                "100.0" : 2.8811422178046673
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.86884855134825,
+                    2.872144863584147,
+                    2.859533712692967
+                ],
+                [
+                    2.8811422178046673,
+                    2.8503367637503563,
+                    2.8627489358900973
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17642635055827868,
+            "scoreError" : 0.010859015772990489,
+            "scoreConfidence" : [
+                0.1655673347852882,
+                0.18728536633126916
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.172755826506815,
+                "50.0" : 0.17644735850424792,
+                "90.0" : 0.18000720448204482,
+                "95.0" : 0.18000720448204482,
+                "99.0" : 0.18000720448204482,
+                "99.9" : 0.18000720448204482,
+                "99.99" : 0.18000720448204482,
+                "99.999" : 0.18000720448204482,
+                "99.9999" : 0.18000720448204482,
+                "100.0" : 0.18000720448204482
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1798924584277748,
+                    0.1799817389089862,
+                    0.18000720448204482
+                ],
+                [
+                    0.17291861644333018,
+                    0.17300225858072105,
+                    0.172755826506815
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3305157243051423,
+            "scoreError" : 0.008470878000936847,
+            "scoreConfidence" : [
+                0.3220448463042055,
+                0.33898660230607913
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3275217020928176,
+                "50.0" : 0.33054629242785405,
+                "90.0" : 0.33337994732806614,
+                "95.0" : 0.33337994732806614,
+                "99.0" : 0.33337994732806614,
+                "99.9" : 0.33337994732806614,
+                "99.99" : 0.33337994732806614,
+                "99.999" : 0.33337994732806614,
+                "99.9999" : 0.33337994732806614,
+                "100.0" : 0.33337994732806614
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3331235898734177,
+                    0.33330405019330756,
+                    0.33337994732806614
+                ],
+                [
+                    0.32796899498229043,
+                    0.3277960613609545,
+                    0.3275217020928176
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.146747917542838,
+            "scoreError" : 0.005243113842760135,
+            "scoreConfidence" : [
+                0.14150480370007787,
+                0.15199103138559814
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14481733343470327,
+                "50.0" : 0.14669620360505384,
+                "90.0" : 0.14881633457841006,
+                "95.0" : 0.14881633457841006,
+                "99.0" : 0.14881633457841006,
+                "99.9" : 0.14881633457841006,
+                "99.99" : 0.14881633457841006,
+                "99.999" : 0.14881633457841006,
+                "99.9999" : 0.14881633457841006,
+                "100.0" : 0.14881633457841006
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1483200889162452,
+                    0.14881633457841006,
+                    0.1481821488753223
+                ],
+                [
+                    0.14521025833478537,
+                    0.1451413411175617,
+                    0.14481733343470327
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40925988718314166,
+            "scoreError" : 0.016398266542048776,
+            "scoreConfidence" : [
+                0.39286162064109287,
+                0.42565815372519045
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4021727301134079,
+                "50.0" : 0.40921094773529365,
+                "90.0" : 0.4171355213981814,
+                "95.0" : 0.4171355213981814,
+                "99.0" : 0.4171355213981814,
+                "99.9" : 0.4171355213981814,
+                "99.99" : 0.4171355213981814,
+                "99.999" : 0.4171355213981814,
+                "99.9999" : 0.4171355213981814,
+                "100.0" : 0.4171355213981814
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41364107151720714,
+                    0.4171355213981814,
+                    0.4118383694094391
+                ],
+                [
+                    0.40658352606114817,
+                    0.40418810459946647,
+                    0.4021727301134079
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1580726904678802,
+            "scoreError" : 0.011857625118871916,
+            "scoreConfidence" : [
+                0.14621506534900827,
+                0.16993031558675212
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15414120656010605,
+                "50.0" : 0.15784746128044508,
+                "90.0" : 0.16289812572080142,
+                "95.0" : 0.16289812572080142,
+                "99.0" : 0.16289812572080142,
+                "99.9" : 0.16289812572080142,
+                "99.99" : 0.16289812572080142,
+                "99.999" : 0.16289812572080142,
+                "99.9999" : 0.16289812572080142,
+                "100.0" : 0.16289812572080142
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15423364014929516,
+                    0.15414120656010605,
+                    0.15436235514941962
+                ],
+                [
+                    0.16289812572080142,
+                    0.16146824781618846,
+                    0.1613325674114705
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04603990474335302,
+            "scoreError" : 1.9147459444826689E-4,
+            "scoreConfidence" : [
+                0.04584843014890475,
+                0.04623137933780128
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04596589192667635,
+                "50.0" : 0.046036036598165776,
+                "90.0" : 0.04613349116785459,
+                "95.0" : 0.04613349116785459,
+                "99.0" : 0.04613349116785459,
+                "99.9" : 0.04613349116785459,
+                "99.99" : 0.04613349116785459,
+                "99.999" : 0.04613349116785459,
+                "99.9999" : 0.04613349116785459,
+                "100.0" : 0.04613349116785459
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04613349116785459,
+                    0.04608754886119586,
+                    0.04607627152302624
+                ],
+                [
+                    0.04598042330805979,
+                    0.04599580167330531,
+                    0.04596589192667635
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8682930.533860566,
+            "scoreError" : 313242.29473320354,
+            "scoreConfidence" : [
+                8369688.239127362,
+                8996172.82859377
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8562608.52140411,
+                "50.0" : 8684311.611321438,
+                "90.0" : 8826646.169461606,
+                "95.0" : 8826646.169461606,
+                "99.0" : 8826646.169461606,
+                "99.9" : 8826646.169461606,
+                "99.99" : 8826646.169461606,
+                "99.999" : 8826646.169461606,
+                "99.9999" : 8826646.169461606,
+                "100.0" : 8826646.169461606
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8826646.169461606,
+                    8767419.731814198,
+                    8747057.766608391
+                ],
+                [
+                    8562608.52140411,
+                    8572285.557840617,
+                    8621565.456034483
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2025-12-04T01-23-15Z-7defb76b60135e43d93db0cf08d534737b8f20f0-jdk17.json
+++ b/performance-results/2025-12-04T01-23-15Z-7defb76b60135e43d93db0cf08d534737b8f20f0-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.360355985611967,
+            "scoreError" : 0.04055333121609072,
+            "scoreConfidence" : [
+                3.3198026543958763,
+                3.4009093168280575
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.354815243489598,
+                "50.0" : 3.3598147213169742,
+                "90.0" : 3.366979256324321,
+                "95.0" : 3.366979256324321,
+                "99.0" : 3.366979256324321,
+                "99.9" : 3.366979256324321,
+                "99.99" : 3.366979256324321,
+                "99.999" : 3.366979256324321,
+                "99.9999" : 3.366979256324321,
+                "100.0" : 3.366979256324321
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.364451462554298,
+                    3.366979256324321
+                ],
+                [
+                    3.354815243489598,
+                    3.3551779800796506
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7013709929836882,
+            "scoreError" : 0.03251980965954205,
+            "scoreConfidence" : [
+                1.6688511833241462,
+                1.7338908026432303
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6968868796221257,
+                "50.0" : 1.70060760743061,
+                "90.0" : 1.7073818774514071,
+                "95.0" : 1.7073818774514071,
+                "99.0" : 1.7073818774514071,
+                "99.9" : 1.7073818774514071,
+                "99.99" : 1.7073818774514071,
+                "99.999" : 1.7073818774514071,
+                "99.9999" : 1.7073818774514071,
+                "100.0" : 1.7073818774514071
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7036550605237601,
+                    1.7073818774514071
+                ],
+                [
+                    1.69756015433746,
+                    1.6968868796221257
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8510771756583426,
+            "scoreError" : 0.030691826181184656,
+            "scoreConfidence" : [
+                0.820385349477158,
+                0.8817690018395272
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8448418136554033,
+                "50.0" : 0.8515702836819348,
+                "90.0" : 0.8563263216140972,
+                "95.0" : 0.8563263216140972,
+                "99.0" : 0.8563263216140972,
+                "99.9" : 0.8563263216140972,
+                "99.99" : 0.8563263216140972,
+                "99.999" : 0.8563263216140972,
+                "99.9999" : 0.8563263216140972,
+                "100.0" : 0.8563263216140972
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.852185242226278,
+                    0.8563263216140972
+                ],
+                [
+                    0.8448418136554033,
+                    0.8509553251375916
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.5446639481515,
+            "scoreError" : 0.4744267167791128,
+            "scoreConfidence" : [
+                16.070237231372385,
+                17.019090664930612
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.348078693893864,
+                "50.0" : 16.55786762578068,
+                "90.0" : 16.714850046132412,
+                "95.0" : 16.714850046132412,
+                "99.0" : 16.714850046132412,
+                "99.9" : 16.714850046132412,
+                "99.99" : 16.714850046132412,
+                "99.999" : 16.714850046132412,
+                "99.9999" : 16.714850046132412,
+                "100.0" : 16.714850046132412
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.714850046132412,
+                    16.678163962284525,
+                    16.696676117609275
+                ],
+                [
+                    16.43757128927684,
+                    16.348078693893864,
+                    16.392643579712068
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2714.5164766101952,
+            "scoreError" : 242.77464943935817,
+            "scoreConfidence" : [
+                2471.741827170837,
+                2957.2911260495534
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2631.278002149444,
+                "50.0" : 2714.718421950418,
+                "90.0" : 2795.9451093144257,
+                "95.0" : 2795.9451093144257,
+                "99.0" : 2795.9451093144257,
+                "99.9" : 2795.9451093144257,
+                "99.99" : 2795.9451093144257,
+                "99.999" : 2795.9451093144257,
+                "99.9999" : 2795.9451093144257,
+                "100.0" : 2795.9451093144257
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2631.278002149444,
+                    2637.6557604053996,
+                    2637.6334228786914
+                ],
+                [
+                    2795.9451093144257,
+                    2791.7810834954357,
+                    2792.805481417775
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74181.20068529503,
+            "scoreError" : 1006.4964779544725,
+            "scoreConfidence" : [
+                73174.70420734056,
+                75187.6971632495
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73786.03715862251,
+                "50.0" : 74196.98625341375,
+                "90.0" : 74514.5620822917,
+                "95.0" : 74514.5620822917,
+                "99.0" : 74514.5620822917,
+                "99.9" : 74514.5620822917,
+                "99.99" : 74514.5620822917,
+                "99.999" : 74514.5620822917,
+                "99.9999" : 74514.5620822917,
+                "100.0" : 74514.5620822917
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74507.32646865374,
+                    74514.5620822917,
+                    74499.01806569239
+                ],
+                [
+                    73786.03715862251,
+                    73885.30589537477,
+                    73894.95444113512
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 362.7454296556889,
+            "scoreError" : 11.155415623662838,
+            "scoreConfidence" : [
+                351.59001403202603,
+                373.90084527935176
+            ],
+            "scorePercentiles" : {
+                "0.0" : 358.952393723411,
+                "50.0" : 362.71103453699703,
+                "90.0" : 366.57235208680305,
+                "95.0" : 366.57235208680305,
+                "99.0" : 366.57235208680305,
+                "99.9" : 366.57235208680305,
+                "99.99" : 366.57235208680305,
+                "99.999" : 366.57235208680305,
+                "99.9999" : 366.57235208680305,
+                "100.0" : 366.57235208680305
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    365.9831727158899,
+                    366.57235208680305,
+                    366.5495905241479
+                ],
+                [
+                    359.43889635810416,
+                    358.9761725257772,
+                    358.952393723411
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 117.39278481874057,
+            "scoreError" : 1.8005401128813827,
+            "scoreConfidence" : [
+                115.59224470585919,
+                119.19332493162194
+            ],
+            "scorePercentiles" : {
+                "0.0" : 116.75454933369264,
+                "50.0" : 117.22861415546572,
+                "90.0" : 118.1880621311331,
+                "95.0" : 118.1880621311331,
+                "99.0" : 118.1880621311331,
+                "99.9" : 118.1880621311331,
+                "99.99" : 118.1880621311331,
+                "99.999" : 118.1880621311331,
+                "99.9999" : 118.1880621311331,
+                "100.0" : 118.1880621311331
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    117.53157928494822,
+                    118.1880621311331,
+                    118.09869075057064
+                ],
+                [
+                    116.85817838611555,
+                    116.75454933369264,
+                    116.92564902598323
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.0610692149732561,
+            "scoreError" : 0.0025258275092135468,
+            "scoreConfidence" : [
+                0.05854338746404255,
+                0.06359504248246964
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.060137666985392725,
+                "50.0" : 0.06111949279903199,
+                "90.0" : 0.06194939575034846,
+                "95.0" : 0.06194939575034846,
+                "99.0" : 0.06194939575034846,
+                "99.9" : 0.06194939575034846,
+                "99.99" : 0.06194939575034846,
+                "99.999" : 0.06194939575034846,
+                "99.9999" : 0.06194939575034846,
+                "100.0" : 0.06194939575034846
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06039965458366802,
+                    0.060137666985392725,
+                    0.060216516577346904
+                ],
+                [
+                    0.06187272492838449,
+                    0.06183933101439596,
+                    0.06194939575034846
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6736348035062543E-4,
+            "scoreError" : 2.60741213415827E-5,
+            "scoreConfidence" : [
+                3.4128935900904275E-4,
+                3.934376016922081E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.588131709518758E-4,
+                "50.0" : 3.6712356443273174E-4,
+                "90.0" : 3.762315292806471E-4,
+                "95.0" : 3.762315292806471E-4,
+                "99.0" : 3.762315292806471E-4,
+                "99.9" : 3.762315292806471E-4,
+                "99.99" : 3.762315292806471E-4,
+                "99.999" : 3.762315292806471E-4,
+                "99.9999" : 3.762315292806471E-4,
+                "100.0" : 3.762315292806471E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.762315292806471E-4,
+                    3.760633385863655E-4,
+                    3.752428050666379E-4
+                ],
+                [
+                    3.5882571441940065E-4,
+                    3.588131709518758E-4,
+                    3.590043237988256E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.191463112586933,
+            "scoreError" : 0.04928182790269893,
+            "scoreConfidence" : [
+                2.142181284684234,
+                2.240744940489632
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1470422367969086,
+                "50.0" : 2.186775807442379,
+                "90.0" : 2.2540977236314745,
+                "95.0" : 2.2582079051704675,
+                "99.0" : 2.2582079051704675,
+                "99.9" : 2.2582079051704675,
+                "99.99" : 2.2582079051704675,
+                "99.999" : 2.2582079051704675,
+                "99.9999" : 2.2582079051704675,
+                "100.0" : 2.2582079051704675
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.2098433148475474,
+                    2.1876703659230095,
+                    2.1858812489617487,
+                    2.150365632337132,
+                    2.1470422367969086
+                ],
+                [
+                    2.2582079051704675,
+                    2.2171060897805366,
+                    2.2007904779929577,
+                    2.1784103615769985,
+                    2.1793134924820223
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013317765575471178,
+            "scoreError" : 3.3465924446437887E-4,
+            "scoreConfidence" : [
+                0.0129831063310068,
+                0.013652424819935557
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01320785783229917,
+                "50.0" : 0.013314764739678835,
+                "90.0" : 0.013432598856092824,
+                "95.0" : 0.013432598856092824,
+                "99.0" : 0.013432598856092824,
+                "99.9" : 0.013432598856092824,
+                "99.99" : 0.013432598856092824,
+                "99.999" : 0.013432598856092824,
+                "99.9999" : 0.013432598856092824,
+                "100.0" : 0.013432598856092824
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013432598856092824,
+                    0.013419999286065118,
+                    0.0134273444827864
+                ],
+                [
+                    0.01320785783229917,
+                    0.013209530193292551,
+                    0.013209262802290992
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0428308364453114,
+            "scoreError" : 0.004560505829791909,
+            "scoreConfidence" : [
+                1.0382703306155194,
+                1.0473913422751033
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0403301344013316,
+                "50.0" : 1.0430034886800772,
+                "90.0" : 1.0444276388511748,
+                "95.0" : 1.0444276388511748,
+                "99.0" : 1.0444276388511748,
+                "99.9" : 1.0444276388511748,
+                "99.99" : 1.0444276388511748,
+                "99.999" : 1.0444276388511748,
+                "99.9999" : 1.0444276388511748,
+                "100.0" : 1.0444276388511748
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0438352498695334,
+                    1.0403301344013316,
+                    1.042171727490621
+                ],
+                [
+                    1.0444276388511748,
+                    1.0442979923767752,
+                    1.0419222756824338
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010283344405529292,
+            "scoreError" : 0.0014360544159085977,
+            "scoreConfidence" : [
+                0.008847289989620694,
+                0.01171939882143789
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.009806795743170223,
+                "50.0" : 0.010288062136101467,
+                "90.0" : 0.010760068264570941,
+                "95.0" : 0.010760068264570941,
+                "99.0" : 0.010760068264570941,
+                "99.9" : 0.010760068264570941,
+                "99.99" : 0.010760068264570941,
+                "99.999" : 0.010760068264570941,
+                "99.9999" : 0.010760068264570941,
+                "100.0" : 0.010760068264570941
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.009806795743170223,
+                    0.009809935283500099,
+                    0.009831086446259867
+                ],
+                [
+                    0.01074503782594307,
+                    0.010747142869731554,
+                    0.010760068264570941
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.974138886784724,
+            "scoreError" : 0.41071973253134575,
+            "scoreConfidence" : [
+                2.563419154253378,
+                3.3848586193160695
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8357039353741498,
+                "50.0" : 2.9753392009514625,
+                "90.0" : 3.108602658794282,
+                "95.0" : 3.108602658794282,
+                "99.0" : 3.108602658794282,
+                "99.9" : 3.108602658794282,
+                "99.99" : 3.108602658794282,
+                "99.999" : 3.108602658794282,
+                "99.9999" : 3.108602658794282,
+                "100.0" : 3.108602658794282
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.844401013083049,
+                    2.8412756136363635,
+                    2.8357039353741498
+                ],
+                [
+                    3.106277388819876,
+                    3.108602658794282,
+                    3.1085727110006216
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8016889366125306,
+            "scoreError" : 0.10481497939805677,
+            "scoreConfidence" : [
+                2.696873957214474,
+                2.906503916010587
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.766349415767635,
+                "50.0" : 2.8018258064808035,
+                "90.0" : 2.8371915617021277,
+                "95.0" : 2.8371915617021277,
+                "99.0" : 2.8371915617021277,
+                "99.9" : 2.8371915617021277,
+                "99.99" : 2.8371915617021277,
+                "99.999" : 2.8371915617021277,
+                "99.9999" : 2.8371915617021277,
+                "100.0" : 2.8371915617021277
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8371915617021277,
+                    2.8337088707849247,
+                    2.836421019285309
+                ],
+                [
+                    2.7699427421766822,
+                    2.7665200099585063,
+                    2.766349415767635
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17930534083335084,
+            "scoreError" : 0.0011413403338308692,
+            "scoreConfidence" : [
+                0.17816400049951997,
+                0.1804466811671817
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17871425648265632,
+                "50.0" : 0.1792561983388657,
+                "90.0" : 0.1799464336098465,
+                "95.0" : 0.1799464336098465,
+                "99.0" : 0.1799464336098465,
+                "99.9" : 0.1799464336098465,
+                "99.99" : 0.1799464336098465,
+                "99.999" : 0.1799464336098465,
+                "99.9999" : 0.1799464336098465,
+                "100.0" : 0.1799464336098465
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1799464336098465,
+                    0.17915380746699153,
+                    0.1795051507628792
+                ],
+                [
+                    0.17926621687848424,
+                    0.17871425648265632,
+                    0.17924617979924717
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3291956126198951,
+            "scoreError" : 0.02262005267515248,
+            "scoreConfidence" : [
+                0.3065755599447426,
+                0.3518156652950476
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3215072421553498,
+                "50.0" : 0.3293400378351934,
+                "90.0" : 0.3367219474729789,
+                "95.0" : 0.3367219474729789,
+                "99.0" : 0.3367219474729789,
+                "99.9" : 0.3367219474729789,
+                "99.99" : 0.3367219474729789,
+                "99.999" : 0.3367219474729789,
+                "99.9999" : 0.3367219474729789,
+                "100.0" : 0.3367219474729789
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3223809913281754,
+                    0.3215072421553498,
+                    0.3216261658572669
+                ],
+                [
+                    0.33629908434221145,
+                    0.3367219474729789,
+                    0.33663824456338787
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14306659410559575,
+            "scoreError" : 0.001992842537906487,
+            "scoreConfidence" : [
+                0.14107375156768925,
+                0.14505943664350224
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14243195624617225,
+                "50.0" : 0.14294427374618315,
+                "90.0" : 0.1442981559118063,
+                "95.0" : 0.1442981559118063,
+                "99.0" : 0.1442981559118063,
+                "99.9" : 0.1442981559118063,
+                "99.99" : 0.1442981559118063,
+                "99.999" : 0.1442981559118063,
+                "99.9999" : 0.1442981559118063,
+                "100.0" : 0.1442981559118063
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14243195624617225,
+                    0.14264784264806574,
+                    0.1424793514895921
+                ],
+                [
+                    0.1442981559118063,
+                    0.14330155349363752,
+                    0.14324070484430057
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3997510526803165,
+            "scoreError" : 0.001452052263390989,
+            "scoreConfidence" : [
+                0.3982990004169255,
+                0.40120310494370753
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39908376937504986,
+                "50.0" : 0.39980051843355197,
+                "90.0" : 0.4004141286086086,
+                "95.0" : 0.4004141286086086,
+                "99.0" : 0.4004141286086086,
+                "99.9" : 0.4004141286086086,
+                "99.99" : 0.4004141286086086,
+                "99.999" : 0.4004141286086086,
+                "99.9999" : 0.4004141286086086,
+                "100.0" : 0.4004141286086086
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3996870786570743,
+                    0.3992450991695944,
+                    0.39908376937504986
+                ],
+                [
+                    0.4004141286086086,
+                    0.40016228206154214,
+                    0.3999139582100296
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.159388054163947,
+            "scoreError" : 0.011337319012799784,
+            "scoreConfidence" : [
+                0.14805073515114722,
+                0.17072537317674677
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15635212689180739,
+                "50.0" : 0.1571345271860036,
+                "90.0" : 0.16576695692027185,
+                "95.0" : 0.16576695692027185,
+                "99.0" : 0.16576695692027185,
+                "99.9" : 0.16576695692027185,
+                "99.99" : 0.16576695692027185,
+                "99.999" : 0.16576695692027185,
+                "99.9999" : 0.16576695692027185,
+                "100.0" : 0.16576695692027185
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16576695692027185,
+                    0.16320779018491016,
+                    0.15723990263844775
+                ],
+                [
+                    0.15702915173355944,
+                    0.15673239661468538,
+                    0.15635212689180739
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.046928034435749,
+            "scoreError" : 0.003350862526112786,
+            "scoreConfidence" : [
+                0.04357717190963621,
+                0.05027889696186179
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04583499455487975,
+                "50.0" : 0.04688206679849265,
+                "90.0" : 0.04819827067669173,
+                "95.0" : 0.04819827067669173,
+                "99.0" : 0.04819827067669173,
+                "99.9" : 0.04819827067669173,
+                "99.99" : 0.04819827067669173,
+                "99.999" : 0.04819827067669173,
+                "99.9999" : 0.04819827067669173,
+                "100.0" : 0.04819827067669173
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04819827067669173,
+                    0.047917720816123124,
+                    0.0479290202592921
+                ],
+                [
+                    0.04584178752664512,
+                    0.04583499455487975,
+                    0.04584641278086218
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8712314.223525856,
+            "scoreError" : 550508.2137877861,
+            "scoreConfidence" : [
+                8161806.00973807,
+                9262822.437313642
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8525601.616368286,
+                "50.0" : 8705538.003109552,
+                "90.0" : 8929177.400892857,
+                "95.0" : 8929177.400892857,
+                "99.0" : 8929177.400892857,
+                "99.9" : 8929177.400892857,
+                "99.99" : 8929177.400892857,
+                "99.999" : 8929177.400892857,
+                "99.9999" : 8929177.400892857,
+                "100.0" : 8929177.400892857
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8527918.93435635,
+                    8525601.616368286,
+                    8549717.072649572
+                ],
+                [
+                    8929177.400892857,
+                    8861358.93356953,
+                    8880111.383318545
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2025-12-07T04-28-01Z-fb5d1ddba75f1ccfe20c96a24ab08d26d76de22a-jdk17.json
+++ b/performance-results/2025-12-07T04-28-01Z-fb5d1ddba75f1ccfe20c96a24ab08d26d76de22a-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3563389793868836,
+            "scoreError" : 0.027414473071397747,
+            "scoreConfidence" : [
+                3.3289245063154858,
+                3.3837534524582815
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3519305826162786,
+                "50.0" : 3.3556502671025425,
+                "90.0" : 3.362124800726171,
+                "95.0" : 3.362124800726171,
+                "99.0" : 3.362124800726171,
+                "99.9" : 3.362124800726171,
+                "99.99" : 3.362124800726171,
+                "99.999" : 3.362124800726171,
+                "99.9999" : 3.362124800726171,
+                "100.0" : 3.362124800726171
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.35538945696139,
+                    3.362124800726171
+                ],
+                [
+                    3.3559110772436953,
+                    3.3519305826162786
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6923205119502358,
+            "scoreError" : 0.030766102695079314,
+            "scoreConfidence" : [
+                1.6615544092551564,
+                1.7230866146453152
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.686347687303837,
+                "50.0" : 1.6929312469480386,
+                "90.0" : 1.6970718666010294,
+                "95.0" : 1.6970718666010294,
+                "99.0" : 1.6970718666010294,
+                "99.9" : 1.6970718666010294,
+                "99.99" : 1.6970718666010294,
+                "99.999" : 1.6970718666010294,
+                "99.9999" : 1.6970718666010294,
+                "100.0" : 1.6970718666010294
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.695053496919354,
+                    1.6970718666010294
+                ],
+                [
+                    1.686347687303837,
+                    1.6908089969767233
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8558611711432685,
+            "scoreError" : 0.02002101224541346,
+            "scoreConfidence" : [
+                0.8358401588978551,
+                0.875882183388682
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8519084899255482,
+                "50.0" : 0.8560315293160432,
+                "90.0" : 0.8594731360154398,
+                "95.0" : 0.8594731360154398,
+                "99.0" : 0.8594731360154398,
+                "99.9" : 0.8594731360154398,
+                "99.99" : 0.8594731360154398,
+                "99.999" : 0.8594731360154398,
+                "99.9999" : 0.8594731360154398,
+                "100.0" : 0.8594731360154398
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8562184502706531,
+                    0.8558446083614334
+                ],
+                [
+                    0.8519084899255482,
+                    0.8594731360154398
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.497304762235682,
+            "scoreError" : 0.037725192760995944,
+            "scoreConfidence" : [
+                16.459579569474688,
+                16.535029954996677
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.486203136599727,
+                "50.0" : 16.492517148521372,
+                "90.0" : 16.522916894713333,
+                "95.0" : 16.522916894713333,
+                "99.0" : 16.522916894713333,
+                "99.9" : 16.522916894713333,
+                "99.99" : 16.522916894713333,
+                "99.999" : 16.522916894713333,
+                "99.9999" : 16.522916894713333,
+                "100.0" : 16.522916894713333
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.494612479348568,
+                    16.489409908433636,
+                    16.486203136599727
+                ],
+                [
+                    16.522916894713333,
+                    16.490421817694177,
+                    16.50026433662464
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2708.969068048022,
+            "scoreError" : 401.68295145964987,
+            "scoreConfidence" : [
+                2307.2861165883724,
+                3110.652019507672
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2577.4044223144947,
+                "50.0" : 2708.570780437086,
+                "90.0" : 2840.8722191611864,
+                "95.0" : 2840.8722191611864,
+                "99.0" : 2840.8722191611864,
+                "99.9" : 2840.8722191611864,
+                "99.99" : 2840.8722191611864,
+                "99.999" : 2840.8722191611864,
+                "99.9999" : 2840.8722191611864,
+                "100.0" : 2840.8722191611864
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2578.4133684427647,
+                    2578.807883422982,
+                    2577.4044223144947
+                ],
+                [
+                    2838.33367745119,
+                    2840.8722191611864,
+                    2839.9828374955146
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73585.2446147895,
+            "scoreError" : 606.9453304300316,
+            "scoreConfidence" : [
+                72978.29928435947,
+                74192.18994521952
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73352.8708812274,
+                "50.0" : 73598.19802755525,
+                "90.0" : 73796.34501222109,
+                "95.0" : 73796.34501222109,
+                "99.0" : 73796.34501222109,
+                "99.9" : 73796.34501222109,
+                "99.99" : 73796.34501222109,
+                "99.999" : 73796.34501222109,
+                "99.9999" : 73796.34501222109,
+                "100.0" : 73796.34501222109
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73374.24286793331,
+                    73352.8708812274,
+                    73442.90671392564
+                ],
+                [
+                    73753.48934118486,
+                    73796.34501222109,
+                    73791.61287224466
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 365.04774638256504,
+            "scoreError" : 1.0287725809945165,
+            "scoreConfidence" : [
+                364.0189738015705,
+                366.0765189635596
+            ],
+            "scorePercentiles" : {
+                "0.0" : 364.3831105877561,
+                "50.0" : 365.11327759472044,
+                "90.0" : 365.3878650670745,
+                "95.0" : 365.3878650670745,
+                "99.0" : 365.3878650670745,
+                "99.9" : 365.3878650670745,
+                "99.99" : 365.3878650670745,
+                "99.999" : 365.3878650670745,
+                "99.9999" : 365.3878650670745,
+                "100.0" : 365.3878650670745
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    365.0807732401258,
+                    365.35199866607763,
+                    364.3831105877561
+                ],
+                [
+                    365.1457819493151,
+                    365.3878650670745,
+                    364.93694878504124
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 116.0865750438817,
+            "scoreError" : 2.9333726525997967,
+            "scoreConfidence" : [
+                113.1532023912819,
+                119.0199476964815
+            ],
+            "scorePercentiles" : {
+                "0.0" : 115.07204064709667,
+                "50.0" : 116.03979148716951,
+                "90.0" : 117.18718101145633,
+                "95.0" : 117.18718101145633,
+                "99.0" : 117.18718101145633,
+                "99.9" : 117.18718101145633,
+                "99.99" : 117.18718101145633,
+                "99.999" : 117.18718101145633,
+                "99.9999" : 117.18718101145633,
+                "100.0" : 117.18718101145633
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    115.15506369587781,
+                    115.18047113960023,
+                    115.07204064709667
+                ],
+                [
+                    117.18718101145633,
+                    116.89911183473878,
+                    117.02558193452039
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06089879539118081,
+            "scoreError" : 2.5355032335691786E-4,
+            "scoreConfidence" : [
+                0.06064524506782389,
+                0.061152345714537724
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.060763269808477544,
+                "50.0" : 0.06091355725973502,
+                "90.0" : 0.06099358093123681,
+                "95.0" : 0.06099358093123681,
+                "99.0" : 0.06099358093123681,
+                "99.9" : 0.06099358093123681,
+                "99.99" : 0.06099358093123681,
+                "99.999" : 0.06099358093123681,
+                "99.9999" : 0.06099358093123681,
+                "100.0" : 0.06099358093123681
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06084282278034327,
+                    0.060763269808477544,
+                    0.060861389629359136
+                ],
+                [
+                    0.06099358093123681,
+                    0.060965984307557244,
+                    0.060965724890110894
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6017732925604516E-4,
+            "scoreError" : 1.1135297485003566E-5,
+            "scoreConfidence" : [
+                3.490420317710416E-4,
+                3.713126267410487E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5644217420837554E-4,
+                "50.0" : 3.602171391479932E-4,
+                "90.0" : 3.638269085365743E-4,
+                "95.0" : 3.638269085365743E-4,
+                "99.0" : 3.638269085365743E-4,
+                "99.9" : 3.638269085365743E-4,
+                "99.99" : 3.638269085365743E-4,
+                "99.999" : 3.638269085365743E-4,
+                "99.9999" : 3.638269085365743E-4,
+                "100.0" : 3.638269085365743E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.638269085365743E-4,
+                    3.638040174636078E-4,
+                    3.637742335564103E-4
+                ],
+                [
+                    3.5666004473957605E-4,
+                    3.5655659703172696E-4,
+                    3.5644217420837554E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2743422310824464,
+            "scoreError" : 0.07096543390299073,
+            "scoreConfidence" : [
+                2.203376797179456,
+                2.345307664985437
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.212699245132743,
+                "50.0" : 2.272660582026812,
+                "90.0" : 2.3338155688301274,
+                "95.0" : 2.3340232256709452,
+                "99.0" : 2.3340232256709452,
+                "99.9" : 2.3340232256709452,
+                "99.99" : 2.3340232256709452,
+                "99.999" : 2.3340232256709452,
+                "99.9999" : 2.3340232256709452,
+                "100.0" : 2.3340232256709452
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.2990111022988504,
+                    2.240313248879928,
+                    2.234881778547486,
+                    2.218694580301686,
+                    2.212699245132743
+                ],
+                [
+                    2.3340232256709452,
+                    2.3265313086764365,
+                    2.3319466572627654,
+                    2.2725794942058624,
+                    2.272741669847762
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013447621055760804,
+            "scoreError" : 4.0539716885053966E-4,
+            "scoreConfidence" : [
+                0.013042223886910264,
+                0.013853018224611343
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01330191980233579,
+                "50.0" : 0.013451430104153051,
+                "90.0" : 0.013580757994532469,
+                "95.0" : 0.013580757994532469,
+                "99.0" : 0.013580757994532469,
+                "99.9" : 0.013580757994532469,
+                "99.99" : 0.013580757994532469,
+                "99.999" : 0.013580757994532469,
+                "99.9999" : 0.013580757994532469,
+                "100.0" : 0.013580757994532469
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013321021750308379,
+                    0.013324573135048274,
+                    0.01330191980233579
+                ],
+                [
+                    0.013579166579082086,
+                    0.01357828707325783,
+                    0.013580757994532469
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0128862381311574,
+            "scoreError" : 0.0731584489543247,
+            "scoreConfidence" : [
+                0.9397277891768328,
+                1.086044687085482
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9888099996045085,
+                "50.0" : 1.0127725979128792,
+                "90.0" : 1.037049086072799,
+                "95.0" : 1.037049086072799,
+                "99.0" : 1.037049086072799,
+                "99.9" : 1.037049086072799,
+                "99.99" : 1.037049086072799,
+                "99.999" : 1.037049086072799,
+                "99.9999" : 1.037049086072799,
+                "100.0" : 1.037049086072799
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0363053041450778,
+                    1.037049086072799,
+                    1.0367479677586564
+                ],
+                [
+                    0.9888099996045085,
+                    0.9891651795252225,
+                    0.9892398916806806
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010278148113185717,
+            "scoreError" : 0.0012593433250485694,
+            "scoreConfidence" : [
+                0.009018804788137148,
+                0.011537491438234286
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.009862133500196251,
+                "50.0" : 0.010278146043600448,
+                "90.0" : 0.010690806225318204,
+                "95.0" : 0.010690806225318204,
+                "99.0" : 0.010690806225318204,
+                "99.9" : 0.010690806225318204,
+                "99.99" : 0.010690806225318204,
+                "99.999" : 0.010690806225318204,
+                "99.9999" : 0.010690806225318204,
+                "100.0" : 0.010690806225318204
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010684829996559586,
+                    0.010690806225318204,
+                    0.010688657695538877
+                ],
+                [
+                    0.009862133500196251,
+                    0.009871462090641311,
+                    0.009870999170860074
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.024319062608304,
+            "scoreError" : 0.18034727495172603,
+            "scoreConfidence" : [
+                2.843971787656578,
+                3.20466633756003
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.965217552459988,
+                "50.0" : 3.0233774266960323,
+                "90.0" : 3.0875273197530864,
+                "95.0" : 3.0875273197530864,
+                "99.0" : 3.0875273197530864,
+                "99.9" : 3.0875273197530864,
+                "99.99" : 3.0875273197530864,
+                "99.999" : 3.0875273197530864,
+                "99.9999" : 3.0875273197530864,
+                "100.0" : 3.0875273197530864
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9663960331950205,
+                    2.9653501558980437,
+                    2.965217552459988
+                ],
+                [
+                    3.081064494146642,
+                    3.0875273197530864,
+                    3.0803588201970444
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7763128345578507,
+            "scoreError" : 0.01059983653719231,
+            "scoreConfidence" : [
+                2.7657129980206583,
+                2.786912671095043
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7712507816569687,
+                "50.0" : 2.7765213734036642,
+                "90.0" : 2.7804090044481513,
+                "95.0" : 2.7804090044481513,
+                "99.0" : 2.7804090044481513,
+                "99.9" : 2.7804090044481513,
+                "99.99" : 2.7804090044481513,
+                "99.999" : 2.7804090044481513,
+                "99.9999" : 2.7804090044481513,
+                "100.0" : 2.7804090044481513
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7803766285793716,
+                    2.7712507816569687,
+                    2.7727978458552816
+                ],
+                [
+                    2.7804090044481513,
+                    2.7763181338145473,
+                    2.7767246129927816
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17967542806659453,
+            "scoreError" : 0.017965225147154065,
+            "scoreConfidence" : [
+                0.16171020291944047,
+                0.1976406532137486
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1731583588273999,
+                "50.0" : 0.18027557999009722,
+                "90.0" : 0.18559000835142808,
+                "95.0" : 0.18559000835142808,
+                "99.0" : 0.18559000835142808,
+                "99.9" : 0.18559000835142808,
+                "99.99" : 0.18559000835142808,
+                "99.999" : 0.18559000835142808,
+                "99.9999" : 0.18559000835142808,
+                "100.0" : 0.18559000835142808
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17520922223000912,
+                    0.17323114117932373,
+                    0.1731583588273999
+                ],
+                [
+                    0.18534193775018531,
+                    0.18552190006122107,
+                    0.18559000835142808
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3261386397074354,
+            "scoreError" : 0.009652849850573625,
+            "scoreConfidence" : [
+                0.31648578985686177,
+                0.335791489558009
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3228050260499048,
+                "50.0" : 0.32625274389908343,
+                "90.0" : 0.3294521786255518,
+                "95.0" : 0.3294521786255518,
+                "99.0" : 0.3294521786255518,
+                "99.9" : 0.3294521786255518,
+                "99.99" : 0.3294521786255518,
+                "99.999" : 0.3294521786255518,
+                "99.9999" : 0.3294521786255518,
+                "100.0" : 0.3294521786255518
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.32334495466890845,
+                    0.32285680444889264,
+                    0.3228050260499048
+                ],
+                [
+                    0.3291605331292584,
+                    0.32921234132209637,
+                    0.3294521786255518
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14475067293380292,
+            "scoreError" : 0.0060697199648937225,
+            "scoreConfidence" : [
+                0.1386809529689092,
+                0.15082039289869664
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1427669940182166,
+                "50.0" : 0.14453484972114128,
+                "90.0" : 0.147077040224729,
+                "95.0" : 0.147077040224729,
+                "99.0" : 0.147077040224729,
+                "99.9" : 0.147077040224729,
+                "99.99" : 0.147077040224729,
+                "99.999" : 0.147077040224729,
+                "99.9999" : 0.147077040224729,
+                "100.0" : 0.147077040224729
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1427669940182166,
+                    0.1428323163938641,
+                    0.14277223018717075
+                ],
+                [
+                    0.14681807373041858,
+                    0.147077040224729,
+                    0.14623738304841846
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3971675430454518,
+            "scoreError" : 0.011313062426821138,
+            "scoreConfidence" : [
+                0.3858544806186307,
+                0.40848060547227294
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39335530389804507,
+                "50.0" : 0.39710330190892673,
+                "90.0" : 0.4011032214824322,
+                "95.0" : 0.4011032214824322,
+                "99.0" : 0.4011032214824322,
+                "99.9" : 0.4011032214824322,
+                "99.99" : 0.4011032214824322,
+                "99.999" : 0.4011032214824322,
+                "99.9999" : 0.4011032214824322,
+                "100.0" : 0.4011032214824322
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3935221592948213,
+                    0.39335530389804507,
+                    0.39358660201511336
+                ],
+                [
+                    0.40081796977955914,
+                    0.4011032214824322,
+                    0.40062000180274016
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1597742229980363,
+            "scoreError" : 0.0035910472131038813,
+            "scoreConfidence" : [
+                0.15618317578493243,
+                0.1633652702111402
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15802010498704253,
+                "50.0" : 0.16002098453707397,
+                "90.0" : 0.16135570681059103,
+                "95.0" : 0.16135570681059103,
+                "99.0" : 0.16135570681059103,
+                "99.9" : 0.16135570681059103,
+                "99.99" : 0.16135570681059103,
+                "99.999" : 0.16135570681059103,
+                "99.9999" : 0.16135570681059103,
+                "100.0" : 0.16135570681059103
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16066298136366558,
+                    0.15966972513611472,
+                    0.16037224393803323
+                ],
+                [
+                    0.16135570681059103,
+                    0.15856457575277086,
+                    0.15802010498704253
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04660365569987746,
+            "scoreError" : 0.0010816334746938485,
+            "scoreConfidence" : [
+                0.04552202222518362,
+                0.04768528917457131
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.046246069700977624,
+                "50.0" : 0.04659359950144497,
+                "90.0" : 0.04697018622477737,
+                "95.0" : 0.04697018622477737,
+                "99.0" : 0.04697018622477737,
+                "99.9" : 0.04697018622477737,
+                "99.99" : 0.04697018622477737,
+                "99.999" : 0.04697018622477737,
+                "99.9999" : 0.04697018622477737,
+                "100.0" : 0.04697018622477737
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.046246069700977624,
+                    0.04625647742022027,
+                    0.04625278238346762
+                ],
+                [
+                    0.04696569688715222,
+                    0.046930721582669664,
+                    0.04697018622477737
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8687179.998988735,
+            "scoreError" : 343146.2141800586,
+            "scoreConfidence" : [
+                8344033.784808676,
+                9030326.213168792
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8571637.398457583,
+                "50.0" : 8682544.172446717,
+                "90.0" : 8809463.842429578,
+                "95.0" : 8809463.842429578,
+                "99.0" : 8809463.842429578,
+                "99.9" : 8809463.842429578,
+                "99.99" : 8809463.842429578,
+                "99.999" : 8809463.842429578,
+                "99.9999" : 8809463.842429578,
+                "100.0" : 8809463.842429578
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8578551.969125215,
+                    8576881.790737564,
+                    8571637.398457583
+                ],
+                [
+                    8809463.842429578,
+                    8800008.617414247,
+                    8786536.375768218
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2025-12-07T04-33-42Z-021fe1b5d2394c979cbb4e7b38839753b99bfffd-jdk17.json
+++ b/performance-results/2025-12-07T04-33-42Z-021fe1b5d2394c979cbb4e7b38839753b99bfffd-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.343447069452365,
+            "scoreError" : 0.06092346200570166,
+            "scoreConfidence" : [
+                3.2825236074466635,
+                3.4043705314580666
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.331601431032405,
+                "50.0" : 3.343931442237619,
+                "90.0" : 3.354323962301818,
+                "95.0" : 3.354323962301818,
+                "99.0" : 3.354323962301818,
+                "99.9" : 3.354323962301818,
+                "99.99" : 3.354323962301818,
+                "99.999" : 3.354323962301818,
+                "99.9999" : 3.354323962301818,
+                "100.0" : 3.354323962301818
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.341986596045283,
+                    3.354323962301818
+                ],
+                [
+                    3.331601431032405,
+                    3.345876288429955
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6853347323688581,
+            "scoreError" : 0.0561841138997306,
+            "scoreConfidence" : [
+                1.6291506184691276,
+                1.7415188462685887
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6754575521295139,
+                "50.0" : 1.6859473128949531,
+                "90.0" : 1.6939867515560125,
+                "95.0" : 1.6939867515560125,
+                "99.0" : 1.6939867515560125,
+                "99.9" : 1.6939867515560125,
+                "99.99" : 1.6939867515560125,
+                "99.999" : 1.6939867515560125,
+                "99.9999" : 1.6939867515560125,
+                "100.0" : 1.6939867515560125
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6754575521295139,
+                    1.6807695159220464
+                ],
+                [
+                    1.6911251098678597,
+                    1.6939867515560125
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8502688859332078,
+            "scoreError" : 0.029614365873157092,
+            "scoreConfidence" : [
+                0.8206545200600507,
+                0.879883251806365
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.845662007814627,
+                "50.0" : 0.8501548226680501,
+                "90.0" : 0.8551038905821041,
+                "95.0" : 0.8551038905821041,
+                "99.0" : 0.8551038905821041,
+                "99.9" : 0.8551038905821041,
+                "99.99" : 0.8551038905821041,
+                "99.999" : 0.8551038905821041,
+                "99.9999" : 0.8551038905821041,
+                "100.0" : 0.8551038905821041
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8471232316840461,
+                    0.853186413652054
+                ],
+                [
+                    0.845662007814627,
+                    0.8551038905821041
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.31558781352581,
+            "scoreError" : 0.26844679230084173,
+            "scoreConfidence" : [
+                16.047141021224967,
+                16.584034605826652
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.19748622833054,
+                "50.0" : 16.315839381476884,
+                "90.0" : 16.41105412958703,
+                "95.0" : 16.41105412958703,
+                "99.0" : 16.41105412958703,
+                "99.9" : 16.41105412958703,
+                "99.99" : 16.41105412958703,
+                "99.999" : 16.41105412958703,
+                "99.9999" : 16.41105412958703,
+                "100.0" : 16.41105412958703
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.41105412958703,
+                    16.381923242150556,
+                    16.40966246029009
+                ],
+                [
+                    16.19748622833054,
+                    16.243645299993428,
+                    16.249755520803213
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2755.0252431331487,
+            "scoreError" : 322.6508454602578,
+            "scoreConfidence" : [
+                2432.374397672891,
+                3077.6760885934063
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2642.662298168731,
+                "50.0" : 2756.376005833841,
+                "90.0" : 2864.3223236741287,
+                "95.0" : 2864.3223236741287,
+                "99.0" : 2864.3223236741287,
+                "99.9" : 2864.3223236741287,
+                "99.99" : 2864.3223236741287,
+                "99.999" : 2864.3223236741287,
+                "99.9999" : 2864.3223236741287,
+                "100.0" : 2864.3223236741287
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2861.3386857795663,
+                    2864.3223236741287,
+                    2854.079088731305
+                ],
+                [
+                    2658.672922936377,
+                    2642.662298168731,
+                    2649.0761395087848
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 71726.31578006886,
+            "scoreError" : 5992.574416746729,
+            "scoreConfidence" : [
+                65733.74136332213,
+                77718.8901968156
+            ],
+            "scorePercentiles" : {
+                "0.0" : 69758.73148372382,
+                "50.0" : 71729.84969433976,
+                "90.0" : 73694.43864130904,
+                "95.0" : 73694.43864130904,
+                "99.0" : 73694.43864130904,
+                "99.9" : 73694.43864130904,
+                "99.99" : 73694.43864130904,
+                "99.999" : 73694.43864130904,
+                "99.9999" : 73694.43864130904,
+                "100.0" : 73694.43864130904
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73694.43864130904,
+                    73664.19213303048,
+                    73672.60781832361
+                ],
+                [
+                    69772.41734837725,
+                    69795.50725564903,
+                    69758.73148372382
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 357.90151266893486,
+            "scoreError" : 11.842496367599374,
+            "scoreConfidence" : [
+                346.0590163013355,
+                369.74400903653424
+            ],
+            "scorePercentiles" : {
+                "0.0" : 353.6744233267283,
+                "50.0" : 357.78390686232615,
+                "90.0" : 362.35145236982237,
+                "95.0" : 362.35145236982237,
+                "99.0" : 362.35145236982237,
+                "99.9" : 362.35145236982237,
+                "99.99" : 362.35145236982237,
+                "99.999" : 362.35145236982237,
+                "99.9999" : 362.35145236982237,
+                "100.0" : 362.35145236982237
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    353.6744233267283,
+                    354.21039642322694,
+                    354.3099384882006
+                ],
+                [
+                    361.25787523645175,
+                    361.604990169179,
+                    362.35145236982237
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 118.48494412643443,
+            "scoreError" : 0.936797624978343,
+            "scoreConfidence" : [
+                117.54814650145609,
+                119.42174175141277
+            ],
+            "scorePercentiles" : {
+                "0.0" : 118.05197358848125,
+                "50.0" : 118.44976654869323,
+                "90.0" : 118.95531073801111,
+                "95.0" : 118.95531073801111,
+                "99.0" : 118.95531073801111,
+                "99.9" : 118.95531073801111,
+                "99.99" : 118.95531073801111,
+                "99.999" : 118.95531073801111,
+                "99.9999" : 118.95531073801111,
+                "100.0" : 118.95531073801111
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    118.71820175811388,
+                    118.6114847680152,
+                    118.95531073801111
+                ],
+                [
+                    118.05197358848125,
+                    118.28804832937126,
+                    118.28464557661388
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06146167027513358,
+            "scoreError" : 0.0016513935993728115,
+            "scoreConfidence" : [
+                0.05981027667576077,
+                0.0631130638745064
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06074278380134968,
+                "50.0" : 0.061497944569578855,
+                "90.0" : 0.062077265239738784,
+                "95.0" : 0.062077265239738784,
+                "99.0" : 0.062077265239738784,
+                "99.9" : 0.062077265239738784,
+                "99.99" : 0.062077265239738784,
+                "99.999" : 0.062077265239738784,
+                "99.9999" : 0.062077265239738784,
+                "100.0" : 0.062077265239738784
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06196536780825738,
+                    0.06192117564304202,
+                    0.062077265239738784
+                ],
+                [
+                    0.06074278380134968,
+                    0.0610747134961157,
+                    0.0609887156622979
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.616458416455701E-4,
+            "scoreError" : 2.356572906880869E-5,
+            "scoreConfidence" : [
+                3.380801125767614E-4,
+                3.852115707143788E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.53147746945956E-4,
+                "50.0" : 3.619182225914842E-4,
+                "90.0" : 3.698886471941033E-4,
+                "95.0" : 3.698886471941033E-4,
+                "99.0" : 3.698886471941033E-4,
+                "99.9" : 3.698886471941033E-4,
+                "99.99" : 3.698886471941033E-4,
+                "99.999" : 3.698886471941033E-4,
+                "99.9999" : 3.698886471941033E-4,
+                "100.0" : 3.698886471941033E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.539998499077694E-4,
+                    3.53147746945956E-4,
+                    3.5483913318579054E-4
+                ],
+                [
+                    3.6900236064262346E-4,
+                    3.698886471941033E-4,
+                    3.6899731199717796E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2734075779303256,
+            "scoreError" : 0.054788603953688626,
+            "scoreConfidence" : [
+                2.218618973976637,
+                2.3281961818840142
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2182404120647594,
+                "50.0" : 2.272299468951842,
+                "90.0" : 2.32589565721898,
+                "95.0" : 2.327115171009772,
+                "99.0" : 2.327115171009772,
+                "99.9" : 2.327115171009772,
+                "99.99" : 2.327115171009772,
+                "99.999" : 2.327115171009772,
+                "99.9999" : 2.327115171009772,
+                "100.0" : 2.327115171009772
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.327115171009772,
+                    2.30022876149954,
+                    2.314920033101852,
+                    2.267780517006803,
+                    2.2672647751076855
+                ],
+                [
+                    2.2866030301783264,
+                    2.2551964608793686,
+                    2.2768184208968814,
+                    2.2182404120647594,
+                    2.2199081975582686
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013829955654287388,
+            "scoreError" : 6.385405779203711E-4,
+            "scoreConfidence" : [
+                0.013191415076367017,
+                0.014468496232207759
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013618252463847456,
+                "50.0" : 0.013828495055354313,
+                "90.0" : 0.01404654468710319,
+                "95.0" : 0.01404654468710319,
+                "99.0" : 0.01404654468710319,
+                "99.9" : 0.01404654468710319,
+                "99.99" : 0.01404654468710319,
+                "99.999" : 0.01404654468710319,
+                "99.9999" : 0.01404654468710319,
+                "100.0" : 0.01404654468710319
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013618252463847456,
+                    0.01362220064840419,
+                    0.013625993877987599
+                ],
+                [
+                    0.014030996232721027,
+                    0.01404654468710319,
+                    0.014035746015660856
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0500997259157596,
+            "scoreError" : 0.146918640379347,
+            "scoreConfidence" : [
+                0.9031810855364126,
+                1.1970183662951066
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0009190832749475,
+                "50.0" : 1.0490372158037702,
+                "90.0" : 1.1004937705513371,
+                "95.0" : 1.1004937705513371,
+                "99.0" : 1.1004937705513371,
+                "99.9" : 1.1004937705513371,
+                "99.99" : 1.1004937705513371,
+                "99.999" : 1.1004937705513371,
+                "99.9999" : 1.1004937705513371,
+                "100.0" : 1.1004937705513371
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0035539026593077,
+                    1.0009190832749475,
+                    1.0024593206374661
+                ],
+                [
+                    1.098651749423267,
+                    1.1004937705513371,
+                    1.0945205289482325
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010400483350033194,
+            "scoreError" : 3.7149520824929797E-4,
+            "scoreConfidence" : [
+                0.010028988141783896,
+                0.010771978558282491
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010267689424757226,
+                "50.0" : 0.010399828778731218,
+                "90.0" : 0.010537247835185377,
+                "95.0" : 0.010537247835185377,
+                "99.0" : 0.010537247835185377,
+                "99.9" : 0.010537247835185377,
+                "99.99" : 0.010537247835185377,
+                "99.999" : 0.010537247835185377,
+                "99.9999" : 0.010537247835185377,
+                "100.0" : 0.010537247835185377
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010509763114252745,
+                    0.010537247835185377,
+                    0.010515854947800557
+                ],
+                [
+                    0.010267689424757226,
+                    0.010289894443209694,
+                    0.010282450334993563
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0372360153641718,
+            "scoreError" : 0.1338255271991154,
+            "scoreConfidence" : [
+                2.9034104881650564,
+                3.171061542563287
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9837477488066826,
+                "50.0" : 3.0388320141445466,
+                "90.0" : 3.091489216934487,
+                "95.0" : 3.091489216934487,
+                "99.0" : 3.091489216934487,
+                "99.9" : 3.091489216934487,
+                "99.99" : 3.091489216934487,
+                "99.999" : 3.091489216934487,
+                "99.9999" : 3.091489216934487,
+                "100.0" : 3.091489216934487
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9934873369239976,
+                    3.006576626201923,
+                    2.9837477488066826
+                ],
+                [
+                    3.07108740208717,
+                    3.0770277612307693,
+                    3.091489216934487
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.796050622002556,
+            "scoreError" : 0.07499372382945846,
+            "scoreConfidence" : [
+                2.7210568981730976,
+                2.871044345832014
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.765124505114736,
+                "50.0" : 2.79810578553988,
+                "90.0" : 2.824421937305846,
+                "95.0" : 2.824421937305846,
+                "99.0" : 2.824421937305846,
+                "99.9" : 2.824421937305846,
+                "99.99" : 2.824421937305846,
+                "99.999" : 2.824421937305846,
+                "99.9999" : 2.824421937305846,
+                "100.0" : 2.824421937305846
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7721852879711752,
+                    2.7788836054459574,
+                    2.765124505114736
+                ],
+                [
+                    2.824421937305846,
+                    2.818360430543815,
+                    2.817327965633803
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18396019856783727,
+            "scoreError" : 0.00542902826453564,
+            "scoreConfidence" : [
+                0.17853117030330162,
+                0.18938922683237291
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.18037352113920854,
+                "50.0" : 0.18434963179793656,
+                "90.0" : 0.1856675214533707,
+                "95.0" : 0.1856675214533707,
+                "99.0" : 0.1856675214533707,
+                "99.9" : 0.1856675214533707,
+                "99.99" : 0.1856675214533707,
+                "99.999" : 0.1856675214533707,
+                "99.9999" : 0.1856675214533707,
+                "100.0" : 0.1856675214533707
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18366658018660006,
+                    0.1837888020289642,
+                    0.18037352113920854
+                ],
+                [
+                    0.1853543050319711,
+                    0.1856675214533707,
+                    0.1849104615669089
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32992880897866445,
+            "scoreError" : 0.008959195295402763,
+            "scoreConfidence" : [
+                0.32096961368326166,
+                0.33888800427406723
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3269075022065313,
+                "50.0" : 0.32972431183157563,
+                "90.0" : 0.33330294987335024,
+                "95.0" : 0.33330294987335024,
+                "99.0" : 0.33330294987335024,
+                "99.9" : 0.33330294987335024,
+                "99.99" : 0.33330294987335024,
+                "99.999" : 0.33330294987335024,
+                "99.9999" : 0.33330294987335024,
+                "100.0" : 0.33330294987335024
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.33330294987335024,
+                    0.3329647497835786,
+                    0.3322087907115806
+                ],
+                [
+                    0.32723983295157066,
+                    0.3269490283453755,
+                    0.3269075022065313
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14627910029752342,
+            "scoreError" : 9.867040015691358E-4,
+            "scoreConfidence" : [
+                0.14529239629595428,
+                0.14726580429909256
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14591907276892546,
+                "50.0" : 0.1461263604069601,
+                "90.0" : 0.14676580964820876,
+                "95.0" : 0.14676580964820876,
+                "99.0" : 0.14676580964820876,
+                "99.9" : 0.14676580964820876,
+                "99.99" : 0.14676580964820876,
+                "99.999" : 0.14676580964820876,
+                "99.9999" : 0.14676580964820876,
+                "100.0" : 0.14676580964820876
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14667506273192626,
+                    0.14609517899196495,
+                    0.14676580964820876
+                ],
+                [
+                    0.1460619358221599,
+                    0.14615754182195526,
+                    0.14591907276892546
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40437887751689344,
+            "scoreError" : 0.007991457358017144,
+            "scoreConfidence" : [
+                0.3963874201588763,
+                0.4123703348749106
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39974111020506053,
+                "50.0" : 0.4053096648943967,
+                "90.0" : 0.4079793602725196,
+                "95.0" : 0.4079793602725196,
+                "99.0" : 0.4079793602725196,
+                "99.9" : 0.4079793602725196,
+                "99.99" : 0.4079793602725196,
+                "99.999" : 0.4079793602725196,
+                "99.9999" : 0.4079793602725196,
+                "100.0" : 0.4079793602725196
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4053913251175612,
+                    0.40535397365327713,
+                    0.4052653561355163
+                ],
+                [
+                    0.4079793602725196,
+                    0.4025421397174254,
+                    0.39974111020506053
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1563823001098737,
+            "scoreError" : 0.001503732858499029,
+            "scoreConfidence" : [
+                0.15487856725137467,
+                0.15788603296837272
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1554952094787909,
+                "50.0" : 0.15644433943080827,
+                "90.0" : 0.15690744545212057,
+                "95.0" : 0.15690744545212057,
+                "99.0" : 0.15690744545212057,
+                "99.9" : 0.15690744545212057,
+                "99.99" : 0.15690744545212057,
+                "99.999" : 0.15690744545212057,
+                "99.9999" : 0.15690744545212057,
+                "100.0" : 0.15690744545212057
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1561489476133223,
+                    0.1554952094787909,
+                    0.1562311601649768
+                ],
+                [
+                    0.1568535192533919,
+                    0.15665751869663977,
+                    0.15690744545212057
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04818898915157613,
+            "scoreError" : 0.002020789338879991,
+            "scoreConfidence" : [
+                0.04616819981269614,
+                0.05020977849045612
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04711052586775458,
+                "50.0" : 0.04829048691309812,
+                "90.0" : 0.048989568202304434,
+                "95.0" : 0.048989568202304434,
+                "99.0" : 0.048989568202304434,
+                "99.9" : 0.048989568202304434,
+                "99.99" : 0.048989568202304434,
+                "99.999" : 0.048989568202304434,
+                "99.9999" : 0.048989568202304434,
+                "100.0" : 0.048989568202304434
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.048989568202304434,
+                    0.04868005650209808,
+                    0.048708933586291546
+                ],
+                [
+                    0.04774393342690997,
+                    0.04790091732409816,
+                    0.04711052586775458
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8703699.500604587,
+            "scoreError" : 197609.44635938286,
+            "scoreConfidence" : [
+                8506090.054245204,
+                8901308.94696397
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8633385.87230371,
+                "50.0" : 8690496.411112621,
+                "90.0" : 8819954.679012345,
+                "95.0" : 8819954.679012345,
+                "99.0" : 8819954.679012345,
+                "99.9" : 8819954.679012345,
+                "99.99" : 8819954.679012345,
+                "99.999" : 8819954.679012345,
+                "99.9999" : 8819954.679012345,
+                "100.0" : 8819954.679012345
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8819954.679012345,
+                    8698293.60173913,
+                    8682699.220486112
+                ],
+                [
+                    8747361.117132867,
+                    8633385.87230371,
+                    8640502.512953367
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-07T23-06-39Z-21b97435dcca306c98b95c491e075e7fff0663d8-jdk17.json
+++ b/performance-results/2026-01-07T23-06-39Z-21b97435dcca306c98b95c491e075e7fff0663d8-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3582732013964547,
+            "scoreError" : 0.04772383878202567,
+            "scoreConfidence" : [
+                3.310549362614429,
+                3.4059970401784803
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3498961569188004,
+                "50.0" : 3.3577635548694684,
+                "90.0" : 3.3676695389280797,
+                "95.0" : 3.3676695389280797,
+                "99.0" : 3.3676695389280797,
+                "99.9" : 3.3676695389280797,
+                "99.99" : 3.3676695389280797,
+                "99.999" : 3.3676695389280797,
+                "99.9999" : 3.3676695389280797,
+                "100.0" : 3.3676695389280797
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3498961569188004,
+                    3.3592872352555165
+                ],
+                [
+                    3.3562398744834203,
+                    3.3676695389280797
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6899587450393958,
+            "scoreError" : 0.027226798755499944,
+            "scoreConfidence" : [
+                1.6627319462838959,
+                1.7171855437948957
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6841079046427267,
+                "50.0" : 1.6912529350930718,
+                "90.0" : 1.6932212053287121,
+                "95.0" : 1.6932212053287121,
+                "99.0" : 1.6932212053287121,
+                "99.9" : 1.6932212053287121,
+                "99.99" : 1.6932212053287121,
+                "99.999" : 1.6932212053287121,
+                "99.9999" : 1.6932212053287121,
+                "100.0" : 1.6932212053287121
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6928390951047914,
+                    1.6896667750813523
+                ],
+                [
+                    1.6841079046427267,
+                    1.6932212053287121
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8503330165693561,
+            "scoreError" : 0.020543980300046533,
+            "scoreConfidence" : [
+                0.8297890362693096,
+                0.8708769968694027
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8474818275926553,
+                "50.0" : 0.8494976292915768,
+                "90.0" : 0.8548549801016156,
+                "95.0" : 0.8548549801016156,
+                "99.0" : 0.8548549801016156,
+                "99.9" : 0.8548549801016156,
+                "99.99" : 0.8548549801016156,
+                "99.999" : 0.8548549801016156,
+                "99.9999" : 0.8548549801016156,
+                "100.0" : 0.8548549801016156
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8490799980101792,
+                    0.8548549801016156
+                ],
+                [
+                    0.8474818275926553,
+                    0.8499152605729743
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.32514331764629,
+            "scoreError" : 0.16438807258475915,
+            "scoreConfidence" : [
+                16.16075524506153,
+                16.48953139023105
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.265882858749396,
+                "50.0" : 16.324318407741377,
+                "90.0" : 16.385562456862505,
+                "95.0" : 16.385562456862505,
+                "99.0" : 16.385562456862505,
+                "99.9" : 16.385562456862505,
+                "99.99" : 16.385562456862505,
+                "99.999" : 16.385562456862505,
+                "99.9999" : 16.385562456862505,
+                "100.0" : 16.385562456862505
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.385562456862505,
+                    16.379424381787985,
+                    16.370032115883447
+                ],
+                [
+                    16.265882858749396,
+                    16.278604699599306,
+                    16.27135339299511
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2723.6659587921654,
+            "scoreError" : 99.41828151971946,
+            "scoreConfidence" : [
+                2624.247677272446,
+                2823.084240311885
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2688.145355355175,
+                "50.0" : 2724.072809832649,
+                "90.0" : 2757.698718721755,
+                "95.0" : 2757.698718721755,
+                "99.0" : 2757.698718721755,
+                "99.9" : 2757.698718721755,
+                "99.99" : 2757.698718721755,
+                "99.999" : 2757.698718721755,
+                "99.9999" : 2757.698718721755,
+                "100.0" : 2757.698718721755
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2692.0438091675796,
+                    2693.8943782464166,
+                    2688.145355355175
+                ],
+                [
+                    2757.698718721755,
+                    2754.2512414188814,
+                    2755.962249843187
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74155.56468666073,
+            "scoreError" : 807.3939110817731,
+            "scoreConfidence" : [
+                73348.17077557895,
+                74962.9585977425
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73858.5233273762,
+                "50.0" : 74151.71474878998,
+                "90.0" : 74435.58580769981,
+                "95.0" : 74435.58580769981,
+                "99.0" : 74435.58580769981,
+                "99.9" : 74435.58580769981,
+                "99.99" : 74435.58580769981,
+                "99.999" : 74435.58580769981,
+                "99.9999" : 74435.58580769981,
+                "100.0" : 74435.58580769981
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74380.23795856422,
+                    74435.39075636341,
+                    74435.58580769981
+                ],
+                [
+                    73900.45873094493,
+                    73923.19153901574,
+                    73858.5233273762
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 358.0040745872121,
+            "scoreError" : 4.963879694267702,
+            "scoreConfidence" : [
+                353.0401948929444,
+                362.96795428147976
+            ],
+            "scorePercentiles" : {
+                "0.0" : 355.6172429955987,
+                "50.0" : 357.8340547761511,
+                "90.0" : 360.0788953078434,
+                "95.0" : 360.0788953078434,
+                "99.0" : 360.0788953078434,
+                "99.9" : 360.0788953078434,
+                "99.99" : 360.0788953078434,
+                "99.999" : 360.0788953078434,
+                "99.9999" : 360.0788953078434,
+                "100.0" : 360.0788953078434
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    355.6172429955987,
+                    357.02867216922243,
+                    356.8986783567775
+                ],
+                [
+                    358.63943738307984,
+                    359.76152131075054,
+                    360.0788953078434
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 117.21761504368568,
+            "scoreError" : 3.8893811549822166,
+            "scoreConfidence" : [
+                113.32823388870347,
+                121.1069961986679
+            ],
+            "scorePercentiles" : {
+                "0.0" : 115.86266285137683,
+                "50.0" : 117.22970255224668,
+                "90.0" : 118.53894730939925,
+                "95.0" : 118.53894730939925,
+                "99.0" : 118.53894730939925,
+                "99.9" : 118.53894730939925,
+                "99.99" : 118.53894730939925,
+                "99.999" : 118.53894730939925,
+                "99.9999" : 118.53894730939925,
+                "100.0" : 118.53894730939925
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    115.9272572342889,
+                    115.86266285137683,
+                    116.07166537433613
+                ],
+                [
+                    118.51741776255582,
+                    118.53894730939925,
+                    118.38773973015722
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.0612040217723219,
+            "scoreError" : 2.543182214418006E-4,
+            "scoreConfidence" : [
+                0.0609497035508801,
+                0.0614583399937637
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061131012103725256,
+                "50.0" : 0.06117441552128113,
+                "90.0" : 0.061380429011606855,
+                "95.0" : 0.061380429011606855,
+                "99.0" : 0.061380429011606855,
+                "99.9" : 0.061380429011606855,
+                "99.99" : 0.061380429011606855,
+                "99.999" : 0.061380429011606855,
+                "99.9999" : 0.061380429011606855,
+                "100.0" : 0.061380429011606855
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.061209915293037494,
+                    0.061131012103725256,
+                    0.06116063316330899
+                ],
+                [
+                    0.061188197879253274,
+                    0.06115394318299954,
+                    0.061380429011606855
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.598055009672496E-4,
+            "scoreError" : 3.095440104884878E-5,
+            "scoreConfidence" : [
+                3.288510999184008E-4,
+                3.907599020160984E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.496757994471273E-4,
+                "50.0" : 3.597533722307806E-4,
+                "90.0" : 3.700750083136523E-4,
+                "95.0" : 3.700750083136523E-4,
+                "99.0" : 3.700750083136523E-4,
+                "99.9" : 3.700750083136523E-4,
+                "99.99" : 3.700750083136523E-4,
+                "99.999" : 3.700750083136523E-4,
+                "99.9999" : 3.700750083136523E-4,
+                "100.0" : 3.700750083136523E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.6970327970372517E-4,
+                    3.700750083136523E-4,
+                    3.6986682849283055E-4
+                ],
+                [
+                    3.4980346475783593E-4,
+                    3.4970862508832643E-4,
+                    3.496757994471273E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.254183771417712,
+            "scoreError" : 0.05767229650709141,
+            "scoreConfidence" : [
+                2.1965114749106207,
+                2.3118560679248037
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.207429116971971,
+                "50.0" : 2.2473282830164316,
+                "90.0" : 2.3129836445590897,
+                "95.0" : 2.314054931975937,
+                "99.0" : 2.314054931975937,
+                "99.9" : 2.314054931975937,
+                "99.99" : 2.314054931975937,
+                "99.999" : 2.314054931975937,
+                "99.9999" : 2.314054931975937,
+                "100.0" : 2.314054931975937
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.303342057807462,
+                    2.261452458842153,
+                    2.2738538219645292,
+                    2.227591734298441,
+                    2.226968996437319
+                ],
+                [
+                    2.2821673489274303,
+                    2.314054931975937,
+                    2.2332041071907103,
+                    2.207429116971971,
+                    2.2117731397611675
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013512398148356064,
+            "scoreError" : 3.855691035770707E-4,
+            "scoreConfidence" : [
+                0.013126829044778993,
+                0.013897967251933135
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013384518570122642,
+                "50.0" : 0.01351426765692234,
+                "90.0" : 0.013639825966572008,
+                "95.0" : 0.013639825966572008,
+                "99.0" : 0.013639825966572008,
+                "99.9" : 0.013639825966572008,
+                "99.99" : 0.013639825966572008,
+                "99.999" : 0.013639825966572008,
+                "99.9999" : 0.013639825966572008,
+                "100.0" : 0.013639825966572008
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013384560805891203,
+                    0.013384518570122642,
+                    0.013391640391614909
+                ],
+                [
+                    0.013636948233705842,
+                    0.013639825966572008,
+                    0.013636894922229768
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.9920386185515553,
+            "scoreError" : 0.06131049205864827,
+            "scoreConfidence" : [
+                0.930728126492907,
+                1.0533491106102035
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9717108149047804,
+                "50.0" : 0.992030493104312,
+                "90.0" : 1.0127445803544304,
+                "95.0" : 1.0127445803544304,
+                "99.0" : 1.0127445803544304,
+                "99.9" : 1.0127445803544304,
+                "99.99" : 1.0127445803544304,
+                "99.999" : 1.0127445803544304,
+                "99.9999" : 1.0127445803544304,
+                "100.0" : 1.0127445803544304
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0118690812506324,
+                    1.0113594560072816,
+                    1.0127445803544304
+                ],
+                [
+                    0.9718462485908649,
+                    0.9717108149047804,
+                    0.9727015302013423
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010698795362015463,
+            "scoreError" : 3.4636597923331727E-4,
+            "scoreConfidence" : [
+                0.010352429382782146,
+                0.01104516134124878
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010580504696569251,
+                "50.0" : 0.010696760952328944,
+                "90.0" : 0.010820650094894729,
+                "95.0" : 0.010820650094894729,
+                "99.0" : 0.010820650094894729,
+                "99.9" : 0.010820650094894729,
+                "99.99" : 0.010820650094894729,
+                "99.999" : 0.010820650094894729,
+                "99.9999" : 0.010820650094894729,
+                "100.0" : 0.010820650094894729
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010586955690024963,
+                    0.010591158208784505,
+                    0.010580504696569251
+                ],
+                [
+                    0.010802363695873382,
+                    0.010811139785945946,
+                    0.010820650094894729
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.966587972974056,
+            "scoreError" : 0.24875373115111482,
+            "scoreConfidence" : [
+                2.717834241822941,
+                3.215341704125171
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8831711729106626,
+                "50.0" : 2.9645276293683356,
+                "90.0" : 3.055611738546121,
+                "95.0" : 3.055611738546121,
+                "99.0" : 3.055611738546121,
+                "99.9" : 3.055611738546121,
+                "99.99" : 3.055611738546121,
+                "99.999" : 3.055611738546121,
+                "99.9999" : 3.055611738546121,
+                "100.0" : 3.055611738546121
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8831711729106626,
+                    2.8861018430467396,
+                    2.887929820438799
+                ],
+                [
+                    3.0455878246041412,
+                    3.055611738546121,
+                    3.0411254382978723
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.79358093513712,
+            "scoreError" : 0.030684911032340938,
+            "scoreConfidence" : [
+                2.762896024104779,
+                2.824265846169461
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7821016920723225,
+                "50.0" : 2.7932019597564173,
+                "90.0" : 2.8062629834455666,
+                "95.0" : 2.8062629834455666,
+                "99.0" : 2.8062629834455666,
+                "99.9" : 2.8062629834455666,
+                "99.99" : 2.8062629834455666,
+                "99.999" : 2.8062629834455666,
+                "99.9999" : 2.8062629834455666,
+                "100.0" : 2.8062629834455666
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8015713795518207,
+                    2.802458161950126,
+                    2.8062629834455666
+                ],
+                [
+                    2.784258853841871,
+                    2.7848325399610134,
+                    2.7821016920723225
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17517514802864928,
+            "scoreError" : 0.007822925441848773,
+            "scoreConfidence" : [
+                0.16735222258680052,
+                0.18299807347049804
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17258622094126988,
+                "50.0" : 0.1751700422296728,
+                "90.0" : 0.17775345230096518,
+                "95.0" : 0.17775345230096518,
+                "99.0" : 0.17775345230096518,
+                "99.9" : 0.17775345230096518,
+                "99.99" : 0.17775345230096518,
+                "99.999" : 0.17775345230096518,
+                "99.9999" : 0.17775345230096518,
+                "100.0" : 0.17775345230096518
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1726374979456548,
+                    0.17266233172761491,
+                    0.17258622094126988
+                ],
+                [
+                    0.17775345230096518,
+                    0.1777336325246601,
+                    0.17767775273173073
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3251558161666765,
+            "scoreError" : 0.006455597512718479,
+            "scoreConfidence" : [
+                0.31870021865395803,
+                0.33161141367939495
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.32397813639161566,
+                "50.0" : 0.3242718313813043,
+                "90.0" : 0.3298473387096774,
+                "95.0" : 0.3298473387096774,
+                "99.0" : 0.3298473387096774,
+                "99.9" : 0.3298473387096774,
+                "99.99" : 0.3298473387096774,
+                "99.999" : 0.3298473387096774,
+                "99.9999" : 0.3298473387096774,
+                "100.0" : 0.3298473387096774
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3298473387096774,
+                    0.32424034203359053,
+                    0.324303320729018
+                ],
+                [
+                    0.3243628209269891,
+                    0.32397813639161566,
+                    0.3242029382091681
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14577972378682338,
+            "scoreError" : 0.005214141125637791,
+            "scoreConfidence" : [
+                0.1405655826611856,
+                0.15099386491246117
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14403540282878913,
+                "50.0" : 0.1457657444462922,
+                "90.0" : 0.14761502287991735,
+                "95.0" : 0.14761502287991735,
+                "99.0" : 0.14761502287991735,
+                "99.9" : 0.14761502287991735,
+                "99.99" : 0.14761502287991735,
+                "99.999" : 0.14761502287991735,
+                "99.9999" : 0.14761502287991735,
+                "100.0" : 0.14761502287991735
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14738624617175872,
+                    0.14761502287991735,
+                    0.1474247694632406
+                ],
+                [
+                    0.14407165865640892,
+                    0.14403540282878913,
+                    0.14414524272082566
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40017184876905293,
+            "scoreError" : 0.04147718156547701,
+            "scoreConfidence" : [
+                0.3586946672035759,
+                0.44164903033452996
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.38643648121956875,
+                "50.0" : 0.40023649107108467,
+                "90.0" : 0.4137701295461128,
+                "95.0" : 0.4137701295461128,
+                "99.0" : 0.4137701295461128,
+                "99.9" : 0.4137701295461128,
+                "99.99" : 0.4137701295461128,
+                "99.999" : 0.4137701295461128,
+                "99.9999" : 0.4137701295461128,
+                "100.0" : 0.4137701295461128
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.38695939654838835,
+                    0.3866157348643006,
+                    0.38643648121956875
+                ],
+                [
+                    0.4137701295461128,
+                    0.41373576484216623,
+                    0.413513585593781
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15716351813169052,
+            "scoreError" : 9.741520930124009E-4,
+            "scoreConfidence" : [
+                0.1561893660386781,
+                0.15813767022470293
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15682332236109586,
+                "50.0" : 0.15703284166361828,
+                "90.0" : 0.15769291475337455,
+                "95.0" : 0.15769291475337455,
+                "99.0" : 0.15769291475337455,
+                "99.9" : 0.15769291475337455,
+                "99.99" : 0.15769291475337455,
+                "99.999" : 0.15769291475337455,
+                "99.9999" : 0.15769291475337455,
+                "100.0" : 0.15769291475337455
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1574792258039117,
+                    0.15711730703242835,
+                    0.15769291475337455
+                ],
+                [
+                    0.15691996254452448,
+                    0.1569483762948082,
+                    0.15682332236109586
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04689786690105385,
+            "scoreError" : 8.132907948444255E-4,
+            "scoreConfidence" : [
+                0.046084576106209425,
+                0.04771115769589828
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04661839376535469,
+                "50.0" : 0.046896819667036974,
+                "90.0" : 0.0471782857264171,
+                "95.0" : 0.0471782857264171,
+                "99.0" : 0.0471782857264171,
+                "99.9" : 0.0471782857264171,
+                "99.99" : 0.0471782857264171,
+                "99.999" : 0.0471782857264171,
+                "99.9999" : 0.0471782857264171,
+                "100.0" : 0.0471782857264171
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04661839376535469,
+                    0.04664957611012889,
+                    0.04663237954077017
+                ],
+                [
+                    0.04714406322394505,
+                    0.047164503039707206,
+                    0.0471782857264171
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8577002.018841572,
+            "scoreError" : 604806.1707346861,
+            "scoreConfidence" : [
+                7972195.848106886,
+                9181808.189576259
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8379098.638190955,
+                "50.0" : 8546584.189031681,
+                "90.0" : 8844743.60300619,
+                "95.0" : 8844743.60300619,
+                "99.0" : 8844743.60300619,
+                "99.9" : 8844743.60300619,
+                "99.99" : 8844743.60300619,
+                "99.999" : 8844743.60300619,
+                "99.9999" : 8844743.60300619,
+                "100.0" : 8844743.60300619
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8844743.60300619,
+                    8759776.550788091,
+                    8704226.046127068
+                ],
+                [
+                    8379098.638190955,
+                    8388942.331936294,
+                    8385224.943000838
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-12T07-32-44Z-5a4e1ddab2b528169fdccd1cf13d29d7036a1577-jdk17.json
+++ b/performance-results/2026-01-12T07-32-44Z-5a4e1ddab2b528169fdccd1cf13d29d7036a1577-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3086680173027405,
+            "scoreError" : 0.023606403822619616,
+            "scoreConfidence" : [
+                3.2850616134801207,
+                3.3322744211253603
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.304530881158271,
+                "50.0" : 3.308620619946675,
+                "90.0" : 3.312899948159342,
+                "95.0" : 3.312899948159342,
+                "99.0" : 3.312899948159342,
+                "99.9" : 3.312899948159342,
+                "99.99" : 3.312899948159342,
+                "99.999" : 3.312899948159342,
+                "99.9999" : 3.312899948159342,
+                "100.0" : 3.312899948159342
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3070385063516876,
+                    3.304530881158271
+                ],
+                [
+                    3.310202733541662,
+                    3.312899948159342
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6660075265724135,
+            "scoreError" : 0.032670634454998106,
+            "scoreConfidence" : [
+                1.6333368921174154,
+                1.6986781610274115
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6595867347740223,
+                "50.0" : 1.6667385720532613,
+                "90.0" : 1.6709662274091097,
+                "95.0" : 1.6709662274091097,
+                "99.0" : 1.6709662274091097,
+                "99.9" : 1.6709662274091097,
+                "99.99" : 1.6709662274091097,
+                "99.999" : 1.6709662274091097,
+                "99.9999" : 1.6709662274091097,
+                "100.0" : 1.6709662274091097
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6689521343008153,
+                    1.6709662274091097
+                ],
+                [
+                    1.6595867347740223,
+                    1.664525009805707
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8364628298395623,
+            "scoreError" : 0.03119180647033938,
+            "scoreConfidence" : [
+                0.805271023369223,
+                0.8676546363099017
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8317555874036906,
+                "50.0" : 0.835445710239188,
+                "90.0" : 0.8432043114761829,
+                "95.0" : 0.8432043114761829,
+                "99.0" : 0.8432043114761829,
+                "99.9" : 0.8432043114761829,
+                "99.99" : 0.8432043114761829,
+                "99.999" : 0.8432043114761829,
+                "99.9999" : 0.8432043114761829,
+                "100.0" : 0.8432043114761829
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8357804104634531,
+                    0.8432043114761829
+                ],
+                [
+                    0.8317555874036906,
+                    0.8351110100149229
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 14.979051313052777,
+            "scoreError" : 0.35395514432213715,
+            "scoreConfidence" : [
+                14.62509616873064,
+                15.333006457374914
+            ],
+            "scorePercentiles" : {
+                "0.0" : 14.801307873103283,
+                "50.0" : 15.0149543874193,
+                "90.0" : 15.106163303037821,
+                "95.0" : 15.106163303037821,
+                "99.0" : 15.106163303037821,
+                "99.9" : 15.106163303037821,
+                "99.99" : 15.106163303037821,
+                "99.999" : 15.106163303037821,
+                "99.9999" : 15.106163303037821,
+                "100.0" : 15.106163303037821
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.106163303037821,
+                    15.082475206264784,
+                    15.054404961151086
+                ],
+                [
+                    14.975503813687514,
+                    14.85445272107216,
+                    14.801307873103283
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2362.160093325993,
+            "scoreError" : 214.33221161815197,
+            "scoreConfidence" : [
+                2147.827881707841,
+                2576.492304944145
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2281.8434614401963,
+                "50.0" : 2360.743722856699,
+                "90.0" : 2441.412675985981,
+                "95.0" : 2441.412675985981,
+                "99.0" : 2441.412675985981,
+                "99.9" : 2441.412675985981,
+                "99.99" : 2441.412675985981,
+                "99.999" : 2441.412675985981,
+                "99.9999" : 2441.412675985981,
+                "100.0" : 2441.412675985981
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2441.412675985981,
+                    2431.956399325897,
+                    2420.992992661037
+                ],
+                [
+                    2296.260577490485,
+                    2300.494453052361,
+                    2281.8434614401963
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 70965.2136140634,
+            "scoreError" : 2014.7357229406266,
+            "scoreConfidence" : [
+                68950.47789112276,
+                72979.94933700403
+            ],
+            "scorePercentiles" : {
+                "0.0" : 70231.30084035234,
+                "50.0" : 71014.60752411725,
+                "90.0" : 71641.86641531343,
+                "95.0" : 71641.86641531343,
+                "99.0" : 71641.86641531343,
+                "99.9" : 71641.86641531343,
+                "99.99" : 71641.86641531343,
+                "99.999" : 71641.86641531343,
+                "99.9999" : 71641.86641531343,
+                "100.0" : 71641.86641531343
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    71578.3793137845,
+                    71631.15181285344,
+                    71641.86641531343
+                ],
+                [
+                    70450.83573444998,
+                    70231.30084035234,
+                    70257.74756762665
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 342.39095469292323,
+            "scoreError" : 6.318828263450137,
+            "scoreConfidence" : [
+                336.0721264294731,
+                348.7097829563734
+            ],
+            "scorePercentiles" : {
+                "0.0" : 339.3301553687233,
+                "50.0" : 342.45971298838924,
+                "90.0" : 345.0199620276948,
+                "95.0" : 345.0199620276948,
+                "99.0" : 345.0199620276948,
+                "99.9" : 345.0199620276948,
+                "99.99" : 345.0199620276948,
+                "99.999" : 345.0199620276948,
+                "99.9999" : 345.0199620276948,
+                "100.0" : 345.0199620276948
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    339.3301553687233,
+                    340.48070400515803,
+                    341.9168391573386
+                ],
+                [
+                    343.0025868194399,
+                    345.0199620276948,
+                    344.5954807791844
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 106.28033207394174,
+            "scoreError" : 4.876632820828606,
+            "scoreConfidence" : [
+                101.40369925311313,
+                111.15696489477034
+            ],
+            "scorePercentiles" : {
+                "0.0" : 104.01594401873164,
+                "50.0" : 106.47776975616193,
+                "90.0" : 108.20981655379842,
+                "95.0" : 108.20981655379842,
+                "99.0" : 108.20981655379842,
+                "99.9" : 108.20981655379842,
+                "99.99" : 108.20981655379842,
+                "99.999" : 108.20981655379842,
+                "99.9999" : 108.20981655379842,
+                "100.0" : 108.20981655379842
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    107.52771938315591,
+                    107.66219507693812,
+                    108.20981655379842
+                ],
+                [
+                    104.01594401873164,
+                    104.83849728185832,
+                    105.42782012916797
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06616436677901343,
+            "scoreError" : 6.551627768227507E-4,
+            "scoreConfidence" : [
+                0.06550920400219068,
+                0.06681952955583617
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0657207738579531,
+                "50.0" : 0.06625299850984395,
+                "90.0" : 0.06633906171430846,
+                "95.0" : 0.06633906171430846,
+                "99.0" : 0.06633906171430846,
+                "99.9" : 0.06633906171430846,
+                "99.99" : 0.06633906171430846,
+                "99.999" : 0.06633906171430846,
+                "99.9999" : 0.06633906171430846,
+                "100.0" : 0.06633906171430846
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06632252783175599,
+                    0.06626860634314759,
+                    0.06623739067654033
+                ],
+                [
+                    0.0660978402503751,
+                    0.06633906171430846,
+                    0.0657207738579531
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.1428490273553536E-4,
+            "scoreError" : 2.2712914468025242E-5,
+            "scoreConfidence" : [
+                3.915719882675101E-4,
+                4.3699781720356063E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.047288636339445E-4,
+                "50.0" : 4.1537158499792016E-4,
+                "90.0" : 4.255573338716765E-4,
+                "95.0" : 4.255573338716765E-4,
+                "99.0" : 4.255573338716765E-4,
+                "99.9" : 4.255573338716765E-4,
+                "99.99" : 4.255573338716765E-4,
+                "99.999" : 4.255573338716765E-4,
+                "99.9999" : 4.255573338716765E-4,
+                "100.0" : 4.255573338716765E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    4.187317079533325E-4,
+                    4.12371460859629E-4,
+                    4.255573338716765E-4
+                ],
+                [
+                    4.183717091362113E-4,
+                    4.0594834095841845E-4,
+                    4.047288636339445E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.4437147327136723,
+            "scoreError" : 0.11831437736257013,
+            "scoreConfidence" : [
+                2.325400355351102,
+                2.5620291100762427
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.340483589515563,
+                "50.0" : 2.4228259489442134,
+                "90.0" : 2.5859016207029524,
+                "95.0" : 2.5936444668049794,
+                "99.0" : 2.5936444668049794,
+                "99.9" : 2.5936444668049794,
+                "99.99" : 2.5936444668049794,
+                "99.999" : 2.5936444668049794,
+                "99.9999" : 2.5936444668049794,
+                "100.0" : 2.5936444668049794
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.5024805108831623,
+                    2.5936444668049794,
+                    2.5162160057847083,
+                    2.4792728852255825,
+                    2.421698828087167
+                ],
+                [
+                    2.4239530698012604,
+                    2.408666768545279,
+                    2.3921241619229847,
+                    2.340483589515563,
+                    2.3586070405660378
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.01418517248523913,
+            "scoreError" : 8.6822758897249E-5,
+            "scoreConfidence" : [
+                0.01409834972634188,
+                0.014271995244136379
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01413388892061114,
+                "50.0" : 0.014187824814604798,
+                "90.0" : 0.014221915429140298,
+                "95.0" : 0.014221915429140298,
+                "99.0" : 0.014221915429140298,
+                "99.9" : 0.014221915429140298,
+                "99.99" : 0.014221915429140298,
+                "99.999" : 0.014221915429140298,
+                "99.9999" : 0.014221915429140298,
+                "100.0" : 0.014221915429140298
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01420025042245201,
+                    0.014204750658024633,
+                    0.014221915429140298
+                ],
+                [
+                    0.014174830274449103,
+                    0.014175399206757587,
+                    0.01413388892061114
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1423879639360042,
+            "scoreError" : 0.24606890297607567,
+            "scoreConfidence" : [
+                0.8963190609599285,
+                1.3884568669120798
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0610216736339522,
+                "50.0" : 1.1420129035123696,
+                "90.0" : 1.2244929777151954,
+                "95.0" : 1.2244929777151954,
+                "99.0" : 1.2244929777151954,
+                "99.9" : 1.2244929777151954,
+                "99.99" : 1.2244929777151954,
+                "99.999" : 1.2244929777151954,
+                "99.9999" : 1.2244929777151954,
+                "100.0" : 1.2244929777151954
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.2244929777151954,
+                    1.2205022237002685,
+                    1.2224488084586236
+                ],
+                [
+                    1.063523583324471,
+                    1.0610216736339522,
+                    1.062338516783514
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010996856395136227,
+            "scoreError" : 4.1380059487657153E-4,
+            "scoreConfidence" : [
+                0.010583055800259655,
+                0.011410656990012799
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010838349035418563,
+                "50.0" : 0.01099046698657177,
+                "90.0" : 0.011171801256557604,
+                "95.0" : 0.011171801256557604,
+                "99.0" : 0.011171801256557604,
+                "99.9" : 0.011171801256557604,
+                "99.99" : 0.011171801256557604,
+                "99.999" : 0.011171801256557604,
+                "99.9999" : 0.011171801256557604,
+                "100.0" : 0.011171801256557604
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010838349035418563,
+                    0.010893222912590901,
+                    0.010864363157162847
+                ],
+                [
+                    0.01108771106055264,
+                    0.01112569094853481,
+                    0.011171801256557604
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.2945091396244384,
+            "scoreError" : 0.09098883253672001,
+            "scoreConfidence" : [
+                3.2035203070877185,
+                3.385497972161158
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.257709601954397,
+                "50.0" : 3.2868262797550702,
+                "90.0" : 3.3514834128686326,
+                "95.0" : 3.3514834128686326,
+                "99.0" : 3.3514834128686326,
+                "99.9" : 3.3514834128686326,
+                "99.99" : 3.3514834128686326,
+                "99.999" : 3.3514834128686326,
+                "99.9999" : 3.3514834128686326,
+                "100.0" : 3.3514834128686326
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.306384920687376,
+                    3.3514834128686326,
+                    3.2947778932806324
+                ],
+                [
+                    3.257709601954397,
+                    3.277824342726081,
+                    3.278874666229508
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.9863464855149613,
+            "scoreError" : 0.10203235100192634,
+            "scoreConfidence" : [
+                2.8843141345130348,
+                3.088378836516888
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.946379823269514,
+                "50.0" : 2.982922012709322,
+                "90.0" : 3.0424652041375113,
+                "95.0" : 3.0424652041375113,
+                "99.0" : 3.0424652041375113,
+                "99.9" : 3.0424652041375113,
+                "99.99" : 3.0424652041375113,
+                "99.999" : 3.0424652041375113,
+                "99.9999" : 3.0424652041375113,
+                "100.0" : 3.0424652041375113
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9968687624325945,
+                    3.0424652041375113,
+                    3.0083145332330825
+                ],
+                [
+                    2.9689752629860493,
+                    2.946379823269514,
+                    2.955075327031019
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18362867231358226,
+            "scoreError" : 0.003935575950244215,
+            "scoreConfidence" : [
+                0.17969309636333805,
+                0.18756424826382648
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.18219160613237625,
+                "50.0" : 0.18362654516118215,
+                "90.0" : 0.1852239251157622,
+                "95.0" : 0.1852239251157622,
+                "99.0" : 0.1852239251157622,
+                "99.9" : 0.1852239251157622,
+                "99.99" : 0.1852239251157622,
+                "99.999" : 0.1852239251157622,
+                "99.9999" : 0.1852239251157622,
+                "100.0" : 0.1852239251157622
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18219160613237625,
+                    0.18230811568891966,
+                    0.1825936661006427
+                ],
+                [
+                    0.18465942422172163,
+                    0.18479529662207111,
+                    0.1852239251157622
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3451486265807106,
+            "scoreError" : 0.007110850390800699,
+            "scoreConfidence" : [
+                0.33803777618990993,
+                0.3522594769715113
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3426368269033098,
+                "50.0" : 0.34455726426231903,
+                "90.0" : 0.34937918460678474,
+                "95.0" : 0.34937918460678474,
+                "99.0" : 0.34937918460678474,
+                "99.9" : 0.34937918460678474,
+                "99.99" : 0.34937918460678474,
+                "99.999" : 0.34937918460678474,
+                "99.9999" : 0.34937918460678474,
+                "100.0" : 0.34937918460678474
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.34937918460678474,
+                    0.3439640152713765,
+                    0.3426368269033098
+                ],
+                [
+                    0.3466691312788158,
+                    0.34515051325326157,
+                    0.34309208817071496
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15220465984829415,
+            "scoreError" : 0.0037766679302265686,
+            "scoreConfidence" : [
+                0.14842799191806758,
+                0.15598132777852072
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15069129935355544,
+                "50.0" : 0.15206128561579757,
+                "90.0" : 0.15384715308995245,
+                "95.0" : 0.15384715308995245,
+                "99.0" : 0.15384715308995245,
+                "99.9" : 0.15384715308995245,
+                "99.99" : 0.15384715308995245,
+                "99.999" : 0.15384715308995245,
+                "99.9999" : 0.15384715308995245,
+                "100.0" : 0.15384715308995245
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15345902846532755,
+                    0.15384715308995245,
+                    0.15285621819877104
+                ],
+                [
+                    0.15126635303282407,
+                    0.15069129935355544,
+                    0.15110790694933438
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40431065655587445,
+            "scoreError" : 0.006008938526897443,
+            "scoreConfidence" : [
+                0.398301718028977,
+                0.4103195950827719
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40157838850740873,
+                "50.0" : 0.40393649031453016,
+                "90.0" : 0.4080502711359556,
+                "95.0" : 0.4080502711359556,
+                "99.0" : 0.4080502711359556,
+                "99.9" : 0.4080502711359556,
+                "99.99" : 0.4080502711359556,
+                "99.999" : 0.4080502711359556,
+                "99.9999" : 0.4080502711359556,
+                "100.0" : 0.4080502711359556
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40494303729348885,
+                    0.4080502711359556,
+                    0.40157838850740873
+                ],
+                [
+                    0.4038052757116899,
+                    0.4040677049173704,
+                    0.4034192617693332
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15897966762127647,
+            "scoreError" : 0.005986003515947302,
+            "scoreConfidence" : [
+                0.15299366410532916,
+                0.16496567113722377
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1568065934706934,
+                "50.0" : 0.15901762127479455,
+                "90.0" : 0.16115803603429382,
+                "95.0" : 0.16115803603429382,
+                "99.0" : 0.16115803603429382,
+                "99.9" : 0.16115803603429382,
+                "99.99" : 0.16115803603429382,
+                "99.999" : 0.16115803603429382,
+                "99.9999" : 0.16115803603429382,
+                "100.0" : 0.16115803603429382
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15736257426552738,
+                    0.1568065934706934,
+                    0.1569601875470869
+                ],
+                [
+                    0.16115803603429382,
+                    0.16091794612599566,
+                    0.1606726682840617
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04792783064195055,
+            "scoreError" : 0.001045098161422302,
+            "scoreConfidence" : [
+                0.04688273248052825,
+                0.04897292880337285
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04755988683803771,
+                "50.0" : 0.0479327613346681,
+                "90.0" : 0.04831010802950739,
+                "95.0" : 0.04831010802950739,
+                "99.0" : 0.04831010802950739,
+                "99.9" : 0.04831010802950739,
+                "99.99" : 0.04831010802950739,
+                "99.999" : 0.04831010802950739,
+                "99.9999" : 0.04831010802950739,
+                "100.0" : 0.04831010802950739
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04755988683803771,
+                    0.04757298300722621,
+                    0.04763469959130012
+                ],
+                [
+                    0.04823082307803608,
+                    0.04831010802950739,
+                    0.048258483307595794
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 9150075.196995642,
+            "scoreError" : 274743.9114851101,
+            "scoreConfidence" : [
+                8875331.285510533,
+                9424819.108480752
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8995557.425359713,
+                "50.0" : 9152335.566077204,
+                "90.0" : 9283544.734693877,
+                "95.0" : 9283544.734693877,
+                "99.0" : 9283544.734693877,
+                "99.9" : 9283544.734693877,
+                "99.99" : 9283544.734693877,
+                "99.999" : 9283544.734693877,
+                "99.9999" : 9283544.734693877,
+                "100.0" : 9283544.734693877
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    9142355.34369287,
+                    9162315.788461538,
+                    9103745.285714285
+                ],
+                [
+                    8995557.425359713,
+                    9212932.604051566,
+                    9283544.734693877
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-13T03-11-07Z-c4656014842ef31ddaa47121a236fc5827b9290b-jdk17.json
+++ b/performance-results/2026-01-13T03-11-07Z-c4656014842ef31ddaa47121a236fc5827b9290b-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3527065597262555,
+            "scoreError" : 0.02543418864257462,
+            "scoreConfidence" : [
+                3.327272371083681,
+                3.37814074836883
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3479770580651977,
+                "50.0" : 3.3530391950377334,
+                "90.0" : 3.356770790764358,
+                "95.0" : 3.356770790764358,
+                "99.0" : 3.356770790764358,
+                "99.9" : 3.356770790764358,
+                "99.99" : 3.356770790764358,
+                "99.999" : 3.356770790764358,
+                "99.9999" : 3.356770790764358,
+                "100.0" : 3.356770790764358
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3479770580651977,
+                    3.3549585829460056
+                ],
+                [
+                    3.3511198071294612,
+                    3.356770790764358
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6926483592774386,
+            "scoreError" : 0.05283625901171431,
+            "scoreConfidence" : [
+                1.6398121002657242,
+                1.745484618289153
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6804909750823214,
+                "50.0" : 1.6962363864486405,
+                "90.0" : 1.697629689130152,
+                "95.0" : 1.697629689130152,
+                "99.0" : 1.697629689130152,
+                "99.9" : 1.697629689130152,
+                "99.99" : 1.697629689130152,
+                "99.999" : 1.697629689130152,
+                "99.9999" : 1.697629689130152,
+                "100.0" : 1.697629689130152
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.697629689130152,
+                    1.6972853021433094
+                ],
+                [
+                    1.6804909750823214,
+                    1.6951874707539714
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8532783702739428,
+            "scoreError" : 0.02351795978407082,
+            "scoreConfidence" : [
+                0.829760410489872,
+                0.8767963300580136
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8489749090805674,
+                "50.0" : 0.8538254446019131,
+                "90.0" : 0.8564876828113778,
+                "95.0" : 0.8564876828113778,
+                "99.0" : 0.8564876828113778,
+                "99.9" : 0.8564876828113778,
+                "99.99" : 0.8564876828113778,
+                "99.999" : 0.8564876828113778,
+                "99.9999" : 0.8564876828113778,
+                "100.0" : 0.8564876828113778
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8489749090805674,
+                    0.8564876828113778
+                ],
+                [
+                    0.8515540669270198,
+                    0.8560968222768064
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.54968184892061,
+            "scoreError" : 0.1615252970150146,
+            "scoreConfidence" : [
+                16.388156551905595,
+                16.711207145935624
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.49850282401758,
+                "50.0" : 16.537651495227536,
+                "90.0" : 16.63415972668732,
+                "95.0" : 16.63415972668732,
+                "99.0" : 16.63415972668732,
+                "99.9" : 16.63415972668732,
+                "99.99" : 16.63415972668732,
+                "99.999" : 16.63415972668732,
+                "99.9999" : 16.63415972668732,
+                "100.0" : 16.63415972668732
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.49850282401758,
+                    16.50238526106155,
+                    16.500261541520253
+                ],
+                [
+                    16.63415972668732,
+                    16.57291772939352,
+                    16.58986401084343
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2778.488690421295,
+            "scoreError" : 62.9238309385271,
+            "scoreConfidence" : [
+                2715.5648594827676,
+                2841.412521359822
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2755.0010038562828,
+                "50.0" : 2779.656064044025,
+                "90.0" : 2800.968590296036,
+                "95.0" : 2800.968590296036,
+                "99.0" : 2800.968590296036,
+                "99.9" : 2800.968590296036,
+                "99.99" : 2800.968590296036,
+                "99.999" : 2800.968590296036,
+                "99.9999" : 2800.968590296036,
+                "100.0" : 2800.968590296036
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2757.1124348113167,
+                    2762.3509052966233,
+                    2755.0010038562828
+                ],
+                [
+                    2796.9612227914267,
+                    2800.968590296036,
+                    2798.537985476086
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73669.51548024778,
+            "scoreError" : 264.7487636233793,
+            "scoreConfidence" : [
+                73404.76671662439,
+                73934.26424387116
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73558.84108694759,
+                "50.0" : 73659.73038091272,
+                "90.0" : 73829.41791564651,
+                "95.0" : 73829.41791564651,
+                "99.0" : 73829.41791564651,
+                "99.9" : 73829.41791564651,
+                "99.99" : 73829.41791564651,
+                "99.999" : 73829.41791564651,
+                "99.9999" : 73829.41791564651,
+                "100.0" : 73829.41791564651
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73558.84108694759,
+                    73638.53351633916,
+                    73603.59558109858
+                ],
+                [
+                    73829.41791564651,
+                    73705.77753596859,
+                    73680.92724548628
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 363.58823731802767,
+            "scoreError" : 19.5274661636333,
+            "scoreConfidence" : [
+                344.0607711543944,
+                383.11570348166094
+            ],
+            "scorePercentiles" : {
+                "0.0" : 357.0611443206261,
+                "50.0" : 363.571275366562,
+                "90.0" : 370.2421797971201,
+                "95.0" : 370.2421797971201,
+                "99.0" : 370.2421797971201,
+                "99.9" : 370.2421797971201,
+                "99.99" : 370.2421797971201,
+                "99.999" : 370.2421797971201,
+                "99.9999" : 370.2421797971201,
+                "100.0" : 370.2421797971201
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    369.7350061319471,
+                    369.8504365279261,
+                    370.2421797971201
+                ],
+                [
+                    357.23311252936946,
+                    357.40754460117694,
+                    357.0611443206261
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 116.72399645866858,
+            "scoreError" : 5.976751259433861,
+            "scoreConfidence" : [
+                110.74724519923473,
+                122.70074771810243
+            ],
+            "scorePercentiles" : {
+                "0.0" : 114.37037290387704,
+                "50.0" : 116.78727106301476,
+                "90.0" : 118.76644388334158,
+                "95.0" : 118.76644388334158,
+                "99.0" : 118.76644388334158,
+                "99.9" : 118.76644388334158,
+                "99.99" : 118.76644388334158,
+                "99.999" : 118.76644388334158,
+                "99.9999" : 118.76644388334158,
+                "100.0" : 118.76644388334158
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    118.76644388334158,
+                    118.56675140486097,
+                    118.63899217614207
+                ],
+                [
+                    114.37037290387704,
+                    115.00779072116855,
+                    114.99362766262117
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06117665360742547,
+            "scoreError" : 3.2240977626609997E-4,
+            "scoreConfidence" : [
+                0.060854243831159366,
+                0.06149906338369157
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06107049203654396,
+                "50.0" : 0.06115804115506514,
+                "90.0" : 0.06137244240281818,
+                "95.0" : 0.06137244240281818,
+                "99.0" : 0.06137244240281818,
+                "99.9" : 0.06137244240281818,
+                "99.99" : 0.06137244240281818,
+                "99.999" : 0.06137244240281818,
+                "99.9999" : 0.06137244240281818,
+                "100.0" : 0.06137244240281818
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06112844996087828,
+                    0.06107049203654396,
+                    0.06107084421088631
+                ],
+                [
+                    0.06123006068417411,
+                    0.061187632349251994,
+                    0.06137244240281818
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.647853614645684E-4,
+            "scoreError" : 2.1770251029056523E-5,
+            "scoreConfidence" : [
+                3.4301511043551187E-4,
+                3.8655561249362495E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.569432405224067E-4,
+                "50.0" : 3.6510763798518783E-4,
+                "90.0" : 3.722969334166025E-4,
+                "95.0" : 3.722969334166025E-4,
+                "99.0" : 3.722969334166025E-4,
+                "99.9" : 3.722969334166025E-4,
+                "99.99" : 3.722969334166025E-4,
+                "99.999" : 3.722969334166025E-4,
+                "99.9999" : 3.722969334166025E-4,
+                "100.0" : 3.722969334166025E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.716994723468445E-4,
+                    3.722969334166025E-4,
+                    3.715565654547381E-4
+                ],
+                [
+                    3.586587105156375E-4,
+                    3.5755724653118126E-4,
+                    3.569432405224067E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2470641837995724,
+            "scoreError" : 0.05171634440612743,
+            "scoreConfidence" : [
+                2.195347839393445,
+                2.2987805282057
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.204149842186467,
+                "50.0" : 2.25384161059735,
+                "90.0" : 2.299950497545833,
+                "95.0" : 2.3017642016110473,
+                "99.0" : 2.3017642016110473,
+                "99.9" : 2.3017642016110473,
+                "99.99" : 2.3017642016110473,
+                "99.999" : 2.3017642016110473,
+                "99.9999" : 2.3017642016110473,
+                "100.0" : 2.3017642016110473
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3017642016110473,
+                    2.263703855590765,
+                    2.2692584690265485,
+                    2.215318050719823,
+                    2.219812548945616
+                ],
+                [
+                    2.283627160958904,
+                    2.252027603242513,
+                    2.2556556179521876,
+                    2.204149842186467,
+                    2.2053244877618523
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013709461442874438,
+            "scoreError" : 3.587780944258974E-4,
+            "scoreConfidence" : [
+                0.01335068334844854,
+                0.014068239537300336
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013581161904270403,
+                "50.0" : 0.013709168517990773,
+                "90.0" : 0.013833087471037798,
+                "95.0" : 0.013833087471037798,
+                "99.0" : 0.013833087471037798,
+                "99.9" : 0.013833087471037798,
+                "99.99" : 0.013833087471037798,
+                "99.999" : 0.013833087471037798,
+                "99.9999" : 0.013833087471037798,
+                "100.0" : 0.013833087471037798
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013828249051390833,
+                    0.013816649879588985,
+                    0.013833087471037798
+                ],
+                [
+                    0.01360168715639256,
+                    0.01359593319456605,
+                    0.013581161904270403
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0251105371056244,
+            "scoreError" : 0.0032110388092383537,
+            "scoreConfidence" : [
+                1.021899498296386,
+                1.0283215759148627
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0236404933469805,
+                "50.0" : 1.025114111256489,
+                "90.0" : 1.026886722764144,
+                "95.0" : 1.026886722764144,
+                "99.0" : 1.026886722764144,
+                "99.9" : 1.026886722764144,
+                "99.99" : 1.026886722764144,
+                "99.999" : 1.026886722764144,
+                "99.9999" : 1.026886722764144,
+                "100.0" : 1.026886722764144
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.02480463848755,
+                    1.0242469218557968,
+                    1.0236404933469805
+                ],
+                [
+                    1.025423584025428,
+                    1.025660862153846,
+                    1.026886722764144
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010465561559227643,
+            "scoreError" : 6.169359007248764E-4,
+            "scoreConfidence" : [
+                0.009848625658502768,
+                0.011082497459952519
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01025134811338549,
+                "50.0" : 0.010466171728282101,
+                "90.0" : 0.010673483467175567,
+                "95.0" : 0.010673483467175567,
+                "99.0" : 0.010673483467175567,
+                "99.9" : 0.010673483467175567,
+                "99.99" : 0.010673483467175567,
+                "99.999" : 0.010673483467175567,
+                "99.9999" : 0.010673483467175567,
+                "100.0" : 0.010673483467175567
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010275518017619969,
+                    0.010267870500731054,
+                    0.01025134811338549
+                ],
+                [
+                    0.010673483467175567,
+                    0.010668323817509543,
+                    0.010656825438944232
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.941225957104143,
+            "scoreError" : 0.1197703155148319,
+            "scoreConfidence" : [
+                2.821455641589311,
+                3.060996272618975
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9010322030162414,
+                "50.0" : 2.937192331759092,
+                "90.0" : 2.987832262246117,
+                "95.0" : 2.987832262246117,
+                "99.0" : 2.987832262246117,
+                "99.9" : 2.987832262246117,
+                "99.99" : 2.987832262246117,
+                "99.999" : 2.987832262246117,
+                "99.9999" : 2.987832262246117,
+                "100.0" : 2.987832262246117
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9010322030162414,
+                    2.903346382472432,
+                    2.9032682437608823
+                ],
+                [
+                    2.9808383700834327,
+                    2.987832262246117,
+                    2.9710382810457516
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.754436993816938,
+            "scoreError" : 0.2496292428472511,
+            "scoreConfidence" : [
+                2.504807750969687,
+                3.0040662366641895
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6712509294871793,
+                "50.0" : 2.753793028500329,
+                "90.0" : 2.8403078006248226,
+                "95.0" : 2.8403078006248226,
+                "99.0" : 2.8403078006248226,
+                "99.9" : 2.8403078006248226,
+                "99.99" : 2.8403078006248226,
+                "99.999" : 2.8403078006248226,
+                "99.9999" : 2.8403078006248226,
+                "100.0" : 2.8403078006248226
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8403078006248226,
+                    2.8327792265647127,
+                    2.8338941020119015
+                ],
+                [
+                    2.673583073777065,
+                    2.6748068304359456,
+                    2.6712509294871793
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17354440442824304,
+            "scoreError" : 0.0036401376471533187,
+            "scoreConfidence" : [
+                0.16990426678108972,
+                0.17718454207539636
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17220411916241907,
+                "50.0" : 0.17360962560227317,
+                "90.0" : 0.17481554806230007,
+                "95.0" : 0.17481554806230007,
+                "99.0" : 0.17481554806230007,
+                "99.9" : 0.17481554806230007,
+                "99.99" : 0.17481554806230007,
+                "99.999" : 0.17481554806230007,
+                "99.9999" : 0.17481554806230007,
+                "100.0" : 0.17481554806230007
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17257353637744186,
+                    0.17231878443299503,
+                    0.17220411916241907
+                ],
+                [
+                    0.17481554806230007,
+                    0.17470872370719776,
+                    0.17464571482710445
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32477626702529855,
+            "scoreError" : 0.004358725076686264,
+            "scoreConfidence" : [
+                0.32041754194861227,
+                0.3291349921019848
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.32353093801358784,
+                "50.0" : 0.3243017575470297,
+                "90.0" : 0.3277223414714075,
+                "95.0" : 0.3277223414714075,
+                "99.0" : 0.3277223414714075,
+                "99.9" : 0.3277223414714075,
+                "99.99" : 0.3277223414714075,
+                "99.999" : 0.3277223414714075,
+                "99.9999" : 0.3277223414714075,
+                "100.0" : 0.3277223414714075
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3277223414714075,
+                    0.32504139595657544,
+                    0.324686089025974
+                ],
+                [
+                    0.3237594116161616,
+                    0.32353093801358784,
+                    0.3239174260680854
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14803951182698424,
+            "scoreError" : 6.84585387122218E-4,
+            "scoreConfidence" : [
+                0.14735492643986203,
+                0.14872409721410645
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14772826169232134,
+                "50.0" : 0.1480501778472369,
+                "90.0" : 0.14840893136250982,
+                "95.0" : 0.14840893136250982,
+                "99.0" : 0.14840893136250982,
+                "99.9" : 0.14840893136250982,
+                "99.99" : 0.14840893136250982,
+                "99.999" : 0.14840893136250982,
+                "99.9999" : 0.14840893136250982,
+                "100.0" : 0.14840893136250982
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14809276545678024,
+                    0.14816951687607421,
+                    0.14840893136250982
+                ],
+                [
+                    0.14772826169232134,
+                    0.14800759023769353,
+                    0.14783000533652638
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3924708860347024,
+            "scoreError" : 0.007662861387629553,
+            "scoreConfidence" : [
+                0.38480802464707287,
+                0.400133747422332
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3897927276554278,
+                "50.0" : 0.39254715809253304,
+                "90.0" : 0.39518497960877297,
+                "95.0" : 0.39518497960877297,
+                "99.0" : 0.39518497960877297,
+                "99.9" : 0.39518497960877297,
+                "99.99" : 0.39518497960877297,
+                "99.999" : 0.39518497960877297,
+                "99.9999" : 0.39518497960877297,
+                "100.0" : 0.39518497960877297
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3902918499395075,
+                    0.38986708245292584,
+                    0.3897927276554278
+                ],
+                [
+                    0.39518497960877297,
+                    0.3948862103060217,
+                    0.39480246624555865
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15946851585612176,
+            "scoreError" : 0.0030452239949115057,
+            "scoreConfidence" : [
+                0.15642329186121026,
+                0.16251373985103326
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15818883082082352,
+                "50.0" : 0.15910943732848848,
+                "90.0" : 0.16098467694264235,
+                "95.0" : 0.16098467694264235,
+                "99.0" : 0.16098467694264235,
+                "99.9" : 0.16098467694264235,
+                "99.99" : 0.16098467694264235,
+                "99.999" : 0.16098467694264235,
+                "99.9999" : 0.16098467694264235,
+                "100.0" : 0.16098467694264235
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15883336630612602,
+                    0.15818883082082352,
+                    0.1605853464101617
+                ],
+                [
+                    0.16098467694264235,
+                    0.15894886643884606,
+                    0.15927000821813087
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04557187715139577,
+            "scoreError" : 0.0019743822179661813,
+            "scoreConfidence" : [
+                0.043597494933429584,
+                0.04754625936936195
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04489849582001365,
+                "50.0" : 0.045573100423181814,
+                "90.0" : 0.046234188156805814,
+                "95.0" : 0.046234188156805814,
+                "99.0" : 0.046234188156805814,
+                "99.9" : 0.046234188156805814,
+                "99.99" : 0.046234188156805814,
+                "99.999" : 0.046234188156805814,
+                "99.9999" : 0.046234188156805814,
+                "100.0" : 0.046234188156805814
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.044948254934129205,
+                    0.04494149731478777,
+                    0.04489849582001365
+                ],
+                [
+                    0.046197945912234424,
+                    0.046234188156805814,
+                    0.04621088077040378
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8579162.2538883,
+            "scoreError" : 224624.1745795969,
+            "scoreConfidence" : [
+                8354538.079308703,
+                8803786.428467896
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8499762.806287171,
+                "50.0" : 8576044.98185867,
+                "90.0" : 8660995.17056277,
+                "95.0" : 8660995.17056277,
+                "99.0" : 8660995.17056277,
+                "99.9" : 8660995.17056277,
+                "99.99" : 8660995.17056277,
+                "99.999" : 8660995.17056277,
+                "99.9999" : 8660995.17056277,
+                "100.0" : 8660995.17056277
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8508287.81632653,
+                    8510996.471489362,
+                    8499762.806287171
+                ],
+                [
+                    8641093.492227979,
+                    8660995.17056277,
+                    8653837.766435986
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-15T05-05-10Z-7fb27297ebbca1524bed042d8b07521b5ca5df7c-jdk17.json
+++ b/performance-results/2026-01-15T05-05-10Z-7fb27297ebbca1524bed042d8b07521b5ca5df7c-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.329678047658623,
+            "scoreError" : 0.05667180350676404,
+            "scoreConfidence" : [
+                3.2730062441518593,
+                3.386349851165387
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.321177557128826,
+                "50.0" : 3.328088270634323,
+                "90.0" : 3.341358092237021,
+                "95.0" : 3.341358092237021,
+                "99.0" : 3.341358092237021,
+                "99.9" : 3.341358092237021,
+                "99.99" : 3.341358092237021,
+                "99.999" : 3.341358092237021,
+                "99.9999" : 3.341358092237021,
+                "100.0" : 3.341358092237021
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.321177557128826,
+                    3.331004039605296
+                ],
+                [
+                    3.3251725016633498,
+                    3.341358092237021
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6777599025482155,
+            "scoreError" : 0.025781196565632603,
+            "scoreConfidence" : [
+                1.6519787059825828,
+                1.7035410991138482
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6740080181626207,
+                "50.0" : 1.6773942519501341,
+                "90.0" : 1.6822430881299733,
+                "95.0" : 1.6822430881299733,
+                "99.0" : 1.6822430881299733,
+                "99.9" : 1.6822430881299733,
+                "99.99" : 1.6822430881299733,
+                "99.999" : 1.6822430881299733,
+                "99.9999" : 1.6822430881299733,
+                "100.0" : 1.6822430881299733
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6740080181626207,
+                    1.6822430881299733
+                ],
+                [
+                    1.6799739204406183,
+                    1.6748145834596502
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8434414622919757,
+            "scoreError" : 0.028539431271384814,
+            "scoreConfidence" : [
+                0.8149020310205909,
+                0.8719808935633605
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8384567532132736,
+                "50.0" : 0.8437087350790496,
+                "90.0" : 0.8478916257965301,
+                "95.0" : 0.8478916257965301,
+                "99.0" : 0.8478916257965301,
+                "99.9" : 0.8478916257965301,
+                "99.99" : 0.8478916257965301,
+                "99.999" : 0.8478916257965301,
+                "99.9999" : 0.8478916257965301,
+                "100.0" : 0.8478916257965301
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8384567532132736,
+                    0.8410893367872528
+                ],
+                [
+                    0.8463281333708464,
+                    0.8478916257965301
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.994111102084927,
+            "scoreError" : 0.45253057327149515,
+            "scoreConfidence" : [
+                15.541580528813432,
+                16.44664167535642
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.820045210261867,
+                "50.0" : 16.003536218030213,
+                "90.0" : 16.146235326066666,
+                "95.0" : 16.146235326066666,
+                "99.0" : 16.146235326066666,
+                "99.9" : 16.146235326066666,
+                "99.99" : 16.146235326066666,
+                "99.999" : 16.146235326066666,
+                "99.9999" : 16.146235326066666,
+                "100.0" : 16.146235326066666
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.820045210261867,
+                    15.870627483868411,
+                    15.852025913716345
+                ],
+                [
+                    16.146235326066666,
+                    16.13928772640425,
+                    16.13644495219202
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2760.030036981973,
+            "scoreError" : 160.00751468885167,
+            "scoreConfidence" : [
+                2600.0225222931213,
+                2920.0375516708245
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2700.4499535503255,
+                "50.0" : 2761.7226425140143,
+                "90.0" : 2813.2151220276323,
+                "95.0" : 2813.2151220276323,
+                "99.0" : 2813.2151220276323,
+                "99.9" : 2813.2151220276323,
+                "99.99" : 2813.2151220276323,
+                "99.999" : 2813.2151220276323,
+                "99.9999" : 2813.2151220276323,
+                "100.0" : 2813.2151220276323
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2813.2151220276323,
+                    2812.2328593933066,
+                    2810.4570520889615
+                ],
+                [
+                    2700.4499535503255,
+                    2712.9882329390666,
+                    2710.837001892545
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 72276.26963088989,
+            "scoreError" : 2115.462808513987,
+            "scoreConfidence" : [
+                70160.8068223759,
+                74391.73243940387
+            ],
+            "scorePercentiles" : {
+                "0.0" : 71548.4011199268,
+                "50.0" : 72291.58093870385,
+                "90.0" : 72979.58238392294,
+                "95.0" : 72979.58238392294,
+                "99.0" : 72979.58238392294,
+                "99.9" : 72979.58238392294,
+                "99.99" : 72979.58238392294,
+                "99.999" : 72979.58238392294,
+                "99.9999" : 72979.58238392294,
+                "100.0" : 72979.58238392294
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    71586.01697932195,
+                    71548.4011199268,
+                    71629.73296506029
+                ],
+                [
+                    72960.45542475989,
+                    72979.58238392294,
+                    72953.4289123474
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 354.9132610684481,
+            "scoreError" : 6.214978775488304,
+            "scoreConfidence" : [
+                348.6982822929598,
+                361.1282398439364
+            ],
+            "scorePercentiles" : {
+                "0.0" : 352.32344444909955,
+                "50.0" : 355.28940043941196,
+                "90.0" : 357.0577074690599,
+                "95.0" : 357.0577074690599,
+                "99.0" : 357.0577074690599,
+                "99.9" : 357.0577074690599,
+                "99.99" : 357.0577074690599,
+                "99.999" : 357.0577074690599,
+                "99.9999" : 357.0577074690599,
+                "100.0" : 357.0577074690599
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    352.32344444909955,
+                    352.54455810244923,
+                    354.04242643491074
+                ],
+                [
+                    356.5363744439132,
+                    356.975055511256,
+                    357.0577074690599
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 116.35653879157513,
+            "scoreError" : 3.709786553405452,
+            "scoreConfidence" : [
+                112.64675223816968,
+                120.06632534498058
+            ],
+            "scorePercentiles" : {
+                "0.0" : 114.97479188035754,
+                "50.0" : 116.34097126776625,
+                "90.0" : 117.73351327137166,
+                "95.0" : 117.73351327137166,
+                "99.0" : 117.73351327137166,
+                "99.9" : 117.73351327137166,
+                "99.99" : 117.73351327137166,
+                "99.999" : 117.73351327137166,
+                "99.9999" : 117.73351327137166,
+                "100.0" : 117.73351327137166
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    117.73351327137166,
+                    117.55551700412119,
+                    117.37896822427992
+                ],
+                [
+                    115.1934680580679,
+                    115.30297431125258,
+                    114.97479188035754
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06250936306340477,
+            "scoreError" : 0.0014667091408924122,
+            "scoreConfidence" : [
+                0.061042653922512354,
+                0.06397607220429717
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061938077557694454,
+                "50.0" : 0.06254170592880155,
+                "90.0" : 0.06301216596514221,
+                "95.0" : 0.06301216596514221,
+                "99.0" : 0.06301216596514221,
+                "99.9" : 0.06301216596514221,
+                "99.99" : 0.06301216596514221,
+                "99.999" : 0.06301216596514221,
+                "99.9999" : 0.06301216596514221,
+                "100.0" : 0.06301216596514221
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.061938077557694454,
+                    0.06212394316367544,
+                    0.06204353338503536
+                ],
+                [
+                    0.06301216596514221,
+                    0.06297898961495346,
+                    0.06295946869392766
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.657993237190661E-4,
+            "scoreError" : 3.7172780177327544E-6,
+            "scoreConfidence" : [
+                3.6208204570133335E-4,
+                3.695166017367988E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6456015183320453E-4,
+                "50.0" : 3.6540337439395614E-4,
+                "90.0" : 3.6787653234086524E-4,
+                "95.0" : 3.6787653234086524E-4,
+                "99.0" : 3.6787653234086524E-4,
+                "99.9" : 3.6787653234086524E-4,
+                "99.99" : 3.6787653234086524E-4,
+                "99.999" : 3.6787653234086524E-4,
+                "99.9999" : 3.6787653234086524E-4,
+                "100.0" : 3.6787653234086524E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.6456015183320453E-4,
+                    3.650612228276722E-4,
+                    3.646837323573904E-4
+                ],
+                [
+                    3.657455259602401E-4,
+                    3.6787653234086524E-4,
+                    3.6686877699502383E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.3046023258255355,
+            "scoreError" : 0.05818048938570765,
+            "scoreConfidence" : [
+                2.246421836439828,
+                2.362782815211243
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.261317123671716,
+                "50.0" : 2.311095421560764,
+                "90.0" : 2.3643012252325275,
+                "95.0" : 2.3658829344688903,
+                "99.0" : 2.3658829344688903,
+                "99.9" : 2.3658829344688903,
+                "99.99" : 2.3658829344688903,
+                "99.999" : 2.3658829344688903,
+                "99.9999" : 2.3658829344688903,
+                "100.0" : 2.3658829344688903
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.350065842105263,
+                    2.306430679889299,
+                    2.3157601632322296,
+                    2.265619511327594,
+                    2.261317123671716
+                ],
+                [
+                    2.329820759375728,
+                    2.3658829344688903,
+                    2.320294353364269,
+                    2.2693921311549805,
+                    2.2614397596653855
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013601464811590034,
+            "scoreError" : 1.2771835983962796E-4,
+            "scoreConfidence" : [
+                0.013473746451750406,
+                0.013729183171429661
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01355335393462486,
+                "50.0" : 0.01360144577409127,
+                "90.0" : 0.013652513348542002,
+                "95.0" : 0.013652513348542002,
+                "99.0" : 0.013652513348542002,
+                "99.9" : 0.013652513348542002,
+                "99.99" : 0.013652513348542002,
+                "99.999" : 0.013652513348542002,
+                "99.9999" : 0.013652513348542002,
+                "100.0" : 0.013652513348542002
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013652513348542002,
+                    0.013631401005984105,
+                    0.013642750023874554
+                ],
+                [
+                    0.01355335393462486,
+                    0.013557280014316256,
+                    0.013571490542198434
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.051340904953647,
+            "scoreError" : 0.03528393055186202,
+            "scoreConfidence" : [
+                1.016056974401785,
+                1.086624835505509
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.038096154245381,
+                "50.0" : 1.0516766931827441,
+                "90.0" : 1.063929370319149,
+                "95.0" : 1.063929370319149,
+                "99.0" : 1.063929370319149,
+                "99.9" : 1.063929370319149,
+                "99.99" : 1.063929370319149,
+                "99.999" : 1.063929370319149,
+                "99.9999" : 1.063929370319149,
+                "100.0" : 1.063929370319149
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0628138319872475,
+                    1.063929370319149,
+                    1.0615225602377667
+                ],
+                [
+                    1.038096154245381,
+                    1.0418308261277216,
+                    1.0398526868046167
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010619612542560006,
+            "scoreError" : 4.4365941722241845E-4,
+            "scoreConfidence" : [
+                0.010175953125337587,
+                0.011063271959782425
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010463371850084752,
+                "50.0" : 0.010618625292392003,
+                "90.0" : 0.01077608550178663,
+                "95.0" : 0.01077608550178663,
+                "99.0" : 0.01077608550178663,
+                "99.9" : 0.01077608550178663,
+                "99.99" : 0.01077608550178663,
+                "99.999" : 0.01077608550178663,
+                "99.9999" : 0.01077608550178663,
+                "100.0" : 0.01077608550178663
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010472256593965846,
+                    0.010463371850084752,
+                    0.01049151080803206
+                ],
+                [
+                    0.010768710724738811,
+                    0.01077608550178663,
+                    0.010745739776751943
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.181022894424789,
+            "scoreError" : 0.11444031463868494,
+            "scoreConfidence" : [
+                3.066582579786104,
+                3.295463209063474
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.126543348125,
+                "50.0" : 3.186609938340726,
+                "90.0" : 3.222504525128866,
+                "95.0" : 3.222504525128866,
+                "99.0" : 3.222504525128866,
+                "99.9" : 3.222504525128866,
+                "99.99" : 3.222504525128866,
+                "99.999" : 3.222504525128866,
+                "99.9999" : 3.222504525128866,
+                "100.0" : 3.222504525128866
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.126543348125,
+                    3.1629028317520556,
+                    3.146930534298301
+                ],
+                [
+                    3.2103170449293965,
+                    3.2169390823151125,
+                    3.222504525128866
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8249023075508357,
+            "scoreError" : 0.031188004997262694,
+            "scoreConfidence" : [
+                2.793714302553573,
+                2.8560903125480985
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8108043485103993,
+                "50.0" : 2.82417730911651,
+                "90.0" : 2.840504744390798,
+                "95.0" : 2.840504744390798,
+                "99.0" : 2.840504744390798,
+                "99.9" : 2.840504744390798,
+                "99.99" : 2.840504744390798,
+                "99.999" : 2.840504744390798,
+                "99.9999" : 2.840504744390798,
+                "100.0" : 2.840504744390798
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.840504744390798,
+                    2.825019890677966,
+                    2.834197807594219
+                ],
+                [
+                    2.8155523265765767,
+                    2.8108043485103993,
+                    2.8233347275550535
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17925348153701934,
+            "scoreError" : 0.002728348414020049,
+            "scoreConfidence" : [
+                0.17652513312299928,
+                0.1819818299510394
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17802491666815018,
+                "50.0" : 0.1792436202252374,
+                "90.0" : 0.18026593539432176,
+                "95.0" : 0.18026593539432176,
+                "99.0" : 0.18026593539432176,
+                "99.9" : 0.18026593539432176,
+                "99.99" : 0.18026593539432176,
+                "99.999" : 0.18026593539432176,
+                "99.9999" : 0.18026593539432176,
+                "100.0" : 0.18026593539432176
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17857674592857142,
+                    0.17857098283989858,
+                    0.17802491666815018
+                ],
+                [
+                    0.18017181386927067,
+                    0.17991049452190339,
+                    0.18026593539432176
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32924866333872627,
+            "scoreError" : 0.005112289286694649,
+            "scoreConfidence" : [
+                0.3241363740520316,
+                0.3343609526254209
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3271798685424505,
+                "50.0" : 0.3295441395197237,
+                "90.0" : 0.3319639377593361,
+                "95.0" : 0.3319639377593361,
+                "99.0" : 0.3319639377593361,
+                "99.9" : 0.3319639377593361,
+                "99.99" : 0.3319639377593361,
+                "99.999" : 0.3319639377593361,
+                "99.9999" : 0.3319639377593361,
+                "100.0" : 0.3319639377593361
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3319639377593361,
+                    0.3272308917539267,
+                    0.3271798685424505
+                ],
+                [
+                    0.3300290029371968,
+                    0.32930882744994733,
+                    0.32977945158950006
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14997680368930608,
+            "scoreError" : 0.006258643548498255,
+            "scoreConfidence" : [
+                0.14371816014080782,
+                0.15623544723780433
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14771569596301276,
+                "50.0" : 0.15000357474232345,
+                "90.0" : 0.15221220357686455,
+                "95.0" : 0.15221220357686455,
+                "99.0" : 0.15221220357686455,
+                "99.9" : 0.15221220357686455,
+                "99.99" : 0.15221220357686455,
+                "99.999" : 0.15221220357686455,
+                "99.9999" : 0.15221220357686455,
+                "100.0" : 0.15221220357686455
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14820695381993332,
+                    0.14771569596301276,
+                    0.14792087928407663
+                ],
+                [
+                    0.15221220357686455,
+                    0.15180019566471356,
+                    0.15200489382723556
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4047083631318668,
+            "scoreError" : 0.022870777971131354,
+            "scoreConfidence" : [
+                0.38183758516073546,
+                0.42757914110299816
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39578823279376263,
+                "50.0" : 0.4057540559837185,
+                "90.0" : 0.413996786181487,
+                "95.0" : 0.413996786181487,
+                "99.0" : 0.413996786181487,
+                "99.9" : 0.413996786181487,
+                "99.99" : 0.413996786181487,
+                "99.999" : 0.413996786181487,
+                "99.9999" : 0.413996786181487,
+                "100.0" : 0.413996786181487
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40091469884541375,
+                    0.3959054622510788,
+                    0.39578823279376263
+                ],
+                [
+                    0.413996786181487,
+                    0.4105934131220233,
+                    0.41105158559743515
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15491788024423972,
+            "scoreError" : 0.005566539301483634,
+            "scoreConfidence" : [
+                0.1493513409427561,
+                0.16048441954572334
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15287488256336565,
+                "50.0" : 0.15500836239026494,
+                "90.0" : 0.15680434627989023,
+                "95.0" : 0.15680434627989023,
+                "99.0" : 0.15680434627989023,
+                "99.9" : 0.15680434627989023,
+                "99.99" : 0.15680434627989023,
+                "99.999" : 0.15680434627989023,
+                "99.9999" : 0.15680434627989023,
+                "100.0" : 0.15680434627989023
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15335264815751945,
+                    0.15310695630473392,
+                    0.15287488256336565
+                ],
+                [
+                    0.1566640766230104,
+                    0.15680434627989023,
+                    0.15670437153691863
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04666586240929096,
+            "scoreError" : 0.0020992423215478433,
+            "scoreConfidence" : [
+                0.04456662008774311,
+                0.0487651047308388
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04596984147137512,
+                "50.0" : 0.04665161429903947,
+                "90.0" : 0.04738214688727476,
+                "95.0" : 0.04738214688727476,
+                "99.0" : 0.04738214688727476,
+                "99.9" : 0.04738214688727476,
+                "99.99" : 0.04738214688727476,
+                "99.999" : 0.04738214688727476,
+                "99.9999" : 0.04738214688727476,
+                "100.0" : 0.04738214688727476
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.045988878968208344,
+                    0.04598966921598205,
+                    0.04596984147137512
+                ],
+                [
+                    0.04738214688727476,
+                    0.047313559382096894,
+                    0.0473510785308086
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8874295.548471965,
+            "scoreError" : 153913.3361281025,
+            "scoreConfidence" : [
+                8720382.212343862,
+                9028208.884600068
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8809304.091549296,
+                "50.0" : 8879951.473100387,
+                "90.0" : 8938640.74173369,
+                "95.0" : 8938640.74173369,
+                "99.0" : 8938640.74173369,
+                "99.9" : 8938640.74173369,
+                "99.99" : 8938640.74173369,
+                "99.999" : 8938640.74173369,
+                "99.9999" : 8938640.74173369,
+                "100.0" : 8938640.74173369
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8858378.294065544,
+                    8815825.91277533,
+                    8809304.091549296
+                ],
+                [
+                    8938640.74173369,
+                    8922099.598572703,
+                    8901524.65213523
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-19T06-06-25Z-2766087b8a1d75c740145e6d8edbc93d196b90f8-jdk17.json
+++ b/performance-results/2026-01-19T06-06-25Z-2766087b8a1d75c740145e6d8edbc93d196b90f8-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3241886864751917,
+            "scoreError" : 0.02769015781727462,
+            "scoreConfidence" : [
+                3.296498528657917,
+                3.3518788442924663
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.318949665692894,
+                "50.0" : 3.3245378681267104,
+                "90.0" : 3.3287293439544507,
+                "95.0" : 3.3287293439544507,
+                "99.0" : 3.3287293439544507,
+                "99.9" : 3.3287293439544507,
+                "99.99" : 3.3287293439544507,
+                "99.999" : 3.3287293439544507,
+                "99.9999" : 3.3287293439544507,
+                "100.0" : 3.3287293439544507
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.318949665692894,
+                    3.322697075739082
+                ],
+                [
+                    3.326378660514339,
+                    3.3287293439544507
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6706922527104653,
+            "scoreError" : 0.04910948369220607,
+            "scoreConfidence" : [
+                1.6215827690182592,
+                1.7198017364026714
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6634428740952594,
+                "50.0" : 1.669042324168799,
+                "90.0" : 1.6812414884090037,
+                "95.0" : 1.6812414884090037,
+                "99.0" : 1.6812414884090037,
+                "99.9" : 1.6812414884090037,
+                "99.99" : 1.6812414884090037,
+                "99.999" : 1.6812414884090037,
+                "99.9999" : 1.6812414884090037,
+                "100.0" : 1.6812414884090037
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6634428740952594,
+                    1.667630929618067
+                ],
+                [
+                    1.6704537187195314,
+                    1.6812414884090037
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8383352447006388,
+            "scoreError" : 0.022809640885066523,
+            "scoreConfidence" : [
+                0.8155256038155723,
+                0.8611448855857053
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8335451878729041,
+                "50.0" : 0.8388729515104405,
+                "90.0" : 0.8420498879087702,
+                "95.0" : 0.8420498879087702,
+                "99.0" : 0.8420498879087702,
+                "99.9" : 0.8420498879087702,
+                "99.99" : 0.8420498879087702,
+                "99.999" : 0.8420498879087702,
+                "99.9999" : 0.8420498879087702,
+                "100.0" : 0.8420498879087702
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8390422915208873,
+                    0.8420498879087702
+                ],
+                [
+                    0.8335451878729041,
+                    0.8387036114999938
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.861308641256171,
+            "scoreError" : 0.27685464215930183,
+            "scoreConfidence" : [
+                15.58445399909687,
+                16.138163283415473
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.74170800321259,
+                "50.0" : 15.866366146543292,
+                "90.0" : 15.99378479722804,
+                "95.0" : 15.99378479722804,
+                "99.0" : 15.99378479722804,
+                "99.9" : 15.99378479722804,
+                "99.99" : 15.99378479722804,
+                "99.999" : 15.99378479722804,
+                "99.9999" : 15.99378479722804,
+                "100.0" : 15.99378479722804
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.940682777909855,
+                    15.861221748172994,
+                    15.99378479722804
+                ],
+                [
+                    15.758943976099955,
+                    15.74170800321259,
+                    15.871510544913589
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2603.9360603160185,
+            "scoreError" : 190.56936436252533,
+            "scoreConfidence" : [
+                2413.366695953493,
+                2794.505424678544
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2538.7570561598013,
+                "50.0" : 2600.730688589376,
+                "90.0" : 2681.138393955026,
+                "95.0" : 2681.138393955026,
+                "99.0" : 2681.138393955026,
+                "99.9" : 2681.138393955026,
+                "99.99" : 2681.138393955026,
+                "99.999" : 2681.138393955026,
+                "99.9999" : 2681.138393955026,
+                "100.0" : 2681.138393955026
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2661.054188872799,
+                    2681.138393955026,
+                    2653.9536438225596
+                ],
+                [
+                    2541.2053457297316,
+                    2547.5077333561926,
+                    2538.7570561598013
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 72243.98354840784,
+            "scoreError" : 1663.1036374233834,
+            "scoreConfidence" : [
+                70580.87991098445,
+                73907.08718583122
+            ],
+            "scorePercentiles" : {
+                "0.0" : 71409.90163230951,
+                "50.0" : 72295.99731155345,
+                "90.0" : 72937.95183993732,
+                "95.0" : 72937.95183993732,
+                "99.0" : 72937.95183993732,
+                "99.9" : 72937.95183993732,
+                "99.99" : 72937.95183993732,
+                "99.999" : 72937.95183993732,
+                "99.9999" : 72937.95183993732,
+                "100.0" : 72937.95183993732
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72588.17515406036,
+                    72711.82088500076,
+                    72937.95183993732
+                ],
+                [
+                    71812.23231009246,
+                    71409.90163230951,
+                    72003.81946904655
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 350.14174629614007,
+            "scoreError" : 8.079961155300403,
+            "scoreConfidence" : [
+                342.0617851408397,
+                358.22170745144047
+            ],
+            "scorePercentiles" : {
+                "0.0" : 347.04297428021357,
+                "50.0" : 350.08397287160324,
+                "90.0" : 353.5525656553841,
+                "95.0" : 353.5525656553841,
+                "99.0" : 353.5525656553841,
+                "99.9" : 353.5525656553841,
+                "99.99" : 353.5525656553841,
+                "99.999" : 353.5525656553841,
+                "99.9999" : 353.5525656553841,
+                "100.0" : 353.5525656553841
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    353.5525656553841,
+                    352.84408084665455,
+                    351.594517460787
+                ],
+                [
+                    347.2429112513814,
+                    348.5734282824194,
+                    347.04297428021357
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 111.27497781317668,
+            "scoreError" : 10.358910491851704,
+            "scoreConfidence" : [
+                100.91606732132497,
+                121.63388830502838
+            ],
+            "scorePercentiles" : {
+                "0.0" : 107.30964962105988,
+                "50.0" : 111.54235801856117,
+                "90.0" : 115.13804047843225,
+                "95.0" : 115.13804047843225,
+                "99.0" : 115.13804047843225,
+                "99.9" : 115.13804047843225,
+                "99.99" : 115.13804047843225,
+                "99.999" : 115.13804047843225,
+                "99.9999" : 115.13804047843225,
+                "100.0" : 115.13804047843225
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    107.30964962105988,
+                    107.70752154650602,
+                    108.81411577141874
+                ],
+                [
+                    115.13804047843225,
+                    114.27060026570362,
+                    114.40993919593951
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06313388184644585,
+            "scoreError" : 0.0013877631045239884,
+            "scoreConfidence" : [
+                0.06174611874192186,
+                0.06452164495096983
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06252908647016157,
+                "50.0" : 0.06317498906711273,
+                "90.0" : 0.06373859725674659,
+                "95.0" : 0.06373859725674659,
+                "99.0" : 0.06373859725674659,
+                "99.9" : 0.06373859725674659,
+                "99.99" : 0.06373859725674659,
+                "99.999" : 0.06373859725674659,
+                "99.9999" : 0.06373859725674659,
+                "100.0" : 0.06373859725674659
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06310251581637483,
+                    0.06252908647016157,
+                    0.0626050321409343
+                ],
+                [
+                    0.06373859725674659,
+                    0.06358059707660714,
+                    0.06324746231785064
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8737529014650765E-4,
+            "scoreError" : 4.7771185724841675E-5,
+            "scoreConfidence" : [
+                3.3960410442166594E-4,
+                4.3514647587134935E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6916131060238443E-4,
+                "50.0" : 3.8672520875770305E-4,
+                "90.0" : 4.057693032950771E-4,
+                "95.0" : 4.057693032950771E-4,
+                "99.0" : 4.057693032950771E-4,
+                "99.9" : 4.057693032950771E-4,
+                "99.99" : 4.057693032950771E-4,
+                "99.999" : 4.057693032950771E-4,
+                "99.9999" : 4.057693032950771E-4,
+                "100.0" : 4.057693032950771E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.9902816293600616E-4,
+                    4.057693032950771E-4,
+                    4.0337528223239455E-4
+                ],
+                [
+                    3.7442225457939995E-4,
+                    3.6916131060238443E-4,
+                    3.7249542723378375E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.298366288697353,
+            "scoreError" : 0.055014200262804916,
+            "scoreConfidence" : [
+                2.243352088434548,
+                2.3533804889601577
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2417112373907195,
+                "50.0" : 2.303666822466819,
+                "90.0" : 2.362921872344047,
+                "95.0" : 2.367619262310606,
+                "99.0" : 2.367619262310606,
+                "99.9" : 2.367619262310606,
+                "99.99" : 2.367619262310606,
+                "99.999" : 2.367619262310606,
+                "99.9999" : 2.367619262310606,
+                "100.0" : 2.367619262310606
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.367619262310606,
+                    2.3096788484988453,
+                    2.3066527751383763,
+                    2.2878752525737815,
+                    2.281341284671533
+                ],
+                [
+                    2.3206453626450116,
+                    2.300680869795261,
+                    2.3182584142327305,
+                    2.249199579716663,
+                    2.2417112373907195
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013655142492393602,
+            "scoreError" : 4.7771166222005307E-4,
+            "scoreConfidence" : [
+                0.013177430830173548,
+                0.014132854154613655
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013482758456620426,
+                "50.0" : 0.013652819185314479,
+                "90.0" : 0.013818902194400686,
+                "95.0" : 0.013818902194400686,
+                "99.0" : 0.013818902194400686,
+                "99.9" : 0.013818902194400686,
+                "99.99" : 0.013818902194400686,
+                "99.999" : 0.013818902194400686,
+                "99.9999" : 0.013818902194400686,
+                "100.0" : 0.013818902194400686
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013482758456620426,
+                    0.013510799057768747,
+                    0.013506640867061236
+                ],
+                [
+                    0.013794839312860213,
+                    0.013818902194400686,
+                    0.013816915065650305
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0083432220015236,
+            "scoreError" : 0.025052972014969335,
+            "scoreConfidence" : [
+                0.9832902499865542,
+                1.0333961940164929
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9974224376620786,
+                "50.0" : 1.0090480818300014,
+                "90.0" : 1.0171361129983727,
+                "95.0" : 1.0171361129983727,
+                "99.0" : 1.0171361129983727,
+                "99.9" : 1.0171361129983727,
+                "99.99" : 1.0171361129983727,
+                "99.999" : 1.0171361129983727,
+                "99.9999" : 1.0171361129983727,
+                "100.0" : 1.0171361129983727
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0171361129983727,
+                    1.015474925264013,
+                    1.0164047389978657
+                ],
+                [
+                    1.0009998786908216,
+                    1.00262123839599,
+                    0.9974224376620786
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010961090194796559,
+            "scoreError" : 8.237651497560426E-4,
+            "scoreConfidence" : [
+                0.010137325045040516,
+                0.011784855344552602
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010680357026749345,
+                "50.0" : 0.010940862484301143,
+                "90.0" : 0.01135315994959357,
+                "95.0" : 0.01135315994959357,
+                "99.0" : 0.01135315994959357,
+                "99.9" : 0.01135315994959357,
+                "99.99" : 0.01135315994959357,
+                "99.999" : 0.01135315994959357,
+                "99.9999" : 0.01135315994959357,
+                "100.0" : 0.01135315994959357
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.011166984730727485,
+                    0.011139780578224245,
+                    0.01135315994959357
+                ],
+                [
+                    0.010684314493106662,
+                    0.010680357026749345,
+                    0.010741944390378042
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.2647587451146323,
+            "scoreError" : 0.35750569688399403,
+            "scoreConfidence" : [
+                2.907253048230638,
+                3.6222644419986265
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1126237299315496,
+                "50.0" : 3.2834358671630977,
+                "90.0" : 3.3861413615436695,
+                "95.0" : 3.3861413615436695,
+                "99.0" : 3.3861413615436695,
+                "99.9" : 3.3861413615436695,
+                "99.99" : 3.3861413615436695,
+                "99.999" : 3.3861413615436695,
+                "99.9999" : 3.3861413615436695,
+                "100.0" : 3.3861413615436695
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.3861413615436695,
+                    3.3770511593517893,
+                    3.3727291078894135
+                ],
+                [
+                    3.145864485534591,
+                    3.194142626436782,
+                    3.1126237299315496
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.867370915141183,
+            "scoreError" : 0.048877649248314725,
+            "scoreConfidence" : [
+                2.8184932658928683,
+                2.9162485643894978
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8458564317017645,
+                "50.0" : 2.866705991019252,
+                "90.0" : 2.8939957080439815,
+                "95.0" : 2.8939957080439815,
+                "99.0" : 2.8939957080439815,
+                "99.9" : 2.8939957080439815,
+                "99.99" : 2.8939957080439815,
+                "99.999" : 2.8939957080439815,
+                "99.9999" : 2.8939957080439815,
+                "100.0" : 2.8939957080439815
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8939957080439815,
+                    2.85481410648016,
+                    2.874180342816092
+                ],
+                [
+                    2.8592316392224126,
+                    2.8761472625826863,
+                    2.8458564317017645
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17829893734740687,
+            "scoreError" : 0.0032666736396303004,
+            "scoreConfidence" : [
+                0.17503226370777658,
+                0.18156561098703716
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17708789059871438,
+                "50.0" : 0.1782053154236765,
+                "90.0" : 0.17953954658886895,
+                "95.0" : 0.17953954658886895,
+                "99.0" : 0.17953954658886895,
+                "99.9" : 0.17953954658886895,
+                "99.99" : 0.17953954658886895,
+                "99.999" : 0.17953954658886895,
+                "99.9999" : 0.17953954658886895,
+                "100.0" : 0.17953954658886895
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17906246952442342,
+                    0.17953954658886895,
+                    0.17944551963106517
+                ],
+                [
+                    0.1773481613229296,
+                    0.17708789059871438,
+                    0.1773100364184397
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3316066440328847,
+            "scoreError" : 0.007774087908584133,
+            "scoreConfidence" : [
+                0.32383255612430056,
+                0.33938073194146884
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3293035264752371,
+                "50.0" : 0.33125398150986146,
+                "90.0" : 0.33687680909550277,
+                "95.0" : 0.33687680909550277,
+                "99.0" : 0.33687680909550277,
+                "99.9" : 0.33687680909550277,
+                "99.99" : 0.33687680909550277,
+                "99.999" : 0.33687680909550277,
+                "99.9999" : 0.33687680909550277,
+                "100.0" : 0.33687680909550277
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.32936386697625397,
+                    0.33144173452207343,
+                    0.3293035264752371
+                ],
+                [
+                    0.33687680909550277,
+                    0.3315876986305912,
+                    0.3310662284976495
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14971057862376216,
+            "scoreError" : 0.00360020093862801,
+            "scoreConfidence" : [
+                0.14611037768513416,
+                0.15331077956239017
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1479145431014081,
+                "50.0" : 0.14991588505382678,
+                "90.0" : 0.15117441938897372,
+                "95.0" : 0.15117441938897372,
+                "99.0" : 0.15117441938897372,
+                "99.9" : 0.15117441938897372,
+                "99.99" : 0.15117441938897372,
+                "99.999" : 0.15117441938897372,
+                "99.9999" : 0.15117441938897372,
+                "100.0" : 0.15117441938897372
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14927726697616098,
+                    0.14867891095880229,
+                    0.1479145431014081
+                ],
+                [
+                    0.15066382818573537,
+                    0.15117441938897372,
+                    0.15055450313149257
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40481327451132537,
+            "scoreError" : 0.021360443541835205,
+            "scoreConfidence" : [
+                0.3834528309694902,
+                0.42617371805316057
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.397132926373059,
+                "50.0" : 0.40474369917434505,
+                "90.0" : 0.41289306597853015,
+                "95.0" : 0.41289306597853015,
+                "99.0" : 0.41289306597853015,
+                "99.9" : 0.41289306597853015,
+                "99.99" : 0.41289306597853015,
+                "99.999" : 0.41289306597853015,
+                "99.9999" : 0.41289306597853015,
+                "100.0" : 0.41289306597853015
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3981267195636595,
+                    0.3984257875298805,
+                    0.397132926373059
+                ],
+                [
+                    0.4110616108188096,
+                    0.4112395368040135,
+                    0.41289306597853015
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15679785884161695,
+            "scoreError" : 0.005542392971336362,
+            "scoreConfidence" : [
+                0.1512554658702806,
+                0.1623402518129533
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15487211678617335,
+                "50.0" : 0.1566813993395738,
+                "90.0" : 0.15893112258033756,
+                "95.0" : 0.15893112258033756,
+                "99.0" : 0.15893112258033756,
+                "99.9" : 0.15893112258033756,
+                "99.99" : 0.15893112258033756,
+                "99.999" : 0.15893112258033756,
+                "99.9999" : 0.15893112258033756,
+                "100.0" : 0.15893112258033756
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15861213062855875,
+                    0.1582231688369223,
+                    0.15893112258033756
+                ],
+                [
+                    0.15500898437548438,
+                    0.15487211678617335,
+                    0.1551396298422253
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04826587093774509,
+            "scoreError" : 0.00463506481121175,
+            "scoreConfidence" : [
+                0.04363080612653334,
+                0.052900935748956844
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04657912639967954,
+                "50.0" : 0.04839780349897714,
+                "90.0" : 0.04986000671606071,
+                "95.0" : 0.04986000671606071,
+                "99.0" : 0.04986000671606071,
+                "99.9" : 0.04986000671606071,
+                "99.99" : 0.04986000671606071,
+                "99.999" : 0.04986000671606071,
+                "99.9999" : 0.04986000671606071,
+                "100.0" : 0.04986000671606071
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04986000671606071,
+                    0.049673510540537855,
+                    0.049756603624223184
+                ],
+                [
+                    0.04712209645741643,
+                    0.04660388188855283,
+                    0.04657912639967954
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8736641.137265144,
+            "scoreError" : 173942.2284395344,
+            "scoreConfidence" : [
+                8562698.90882561,
+                8910583.365704678
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8678763.289679099,
+                "50.0" : 8720670.78806911,
+                "90.0" : 8846544.553492485,
+                "95.0" : 8846544.553492485,
+                "99.0" : 8846544.553492485,
+                "99.9" : 8846544.553492485,
+                "99.99" : 8846544.553492485,
+                "99.999" : 8846544.553492485,
+                "99.9999" : 8846544.553492485,
+                "100.0" : 8846544.553492485
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8701597.464347826,
+                    8692172.812337099,
+                    8761024.591943959
+                ],
+                [
+                    8678763.289679099,
+                    8739744.111790393,
+                    8846544.553492485
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-20T00-56-49Z-c225c596f8dbfe590965bef7999943969bb1b24b-jdk17.json
+++ b/performance-results/2026-01-20T00-56-49Z-c225c596f8dbfe590965bef7999943969bb1b24b-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3369919393530347,
+            "scoreError" : 0.0033809284572469825,
+            "scoreConfidence" : [
+                3.3336110108957877,
+                3.3403728678102818
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3364429062995606,
+                "50.0" : 3.3369545026088234,
+                "90.0" : 3.337615845894932,
+                "95.0" : 3.337615845894932,
+                "99.0" : 3.337615845894932,
+                "99.9" : 3.337615845894932,
+                "99.99" : 3.337615845894932,
+                "99.999" : 3.337615845894932,
+                "99.9999" : 3.337615845894932,
+                "100.0" : 3.337615845894932
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3372072105768846,
+                    3.337615845894932
+                ],
+                [
+                    3.3364429062995606,
+                    3.3367017946407618
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6806822548819274,
+            "scoreError" : 0.048329890833271834,
+            "scoreConfidence" : [
+                1.6323523640486555,
+                1.7290121457151992
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6725080867753328,
+                "50.0" : 1.679985903270962,
+                "90.0" : 1.6902491262104522,
+                "95.0" : 1.6902491262104522,
+                "99.0" : 1.6902491262104522,
+                "99.9" : 1.6902491262104522,
+                "99.99" : 1.6902491262104522,
+                "99.999" : 1.6902491262104522,
+                "99.9999" : 1.6902491262104522,
+                "100.0" : 1.6902491262104522
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6725080867753328,
+                    1.682047350848354
+                ],
+                [
+                    1.6779244556935702,
+                    1.6902491262104522
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8496222802316474,
+            "scoreError" : 0.016953272038121973,
+            "scoreConfidence" : [
+                0.8326690081935254,
+                0.8665755522697695
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8468114065959769,
+                "50.0" : 0.8498048292020751,
+                "90.0" : 0.8520680559264627,
+                "95.0" : 0.8520680559264627,
+                "99.0" : 0.8520680559264627,
+                "99.9" : 0.8520680559264627,
+                "99.99" : 0.8520680559264627,
+                "99.999" : 0.8520680559264627,
+                "99.9999" : 0.8520680559264627,
+                "100.0" : 0.8520680559264627
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.85163504383954,
+                    0.8520680559264627
+                ],
+                [
+                    0.8468114065959769,
+                    0.8479746145646102
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.950281285645382,
+            "scoreError" : 0.3649671134921704,
+            "scoreConfidence" : [
+                15.585314172153211,
+                16.315248399137552
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.722623860412615,
+                "50.0" : 15.955752120693477,
+                "90.0" : 16.091051919425244,
+                "95.0" : 16.091051919425244,
+                "99.0" : 16.091051919425244,
+                "99.9" : 16.091051919425244,
+                "99.99" : 16.091051919425244,
+                "99.999" : 16.091051919425244,
+                "99.9999" : 16.091051919425244,
+                "100.0" : 16.091051919425244
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.722623860412615,
+                    15.958330382412356,
+                    16.059299178257632
+                ],
+                [
+                    16.091051919425244,
+                    15.953173858974598,
+                    15.91720851438985
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2695.366495879815,
+            "scoreError" : 103.8552216666639,
+            "scoreConfidence" : [
+                2591.511274213151,
+                2799.221717546479
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2647.2998394347856,
+                "50.0" : 2716.3323115088465,
+                "90.0" : 2722.9724155634867,
+                "95.0" : 2722.9724155634867,
+                "99.0" : 2722.9724155634867,
+                "99.9" : 2722.9724155634867,
+                "99.99" : 2722.9724155634867,
+                "99.999" : 2722.9724155634867,
+                "99.9999" : 2722.9724155634867,
+                "100.0" : 2722.9724155634867
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2721.1515859701217,
+                    2722.9724155634867,
+                    2718.408625188232
+                ],
+                [
+                    2714.255997829461,
+                    2648.110511292804,
+                    2647.2998394347856
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73144.85158798449,
+            "scoreError" : 510.3132651778953,
+            "scoreConfidence" : [
+                72634.53832280659,
+                73655.1648531624
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72848.43636911995,
+                "50.0" : 73129.31728556516,
+                "90.0" : 73389.82789203823,
+                "95.0" : 73389.82789203823,
+                "99.0" : 73389.82789203823,
+                "99.9" : 73389.82789203823,
+                "99.99" : 73389.82789203823,
+                "99.999" : 73389.82789203823,
+                "99.9999" : 73389.82789203823,
+                "100.0" : 73389.82789203823
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73267.67144949266,
+                    73113.18382067769,
+                    72848.43636911995
+                ],
+                [
+                    73389.82789203823,
+                    73104.53924612585,
+                    73145.45075045263
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 353.4334793192758,
+            "scoreError" : 29.4881370080405,
+            "scoreConfidence" : [
+                323.9453423112353,
+                382.9216163273163
+            ],
+            "scorePercentiles" : {
+                "0.0" : 340.7918799592139,
+                "50.0" : 354.29857034272084,
+                "90.0" : 363.91562317865794,
+                "95.0" : 363.91562317865794,
+                "99.0" : 363.91562317865794,
+                "99.9" : 363.91562317865794,
+                "99.99" : 363.91562317865794,
+                "99.999" : 363.91562317865794,
+                "99.9999" : 363.91562317865794,
+                "100.0" : 363.91562317865794
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    340.7918799592139,
+                    347.6279308897773,
+                    343.83393643512125
+                ],
+                [
+                    360.9692097956644,
+                    363.91562317865794,
+                    363.46229565722035
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 113.98572574550523,
+            "scoreError" : 1.801230113152764,
+            "scoreConfidence" : [
+                112.18449563235247,
+                115.786955858658
+            ],
+            "scorePercentiles" : {
+                "0.0" : 113.35123829226846,
+                "50.0" : 113.82036018989943,
+                "90.0" : 114.85077920551134,
+                "95.0" : 114.85077920551134,
+                "99.0" : 114.85077920551134,
+                "99.9" : 114.85077920551134,
+                "99.99" : 114.85077920551134,
+                "99.999" : 114.85077920551134,
+                "99.9999" : 114.85077920551134,
+                "100.0" : 114.85077920551134
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    113.45452232609294,
+                    113.52321450973525,
+                    114.11750587006361
+                ],
+                [
+                    114.61709426935975,
+                    114.85077920551134,
+                    113.35123829226846
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.061741851792983436,
+            "scoreError" : 0.001107718440668761,
+            "scoreConfidence" : [
+                0.06063413335231468,
+                0.0628495702336522
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061197673490119765,
+                "50.0" : 0.06171810835085337,
+                "90.0" : 0.06237356190434609,
+                "95.0" : 0.06237356190434609,
+                "99.0" : 0.06237356190434609,
+                "99.9" : 0.06237356190434609,
+                "99.99" : 0.06237356190434609,
+                "99.999" : 0.06237356190434609,
+                "99.9999" : 0.06237356190434609,
+                "100.0" : 0.06237356190434609
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.061597886550946744,
+                    0.06237356190434609,
+                    0.061197673490119765
+                ],
+                [
+                    0.06155721984820225,
+                    0.061886438813525756,
+                    0.061838330150759985
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.746026166530696E-4,
+            "scoreError" : 6.964555267138393E-5,
+            "scoreConfidence" : [
+                3.049570639816857E-4,
+                4.4424816932445355E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.488262175762017E-4,
+                "50.0" : 3.759946534996611E-4,
+                "90.0" : 4.002206954249069E-4,
+                "95.0" : 4.002206954249069E-4,
+                "99.0" : 4.002206954249069E-4,
+                "99.9" : 4.002206954249069E-4,
+                "99.99" : 4.002206954249069E-4,
+                "99.999" : 4.002206954249069E-4,
+                "99.9999" : 4.002206954249069E-4,
+                "100.0" : 4.002206954249069E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.488262175762017E-4,
+                    3.504094203398765E-4,
+                    3.571644491621685E-4
+                ],
+                [
+                    4.002206954249069E-4,
+                    3.9617005957811013E-4,
+                    3.948248578371538E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2359022187386897,
+            "scoreError" : 0.048000831669903134,
+            "scoreConfidence" : [
+                2.1879013870687865,
+                2.283903050408593
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.200100458864936,
+                "50.0" : 2.2267356756517787,
+                "90.0" : 2.2873675282944466,
+                "95.0" : 2.289163054245823,
+                "99.0" : 2.289163054245823,
+                "99.9" : 2.289163054245823,
+                "99.99" : 2.289163054245823,
+                "99.999" : 2.289163054245823,
+                "99.9999" : 2.289163054245823,
+                "100.0" : 2.289163054245823
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.289163054245823,
+                    2.2659390858631627,
+                    2.252156977482549,
+                    2.218982851342356,
+                    2.200100458864936
+                ],
+                [
+                    2.271207794732062,
+                    2.2218457082870473,
+                    2.2316256430165105,
+                    2.2052889056229326,
+                    2.2027117079295153
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013757111623981843,
+            "scoreError" : 5.870107209998491E-5,
+            "scoreConfidence" : [
+                0.013698410551881857,
+                0.013815812696081828
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013733083765003158,
+                "50.0" : 0.013757003254712899,
+                "90.0" : 0.013779307822679322,
+                "95.0" : 0.013779307822679322,
+                "99.0" : 0.013779307822679322,
+                "99.9" : 0.013779307822679322,
+                "99.99" : 0.013779307822679322,
+                "99.999" : 0.013779307822679322,
+                "99.9999" : 0.013779307822679322,
+                "100.0" : 0.013779307822679322
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013779307822679322,
+                    0.013744387804469075,
+                    0.013733083765003158
+                ],
+                [
+                    0.013778143316533618,
+                    0.013769618704956722,
+                    0.013738128330249165
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.002292983792868,
+            "scoreError" : 0.10762628782566722,
+            "scoreConfidence" : [
+                0.8946666959672008,
+                1.1099192716185353
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9656374685206643,
+                "50.0" : 1.002044171861448,
+                "90.0" : 1.0394805229186155,
+                "95.0" : 1.0394805229186155,
+                "99.0" : 1.0394805229186155,
+                "99.9" : 1.0394805229186155,
+                "99.99" : 1.0394805229186155,
+                "99.999" : 1.0394805229186155,
+                "99.9999" : 1.0394805229186155,
+                "100.0" : 1.0394805229186155
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0394805229186155,
+                    1.0356904092792047,
+                    1.0367325559817542
+                ],
+                [
+                    0.9656374685206643,
+                    0.9678190116132779,
+                    0.9683979344436913
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.011156136117321228,
+            "scoreError" : 0.0012432444353591737,
+            "scoreConfidence" : [
+                0.009912891681962055,
+                0.012399380552680401
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01072778764278297,
+                "50.0" : 0.011127166738874641,
+                "90.0" : 0.011627713230608952,
+                "95.0" : 0.011627713230608952,
+                "99.0" : 0.011627713230608952,
+                "99.9" : 0.011627713230608952,
+                "99.99" : 0.011627713230608952,
+                "99.999" : 0.011627713230608952,
+                "99.9999" : 0.011627713230608952,
+                "100.0" : 0.011627713230608952
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.011578908152206635,
+                    0.011627713230608952,
+                    0.011466292523075159
+                ],
+                [
+                    0.010788040954674123,
+                    0.01072778764278297,
+                    0.010748074200579522
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.141829250583033,
+            "scoreError" : 0.3289447368114643,
+            "scoreConfidence" : [
+                2.812884513771569,
+                3.470773987394497
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0122537156626508,
+                "50.0" : 3.141288800475499,
+                "90.0" : 3.2950389018445323,
+                "95.0" : 3.2950389018445323,
+                "99.0" : 3.2950389018445323,
+                "99.9" : 3.2950389018445323,
+                "99.99" : 3.2950389018445323,
+                "99.999" : 3.2950389018445323,
+                "99.9999" : 3.2950389018445323,
+                "100.0" : 3.2950389018445323
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0328268047301394,
+                    3.073526163491088,
+                    3.0122537156626508
+                ],
+                [
+                    3.20905143745991,
+                    3.228278480309877,
+                    3.2950389018445323
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8418326806771,
+            "scoreError" : 0.17621839879500834,
+            "scoreConfidence" : [
+                2.6656142818820916,
+                3.0180510794721087
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.771659161862528,
+                "50.0" : 2.8427125573620335,
+                "90.0" : 2.904453444541231,
+                "95.0" : 2.904453444541231,
+                "99.0" : 2.904453444541231,
+                "99.9" : 2.904453444541231,
+                "99.99" : 2.904453444541231,
+                "99.999" : 2.904453444541231,
+                "99.9999" : 2.904453444541231,
+                "100.0" : 2.904453444541231
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7993117914917436,
+                    2.771659161862528,
+                    2.785089408521303
+                ],
+                [
+                    2.904453444541231,
+                    2.9043689544134725,
+                    2.886113323232323
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1853932139397514,
+            "scoreError" : 0.021291625586883432,
+            "scoreConfidence" : [
+                0.16410158835286795,
+                0.20668483952663483
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1781711806082634,
+                "50.0" : 0.18534020944035706,
+                "90.0" : 0.19248495746155178,
+                "95.0" : 0.19248495746155178,
+                "99.0" : 0.19248495746155178,
+                "99.9" : 0.19248495746155178,
+                "99.99" : 0.19248495746155178,
+                "99.999" : 0.19248495746155178,
+                "99.9999" : 0.19248495746155178,
+                "100.0" : 0.19248495746155178
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.19248105370135118,
+                    0.19248495746155178,
+                    0.1919966225400787
+                ],
+                [
+                    0.1785416729866281,
+                    0.1786837963406354,
+                    0.1781711806082634
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3316495353985454,
+            "scoreError" : 0.005841730175111878,
+            "scoreConfidence" : [
+                0.32580780522343356,
+                0.3374912655736573
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3289185548612025,
+                "50.0" : 0.33194948428164806,
+                "90.0" : 0.3340316333088383,
+                "95.0" : 0.3340316333088383,
+                "99.0" : 0.3340316333088383,
+                "99.9" : 0.3340316333088383,
+                "99.99" : 0.3340316333088383,
+                "99.999" : 0.3340316333088383,
+                "99.9999" : 0.3340316333088383,
+                "100.0" : 0.3340316333088383
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3340316333088383,
+                    0.3332992072390348,
+                    0.33296248937870415
+                ],
+                [
+                    0.3289185548612025,
+                    0.3297488484189007,
+                    0.33093647918459196
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15059541764140014,
+            "scoreError" : 0.008970325557027835,
+            "scoreConfidence" : [
+                0.1416250920843723,
+                0.15956574319842798
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14756911916005078,
+                "50.0" : 0.15036193262347936,
+                "90.0" : 0.15413548944204686,
+                "95.0" : 0.15413548944204686,
+                "99.0" : 0.15413548944204686,
+                "99.9" : 0.15413548944204686,
+                "99.99" : 0.15413548944204686,
+                "99.999" : 0.15413548944204686,
+                "99.9999" : 0.15413548944204686,
+                "100.0" : 0.15413548944204686
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14781834828238632,
+                    0.14770630570858873,
+                    0.14756911916005078
+                ],
+                [
+                    0.15413548944204686,
+                    0.1529055169645724,
+                    0.15343772629075567
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4058956799740767,
+            "scoreError" : 0.02252564307222086,
+            "scoreConfidence" : [
+                0.38337003690185584,
+                0.4284213230462976
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39841208920318727,
+                "50.0" : 0.40475192698928086,
+                "90.0" : 0.41624334414151926,
+                "95.0" : 0.41624334414151926,
+                "99.0" : 0.41624334414151926,
+                "99.9" : 0.41624334414151926,
+                "99.99" : 0.41624334414151926,
+                "99.999" : 0.41624334414151926,
+                "99.9999" : 0.41624334414151926,
+                "100.0" : 0.41624334414151926
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.39841208920318727,
+                    0.3984122807569721,
+                    0.39959275609366257
+                ],
+                [
+                    0.41624334414151926,
+                    0.4128025117642203,
+                    0.40991109788489916
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16224431239704917,
+            "scoreError" : 0.003993844652780275,
+            "scoreConfidence" : [
+                0.1582504677442689,
+                0.16623815704982944
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15953027402089814,
+                "50.0" : 0.16250023437328742,
+                "90.0" : 0.16342289258399792,
+                "95.0" : 0.16342289258399792,
+                "99.0" : 0.16342289258399792,
+                "99.9" : 0.16342289258399792,
+                "99.99" : 0.16342289258399792,
+                "99.999" : 0.16342289258399792,
+                "99.9999" : 0.16342289258399792,
+                "100.0" : 0.16342289258399792
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16336123796066387,
+                    0.16215100107016037,
+                    0.15953027402089814
+                ],
+                [
+                    0.16342289258399792,
+                    0.16249431831919664,
+                    0.1625061504273782
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.047248611208335546,
+            "scoreError" : 5.186565161471063E-4,
+            "scoreConfidence" : [
+                0.04672995469218844,
+                0.04776726772448265
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04698622593043306,
+                "50.0" : 0.04732804032084406,
+                "90.0" : 0.047454746628387036,
+                "95.0" : 0.047454746628387036,
+                "99.0" : 0.047454746628387036,
+                "99.9" : 0.047454746628387036,
+                "99.99" : 0.047454746628387036,
+                "99.999" : 0.047454746628387036,
+                "99.9999" : 0.047454746628387036,
+                "100.0" : 0.047454746628387036
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.047454746628387036,
+                    0.04698622593043306,
+                    0.0470530496544001
+                ],
+                [
+                    0.04734156439510498,
+                    0.047338206751274564,
+                    0.04731787389041355
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8602617.251060238,
+            "scoreError" : 234301.75046216682,
+            "scoreConfidence" : [
+                8368315.500598071,
+                8836919.001522405
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8498020.231945625,
+                "50.0" : 8599613.922939748,
+                "90.0" : 8715652.056620209,
+                "95.0" : 8715652.056620209,
+                "99.0" : 8715652.056620209,
+                "99.9" : 8715652.056620209,
+                "99.99" : 8715652.056620209,
+                "99.999" : 8715652.056620209,
+                "99.9999" : 8715652.056620209,
+                "100.0" : 8715652.056620209
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8674511.562879445,
+                    8615074.6124031,
+                    8715652.056620209
+                ],
+                [
+                    8498020.231945625,
+                    8528291.809036657,
+                    8584153.233476395
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-20T01-31-43Z-d1798b1881e796ccddc4c8c74425344b70fc303e-jdk17.json
+++ b/performance-results/2026-01-20T01-31-43Z-d1798b1881e796ccddc4c8c74425344b70fc303e-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3565659079948604,
+            "scoreError" : 0.02909729039730961,
+            "scoreConfidence" : [
+                3.327468617597551,
+                3.38566319839217
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3523005806721664,
+                "50.0" : 3.3555995370142275,
+                "90.0" : 3.362763977278821,
+                "95.0" : 3.362763977278821,
+                "99.0" : 3.362763977278821,
+                "99.9" : 3.362763977278821,
+                "99.99" : 3.362763977278821,
+                "99.999" : 3.362763977278821,
+                "99.9999" : 3.362763977278821,
+                "100.0" : 3.362763977278821
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3523005806721664,
+                    3.356683470046411
+                ],
+                [
+                    3.3545156039820436,
+                    3.362763977278821
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6983985834627304,
+            "scoreError" : 0.021957658262445317,
+            "scoreConfidence" : [
+                1.6764409252002852,
+                1.7203562417251757
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6953379554020118,
+                "50.0" : 1.6975192264610817,
+                "90.0" : 1.7032179255267466,
+                "95.0" : 1.7032179255267466,
+                "99.0" : 1.7032179255267466,
+                "99.9" : 1.7032179255267466,
+                "99.99" : 1.7032179255267466,
+                "99.999" : 1.7032179255267466,
+                "99.9999" : 1.7032179255267466,
+                "100.0" : 1.7032179255267466
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6970199269445398,
+                    1.6953379554020118
+                ],
+                [
+                    1.6980185259776235,
+                    1.7032179255267466
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8522633891145884,
+            "scoreError" : 0.01022756799423146,
+            "scoreConfidence" : [
+                0.842035821120357,
+                0.8624909571088198
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.850456399888599,
+                "50.0" : 0.85218260442453,
+                "90.0" : 0.854231947720695,
+                "95.0" : 0.854231947720695,
+                "99.0" : 0.854231947720695,
+                "99.9" : 0.854231947720695,
+                "99.99" : 0.854231947720695,
+                "99.999" : 0.854231947720695,
+                "99.9999" : 0.854231947720695,
+                "100.0" : 0.854231947720695
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8526078063390661,
+                    0.854231947720695
+                ],
+                [
+                    0.850456399888599,
+                    0.8517574025099939
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.57267981083243,
+            "scoreError" : 0.3412133130352387,
+            "scoreConfidence" : [
+                16.23146649779719,
+                16.91389312386767
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.460344026836072,
+                "50.0" : 16.56882225085223,
+                "90.0" : 16.691048751312252,
+                "95.0" : 16.691048751312252,
+                "99.0" : 16.691048751312252,
+                "99.9" : 16.691048751312252,
+                "99.99" : 16.691048751312252,
+                "99.999" : 16.691048751312252,
+                "99.9999" : 16.691048751312252,
+                "100.0" : 16.691048751312252
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.675232362520582,
+                    16.691048751312252,
+                    16.68470110167817
+                ],
+                [
+                    16.462340483463652,
+                    16.462412139183872,
+                    16.460344026836072
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2740.0995449058896,
+            "scoreError" : 398.0235028099149,
+            "scoreConfidence" : [
+                2342.0760420959746,
+                3138.1230477158047
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2607.1456906011585,
+                "50.0" : 2741.5469380266486,
+                "90.0" : 2870.4950448212803,
+                "95.0" : 2870.4950448212803,
+                "99.0" : 2870.4950448212803,
+                "99.9" : 2870.4950448212803,
+                "99.99" : 2870.4950448212803,
+                "99.999" : 2870.4950448212803,
+                "99.9999" : 2870.4950448212803,
+                "100.0" : 2870.4950448212803
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2869.5963254577605,
+                    2868.8721857858905,
+                    2870.4950448212803
+                ],
+                [
+                    2610.26633250184,
+                    2614.2216902674068,
+                    2607.1456906011585
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73774.64415623451,
+            "scoreError" : 399.2155056605129,
+            "scoreConfidence" : [
+                73375.428650574,
+                74173.85966189503
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73620.27603608764,
+                "50.0" : 73752.67834877816,
+                "90.0" : 73960.06722162131,
+                "95.0" : 73960.06722162131,
+                "99.0" : 73960.06722162131,
+                "99.9" : 73960.06722162131,
+                "99.99" : 73960.06722162131,
+                "99.999" : 73960.06722162131,
+                "99.9999" : 73960.06722162131,
+                "100.0" : 73960.06722162131
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73661.36533036416,
+                    73620.27603608764,
+                    73670.78160530236
+                ],
+                [
+                    73900.79965177768,
+                    73960.06722162131,
+                    73834.57509225397
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 364.59281532829914,
+            "scoreError" : 21.776741256960324,
+            "scoreConfidence" : [
+                342.8160740713388,
+                386.3695565852595
+            ],
+            "scorePercentiles" : {
+                "0.0" : 357.4240749057363,
+                "50.0" : 364.350026911476,
+                "90.0" : 372.2182086963774,
+                "95.0" : 372.2182086963774,
+                "99.0" : 372.2182086963774,
+                "99.9" : 372.2182086963774,
+                "99.99" : 372.2182086963774,
+                "99.999" : 372.2182086963774,
+                "99.9999" : 372.2182086963774,
+                "100.0" : 372.2182086963774
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    371.0366230488987,
+                    371.7648259171136,
+                    372.2182086963774
+                ],
+                [
+                    357.4240749057363,
+                    357.4497286276155,
+                    357.6634307740532
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 117.84545203683285,
+            "scoreError" : 2.05641655721366,
+            "scoreConfidence" : [
+                115.78903547961919,
+                119.90186859404652
+            ],
+            "scorePercentiles" : {
+                "0.0" : 117.11030616510163,
+                "50.0" : 117.82113007821332,
+                "90.0" : 118.60251157008942,
+                "95.0" : 118.60251157008942,
+                "99.0" : 118.60251157008942,
+                "99.9" : 118.60251157008942,
+                "99.99" : 118.60251157008942,
+                "99.999" : 118.60251157008942,
+                "99.9999" : 118.60251157008942,
+                "100.0" : 118.60251157008942
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    117.21382409177178,
+                    117.11030616510163,
+                    117.21222506264316
+                ],
+                [
+                    118.60251157008942,
+                    118.42843606465485,
+                    118.50540926673628
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.060051817919277155,
+            "scoreError" : 2.879121864454223E-4,
+            "scoreConfidence" : [
+                0.05976390573283173,
+                0.06033973010572258
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.059949055296113565,
+                "50.0" : 0.060042661667658634,
+                "90.0" : 0.06020653113824369,
+                "95.0" : 0.06020653113824369,
+                "99.0" : 0.06020653113824369,
+                "99.9" : 0.06020653113824369,
+                "99.99" : 0.06020653113824369,
+                "99.999" : 0.06020653113824369,
+                "99.9999" : 0.06020653113824369,
+                "100.0" : 0.06020653113824369
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.059949055296113565,
+                    0.05999261777321839,
+                    0.059956038725111065
+                ],
+                [
+                    0.060092705562098885,
+                    0.06020653113824369,
+                    0.060113959020877294
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.69741313168671E-4,
+            "scoreError" : 4.676508045761453E-5,
+            "scoreConfidence" : [
+                3.2297623271105647E-4,
+                4.165063936262855E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.541745847819058E-4,
+                "50.0" : 3.6982475854119886E-4,
+                "90.0" : 3.853583380770428E-4,
+                "95.0" : 3.853583380770428E-4,
+                "99.0" : 3.853583380770428E-4,
+                "99.9" : 3.853583380770428E-4,
+                "99.99" : 3.853583380770428E-4,
+                "99.999" : 3.853583380770428E-4,
+                "99.9999" : 3.853583380770428E-4,
+                "100.0" : 3.853583380770428E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.541745847819058E-4,
+                    3.5506275296334126E-4,
+                    3.5432739854464936E-4
+                ],
+                [
+                    3.853583380770428E-4,
+                    3.845867641190565E-4,
+                    3.849380405260301E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.22821511281371,
+            "scoreError" : 0.061178614025848926,
+            "scoreConfidence" : [
+                2.167036498787861,
+                2.2893937268395588
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1814519688113414,
+                "50.0" : 2.225911141471128,
+                "90.0" : 2.2978897245927916,
+                "95.0" : 2.301223997468937,
+                "99.0" : 2.301223997468937,
+                "99.9" : 2.301223997468937,
+                "99.99" : 2.301223997468937,
+                "99.999" : 2.301223997468937,
+                "99.9999" : 2.301223997468937,
+                "100.0" : 2.301223997468937
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.260011633446328,
+                    2.301223997468937,
+                    2.246904518535161,
+                    2.19555346388584,
+                    2.194096263931549
+                ],
+                [
+                    2.267881268707483,
+                    2.2228102865081127,
+                    2.229011996434143,
+                    2.1832057304082078,
+                    2.1814519688113414
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.01367544752363349,
+            "scoreError" : 1.2448420019077353E-4,
+            "scoreConfidence" : [
+                0.013550963323442716,
+                0.013799931723824262
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013632492215265196,
+                "50.0" : 0.013671978918183536,
+                "90.0" : 0.013722857945633514,
+                "95.0" : 0.013722857945633514,
+                "99.0" : 0.013722857945633514,
+                "99.9" : 0.013722857945633514,
+                "99.99" : 0.013722857945633514,
+                "99.999" : 0.013722857945633514,
+                "99.9999" : 0.013722857945633514,
+                "100.0" : 0.013722857945633514
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01370715239289704,
+                    0.013722857945633514,
+                    0.01371705545108012
+                ],
+                [
+                    0.013636805443470032,
+                    0.013632492215265196,
+                    0.013636321693455022
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0682878950662047,
+            "scoreError" : 0.12705656689675426,
+            "scoreConfidence" : [
+                0.9412313281694504,
+                1.195344461962959
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0264412951862876,
+                "50.0" : 1.0683711700550145,
+                "90.0" : 1.1100049150943396,
+                "95.0" : 1.1100049150943396,
+                "99.0" : 1.1100049150943396,
+                "99.9" : 1.1100049150943396,
+                "99.99" : 1.1100049150943396,
+                "99.999" : 1.1100049150943396,
+                "99.9999" : 1.1100049150943396,
+                "100.0" : 1.1100049150943396
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.1093996508764146,
+                    1.1100049150943396,
+                    1.10954084444691
+                ],
+                [
+                    1.0269979755596632,
+                    1.0264412951862876,
+                    1.0273426892336142
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010772840796730113,
+            "scoreError" : 9.524080495262931E-5,
+            "scoreConfidence" : [
+                0.010677599991777484,
+                0.010868081601682742
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010738634338375366,
+                "50.0" : 0.010774617574210808,
+                "90.0" : 0.01080508702820913,
+                "95.0" : 0.01080508702820913,
+                "99.0" : 0.01080508702820913,
+                "99.9" : 0.01080508702820913,
+                "99.99" : 0.01080508702820913,
+                "99.999" : 0.01080508702820913,
+                "99.9999" : 0.01080508702820913,
+                "100.0" : 0.01080508702820913
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010740044503584945,
+                    0.010747210844538826,
+                    0.010738634338375366
+                ],
+                [
+                    0.01080508702820913,
+                    0.010802024303882789,
+                    0.010804043761789624
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.924047611814379,
+            "scoreError" : 0.22909547060864535,
+            "scoreConfidence" : [
+                2.6949521412057336,
+                3.1531430824230244
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8493089105413105,
+                "50.0" : 2.920741489146526,
+                "90.0" : 3.011915883804937,
+                "95.0" : 3.011915883804937,
+                "99.0" : 3.011915883804937,
+                "99.9" : 3.011915883804937,
+                "99.99" : 3.011915883804937,
+                "99.999" : 3.011915883804937,
+                "99.9999" : 3.011915883804937,
+                "100.0" : 3.011915883804937
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8493089105413105,
+                    2.849731603988604,
+                    2.8502984854700855
+                ],
+                [
+                    2.991846294258373,
+                    3.011915883804937,
+                    2.9911844928229665
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.670980699059141,
+            "scoreError" : 0.13557167754750615,
+            "scoreConfidence" : [
+                2.5354090215116347,
+                2.806552376606647
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.624018638152716,
+                "50.0" : 2.670392704490415,
+                "90.0" : 2.7189877944535072,
+                "95.0" : 2.7189877944535072,
+                "99.0" : 2.7189877944535072,
+                "99.9" : 2.7189877944535072,
+                "99.99" : 2.7189877944535072,
+                "99.999" : 2.7189877944535072,
+                "99.9999" : 2.7189877944535072,
+                "100.0" : 2.7189877944535072
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.6293500110410095,
+                    2.624018638152716,
+                    2.6274174179143683
+                ],
+                [
+                    2.7189877944535072,
+                    2.711435397939821,
+                    2.71467493485342
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17345344398261675,
+            "scoreError" : 0.00217415691512853,
+            "scoreConfidence" : [
+                0.1712792870674882,
+                0.1756276008977453
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17264134719033233,
+                "50.0" : 0.17345784817281068,
+                "90.0" : 0.17423066994198505,
+                "95.0" : 0.17423066994198505,
+                "99.0" : 0.17423066994198505,
+                "99.9" : 0.17423066994198505,
+                "99.99" : 0.17423066994198505,
+                "99.999" : 0.17423066994198505,
+                "99.9999" : 0.17423066994198505,
+                "100.0" : 0.17423066994198505
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17278665312046443,
+                    0.17281856316317007,
+                    0.17264134719033233
+                ],
+                [
+                    0.17423066994198505,
+                    0.1741462972972973,
+                    0.17409713318245126
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.33356142589434357,
+            "scoreError" : 0.0021426921693738477,
+            "scoreConfidence" : [
+                0.3314187337249697,
+                0.3357041180637174
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.33263058169238957,
+                "50.0" : 0.33347821976195247,
+                "90.0" : 0.334770325488752,
+                "95.0" : 0.334770325488752,
+                "99.0" : 0.334770325488752,
+                "99.9" : 0.334770325488752,
+                "99.99" : 0.334770325488752,
+                "99.999" : 0.334770325488752,
+                "99.9999" : 0.334770325488752,
+                "100.0" : 0.334770325488752
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.33307122355448976,
+                    0.33263058169238957,
+                    0.33316683685367804
+                ],
+                [
+                    0.334770325488752,
+                    0.33378960267022695,
+                    0.33393998510652506
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14493335831148202,
+            "scoreError" : 0.0064117598842357475,
+            "scoreConfidence" : [
+                0.13852159842724626,
+                0.15134511819571778
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14272692212945123,
+                "50.0" : 0.14490842998063175,
+                "90.0" : 0.14709188416732857,
+                "95.0" : 0.14709188416732857,
+                "99.0" : 0.14709188416732857,
+                "99.9" : 0.14709188416732857,
+                "99.99" : 0.14709188416732857,
+                "99.999" : 0.14709188416732857,
+                "99.9999" : 0.14709188416732857,
+                "100.0" : 0.14709188416732857
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14688608560265562,
+                    0.14709188416732857,
+                    0.14707800475048902
+                ],
+                [
+                    0.14272692212945123,
+                    0.1428864788603598,
+                    0.14293077435860788
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40391403845751034,
+            "scoreError" : 0.0069992717103224645,
+            "scoreConfidence" : [
+                0.3969147667471879,
+                0.4109133101678328
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4020319135643644,
+                "50.0" : 0.4028811804480559,
+                "90.0" : 0.40850933639705883,
+                "95.0" : 0.40850933639705883,
+                "99.0" : 0.40850933639705883,
+                "99.9" : 0.40850933639705883,
+                "99.99" : 0.40850933639705883,
+                "99.999" : 0.40850933639705883,
+                "99.9999" : 0.40850933639705883,
+                "100.0" : 0.40850933639705883
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40228275932257934,
+                    0.4020319135643644,
+                    0.4022804038376443
+                ],
+                [
+                    0.40850933639705883,
+                    0.4049002160498826,
+                    0.40347960157353235
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15920476275206996,
+            "scoreError" : 0.0011255251717946432,
+            "scoreConfidence" : [
+                0.1580792375802753,
+                0.1603302879238646
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1586610307001539,
+                "50.0" : 0.1591623762396019,
+                "90.0" : 0.15966652500319325,
+                "95.0" : 0.15966652500319325,
+                "99.0" : 0.15966652500319325,
+                "99.9" : 0.15966652500319325,
+                "99.99" : 0.15966652500319325,
+                "99.999" : 0.15966652500319325,
+                "99.9999" : 0.15966652500319325,
+                "100.0" : 0.15966652500319325
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15963130830380232,
+                    0.15931002647424256,
+                    0.15966652500319325
+                ],
+                [
+                    0.1589449600260665,
+                    0.1590147260049612,
+                    0.1586610307001539
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.047134418008959976,
+            "scoreError" : 7.722438433165226E-4,
+            "scoreConfidence" : [
+                0.046362174165643456,
+                0.047906661852276496
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04695285000680806,
+                "50.0" : 0.04697503236315342,
+                "90.0" : 0.04760471325202555,
+                "95.0" : 0.04760471325202555,
+                "99.0" : 0.04760471325202555,
+                "99.9" : 0.04760471325202555,
+                "99.99" : 0.04760471325202555,
+                "99.999" : 0.04760471325202555,
+                "99.9999" : 0.04760471325202555,
+                "100.0" : 0.04760471325202555
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04760471325202555,
+                    0.04734132461949961,
+                    0.046966248640347166
+                ],
+                [
+                    0.04698381608595967,
+                    0.04695285000680806,
+                    0.046957555449119795
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8533704.928964783,
+            "scoreError" : 51180.49194204957,
+            "scoreConfidence" : [
+                8482524.437022733,
+                8584885.420906832
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8513408.293617021,
+                "50.0" : 8533399.248732865,
+                "90.0" : 8553357.033333333,
+                "95.0" : 8553357.033333333,
+                "99.0" : 8553357.033333333,
+                "99.9" : 8553357.033333333,
+                "99.99" : 8553357.033333333,
+                "99.999" : 8553357.033333333,
+                "99.9999" : 8553357.033333333,
+                "100.0" : 8553357.033333333
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8524858.155877342,
+                    8515352.046808511,
+                    8513408.293617021
+                ],
+                [
+                    8553357.033333333,
+                    8553313.702564102,
+                    8541940.341588385
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-20T01-57-49Z-e5f21b8ffcc3417c007349f4fc5f5ac948c58175-jdk17.json
+++ b/performance-results/2026-01-20T01-57-49Z-e5f21b8ffcc3417c007349f4fc5f5ac948c58175-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.343681316664281,
+            "scoreError" : 0.03366635817545138,
+            "scoreConfidence" : [
+                3.31001495848883,
+                3.3773476748397324
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3382498956703386,
+                "50.0" : 3.344149027511724,
+                "90.0" : 3.3481773159633392,
+                "95.0" : 3.3481773159633392,
+                "99.0" : 3.3481773159633392,
+                "99.9" : 3.3481773159633392,
+                "99.99" : 3.3481773159633392,
+                "99.999" : 3.3481773159633392,
+                "99.9999" : 3.3481773159633392,
+                "100.0" : 3.3481773159633392
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3382498956703386,
+                    3.348103614536168
+                ],
+                [
+                    3.34019444048728,
+                    3.3481773159633392
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.681403118287457,
+            "scoreError" : 0.02917549286944803,
+            "scoreConfidence" : [
+                1.6522276254180088,
+                1.710578611156905
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6767672090363033,
+                "50.0" : 1.6810445788783244,
+                "90.0" : 1.6867561063568763,
+                "95.0" : 1.6867561063568763,
+                "99.0" : 1.6867561063568763,
+                "99.9" : 1.6867561063568763,
+                "99.99" : 1.6867561063568763,
+                "99.999" : 1.6867561063568763,
+                "99.9999" : 1.6867561063568763,
+                "100.0" : 1.6867561063568763
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.67872608715123,
+                    1.6767672090363033
+                ],
+                [
+                    1.6833630706054186,
+                    1.6867561063568763
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8489326622674713,
+            "scoreError" : 0.010777876616621279,
+            "scoreConfidence" : [
+                0.83815478565085,
+                0.8597105388840927
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.847015090207117,
+                "50.0" : 0.8488850620556458,
+                "90.0" : 0.850945434751477,
+                "95.0" : 0.850945434751477,
+                "99.0" : 0.850945434751477,
+                "99.9" : 0.850945434751477,
+                "99.99" : 0.850945434751477,
+                "99.999" : 0.850945434751477,
+                "99.9999" : 0.850945434751477,
+                "100.0" : 0.850945434751477
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8494385452409313,
+                    0.850945434751477
+                ],
+                [
+                    0.847015090207117,
+                    0.8483315788703603
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.244514871758437,
+            "scoreError" : 0.26537238439870275,
+            "scoreConfidence" : [
+                15.979142487359734,
+                16.50988725615714
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.165235472086735,
+                "50.0" : 16.20213259992698,
+                "90.0" : 16.402387117716927,
+                "95.0" : 16.402387117716927,
+                "99.0" : 16.402387117716927,
+                "99.9" : 16.402387117716927,
+                "99.99" : 16.402387117716927,
+                "99.999" : 16.402387117716927,
+                "99.9999" : 16.402387117716927,
+                "100.0" : 16.402387117716927
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.165235472086735,
+                    16.22373163352081,
+                    16.180426189973886
+                ],
+                [
+                    16.402387117716927,
+                    16.18053356633315,
+                    16.314775250919098
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2657.1139078918154,
+            "scoreError" : 227.25167433415993,
+            "scoreConfidence" : [
+                2429.8622335576556,
+                2884.3655822259752
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2571.9686294445173,
+                "50.0" : 2657.2707620782453,
+                "90.0" : 2742.2035929121594,
+                "95.0" : 2742.2035929121594,
+                "99.0" : 2742.2035929121594,
+                "99.9" : 2742.2035929121594,
+                "99.99" : 2742.2035929121594,
+                "99.999" : 2742.2035929121594,
+                "99.9999" : 2742.2035929121594,
+                "100.0" : 2742.2035929121594
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2571.9686294445173,
+                    2587.6509485840193,
+                    2591.190950356463
+                ],
+                [
+                    2726.3187522537064,
+                    2742.2035929121594,
+                    2723.3505738000276
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73117.94957238623,
+            "scoreError" : 1360.6647655287818,
+            "scoreConfidence" : [
+                71757.28480685745,
+                74478.61433791502
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72542.3761369032,
+                "50.0" : 73222.65545228215,
+                "90.0" : 73683.38920389857,
+                "95.0" : 73683.38920389857,
+                "99.0" : 73683.38920389857,
+                "99.9" : 73683.38920389857,
+                "99.99" : 73683.38920389857,
+                "99.999" : 73683.38920389857,
+                "99.9999" : 73683.38920389857,
+                "100.0" : 73683.38920389857
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73032.60506221472,
+                    72542.3761369032,
+                    72564.33119361423
+                ],
+                [
+                    73683.38920389857,
+                    73472.28999533721,
+                    73412.70584234959
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 348.18239891407296,
+            "scoreError" : 6.513369768186732,
+            "scoreConfidence" : [
+                341.6690291458862,
+                354.6957686822597
+            ],
+            "scorePercentiles" : {
+                "0.0" : 344.747394512425,
+                "50.0" : 348.5011456297,
+                "90.0" : 350.5372297189189,
+                "95.0" : 350.5372297189189,
+                "99.0" : 350.5372297189189,
+                "99.9" : 350.5372297189189,
+                "99.99" : 350.5372297189189,
+                "99.999" : 350.5372297189189,
+                "99.9999" : 350.5372297189189,
+                "100.0" : 350.5372297189189
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    350.4735309772359,
+                    347.8840395673023,
+                    349.11825169209766
+                ],
+                [
+                    344.747394512425,
+                    346.33394701645807,
+                    350.5372297189189
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 113.76428405719787,
+            "scoreError" : 2.454248882196933,
+            "scoreConfidence" : [
+                111.31003517500093,
+                116.2185329393948
+            ],
+            "scorePercentiles" : {
+                "0.0" : 112.34707346221256,
+                "50.0" : 113.86168208629063,
+                "90.0" : 114.62957238167274,
+                "95.0" : 114.62957238167274,
+                "99.0" : 114.62957238167274,
+                "99.9" : 114.62957238167274,
+                "99.99" : 114.62957238167274,
+                "99.999" : 114.62957238167274,
+                "99.9999" : 114.62957238167274,
+                "100.0" : 114.62957238167274
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    114.62957238167274,
+                    113.27030700456497,
+                    114.61538732215563
+                ],
+                [
+                    112.34707346221256,
+                    114.06829713505921,
+                    113.65506703752204
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.061974553290733696,
+            "scoreError" : 0.0010583112973518779,
+            "scoreConfidence" : [
+                0.06091624199338182,
+                0.06303286458808557
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06157606767116371,
+                "50.0" : 0.061920013345203403,
+                "90.0" : 0.06262406605504588,
+                "95.0" : 0.06262406605504588,
+                "99.0" : 0.06262406605504588,
+                "99.9" : 0.06262406605504588,
+                "99.99" : 0.06262406605504588,
+                "99.999" : 0.06262406605504588,
+                "99.9999" : 0.06262406605504588,
+                "100.0" : 0.06262406605504588
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0616751922759063,
+                    0.061994732714637305,
+                    0.06262406605504588
+                ],
+                [
+                    0.06157606767116371,
+                    0.061845293975769496,
+                    0.06213196705187946
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.593894396718362E-4,
+            "scoreError" : 2.379124908127924E-5,
+            "scoreConfidence" : [
+                3.3559819059055695E-4,
+                3.8318068875311547E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.474444026520309E-4,
+                "50.0" : 3.602595978970368E-4,
+                "90.0" : 3.7024588460034995E-4,
+                "95.0" : 3.7024588460034995E-4,
+                "99.0" : 3.7024588460034995E-4,
+                "99.9" : 3.7024588460034995E-4,
+                "99.99" : 3.7024588460034995E-4,
+                "99.999" : 3.7024588460034995E-4,
+                "99.9999" : 3.7024588460034995E-4,
+                "100.0" : 3.7024588460034995E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.5229989272247915E-4,
+                    3.5850754349494375E-4,
+                    3.474444026520309E-4
+                ],
+                [
+                    3.7024588460034995E-4,
+                    3.6582726226208357E-4,
+                    3.620116522991299E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.231634409319813,
+            "scoreError" : 0.05552467630962116,
+            "scoreConfidence" : [
+                2.1761097330101915,
+                2.287159085629434
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1721275173761945,
+                "50.0" : 2.2338177911229495,
+                "90.0" : 2.277017942549553,
+                "95.0" : 2.2774626969489984,
+                "99.0" : 2.2774626969489984,
+                "99.9" : 2.2774626969489984,
+                "99.99" : 2.2774626969489984,
+                "99.999" : 2.2774626969489984,
+                "99.9999" : 2.2774626969489984,
+                "100.0" : 2.2774626969489984
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.271019267938238,
+                    2.250574190369037,
+                    2.2730151529545455,
+                    2.1988921383025506,
+                    2.2264992219501334
+                ],
+                [
+                    2.2774626969489984,
+                    2.206357202735495,
+                    2.2411363602957652,
+                    2.1721275173761945,
+                    2.1992603443271768
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013727537820739285,
+            "scoreError" : 1.1383384944390988E-4,
+            "scoreConfidence" : [
+                0.013613703971295375,
+                0.013841371670183195
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013663236406189798,
+                "50.0" : 0.013736264440926288,
+                "90.0" : 0.013769541556569285,
+                "95.0" : 0.013769541556569285,
+                "99.0" : 0.013769541556569285,
+                "99.9" : 0.013769541556569285,
+                "99.99" : 0.013769541556569285,
+                "99.999" : 0.013769541556569285,
+                "99.9999" : 0.013769541556569285,
+                "100.0" : 0.013769541556569285
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01372804211624523,
+                    0.013761907054546055,
+                    0.013663236406189798
+                ],
+                [
+                    0.013698013025277997,
+                    0.013744486765607347,
+                    0.013769541556569285
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0433036747938573,
+            "scoreError" : 0.12381456518019265,
+            "scoreConfidence" : [
+                0.9194891096136647,
+                1.16711823997405
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9987403171876561,
+                "50.0" : 1.0443964958413448,
+                "90.0" : 1.0877230820100066,
+                "95.0" : 1.0877230820100066,
+                "99.0" : 1.0877230820100066,
+                "99.9" : 1.0877230820100066,
+                "99.99" : 1.0877230820100066,
+                "99.999" : 1.0877230820100066,
+                "99.9999" : 1.0877230820100066,
+                "100.0" : 1.0877230820100066
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0877230820100066,
+                    1.0820595450119022,
+                    1.08058917093463
+                ],
+                [
+                    1.0082038207480593,
+                    1.00250611287089,
+                    0.9987403171876561
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.011067481434658364,
+            "scoreError" : 0.0010045717532844096,
+            "scoreConfidence" : [
+                0.010062909681373954,
+                0.012072053187942773
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010666412289477895,
+                "50.0" : 0.011092602718226735,
+                "90.0" : 0.011463613771109694,
+                "95.0" : 0.011463613771109694,
+                "99.0" : 0.011463613771109694,
+                "99.9" : 0.011463613771109694,
+                "99.99" : 0.011463613771109694,
+                "99.999" : 0.011463613771109694,
+                "99.9999" : 0.011463613771109694,
+                "100.0" : 0.011463613771109694
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010666412289477895,
+                    0.010701097736991015,
+                    0.01088606959944613
+                ],
+                [
+                    0.011463613771109694,
+                    0.011299135837007342,
+                    0.011388559373918113
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1794783242605202,
+            "scoreError" : 0.46449276506536996,
+            "scoreConfidence" : [
+                2.71498555919515,
+                3.6439710893258903
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9920917093301433,
+                "50.0" : 3.15866873475614,
+                "90.0" : 3.3785147574324323,
+                "95.0" : 3.3785147574324323,
+                "99.0" : 3.3785147574324323,
+                "99.9" : 3.3785147574324323,
+                "99.99" : 3.3785147574324323,
+                "99.999" : 3.3785147574324323,
+                "99.9999" : 3.3785147574324323,
+                "100.0" : 3.3785147574324323
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.343074652406417,
+                    3.3785147574324323,
+                    3.250788486679662
+                ],
+                [
+                    2.9920917093301433,
+                    3.066548982832618,
+                    3.0458513568818515
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8253320033799016,
+            "scoreError" : 0.10349404955788573,
+            "scoreConfidence" : [
+                2.721837953822016,
+                2.9288260529377874
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.784068478563474,
+                "50.0" : 2.8187945360565703,
+                "90.0" : 2.871499109675567,
+                "95.0" : 2.871499109675567,
+                "99.0" : 2.871499109675567,
+                "99.9" : 2.871499109675567,
+                "99.99" : 2.871499109675567,
+                "99.999" : 2.871499109675567,
+                "99.9999" : 2.871499109675567,
+                "100.0" : 2.871499109675567
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8183311425753734,
+                    2.784068478563474,
+                    2.791620511303377
+                ],
+                [
+                    2.871499109675567,
+                    2.867214848623853,
+                    2.8192579295377675
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17894751713859036,
+            "scoreError" : 0.004078007421958699,
+            "scoreConfidence" : [
+                0.17486950971663168,
+                0.18302552456054905
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17805103603667766,
+                "50.0" : 0.178403062769233,
+                "90.0" : 0.18188955920119312,
+                "95.0" : 0.18188955920119312,
+                "99.0" : 0.18188955920119312,
+                "99.9" : 0.18188955920119312,
+                "99.99" : 0.18188955920119312,
+                "99.999" : 0.18188955920119312,
+                "99.9999" : 0.18188955920119312,
+                "100.0" : 0.18188955920119312
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17829642139138496,
+                    0.17845241747711416,
+                    0.17864196066382035
+                ],
+                [
+                    0.18188955920119312,
+                    0.17835370806135187,
+                    0.17805103603667766
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3299937939867755,
+            "scoreError" : 0.009487029240661618,
+            "scoreConfidence" : [
+                0.32050676474611384,
+                0.3394808232274371
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3268440069941497,
+                "50.0" : 0.32944595238269336,
+                "90.0" : 0.33563517439167645,
+                "95.0" : 0.33563517439167645,
+                "99.0" : 0.33563517439167645,
+                "99.9" : 0.33563517439167645,
+                "99.99" : 0.33563517439167645,
+                "99.999" : 0.33563517439167645,
+                "99.9999" : 0.33563517439167645,
+                "100.0" : 0.33563517439167645
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.32720114236167913,
+                    0.3278439723633741,
+                    0.3268440069941497
+                ],
+                [
+                    0.33563517439167645,
+                    0.33139053540776087,
+                    0.3310479324020127
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14675644979148228,
+            "scoreError" : 0.0031190866118823084,
+            "scoreConfidence" : [
+                0.14363736317959996,
+                0.1498755364033646
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14588477239638797,
+                "50.0" : 0.14645894567750023,
+                "90.0" : 0.1489643237949115,
+                "95.0" : 0.1489643237949115,
+                "99.0" : 0.1489643237949115,
+                "99.9" : 0.1489643237949115,
+                "99.99" : 0.1489643237949115,
+                "99.999" : 0.1489643237949115,
+                "99.9999" : 0.1489643237949115,
+                "100.0" : 0.1489643237949115
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1489643237949115,
+                    0.14588477239638797,
+                    0.1465095578850211
+                ],
+                [
+                    0.14660341692932433,
+                    0.14640833346997936,
+                    0.1461682942732694
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40504695650034833,
+            "scoreError" : 0.006408741889734182,
+            "scoreConfidence" : [
+                0.39863821461061416,
+                0.4114556983900825
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4025488224449543,
+                "50.0" : 0.4050338583891334,
+                "90.0" : 0.40893433878552443,
+                "95.0" : 0.40893433878552443,
+                "99.0" : 0.40893433878552443,
+                "99.9" : 0.40893433878552443,
+                "99.99" : 0.40893433878552443,
+                "99.999" : 0.40893433878552443,
+                "99.9999" : 0.40893433878552443,
+                "100.0" : 0.40893433878552443
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4056486385024135,
+                    0.40308222249093106,
+                    0.4025488224449543
+                ],
+                [
+                    0.40893433878552443,
+                    0.40451388564841034,
+                    0.40555383112985643
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15748155331733885,
+            "scoreError" : 0.0018437403397564068,
+            "scoreConfidence" : [
+                0.15563781297758245,
+                0.15932529365709525
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15649936113241208,
+                "50.0" : 0.15753467187218761,
+                "90.0" : 0.15833836359606068,
+                "95.0" : 0.15833836359606068,
+                "99.0" : 0.15833836359606068,
+                "99.9" : 0.15833836359606068,
+                "99.99" : 0.15833836359606068,
+                "99.999" : 0.15833836359606068,
+                "99.9999" : 0.15833836359606068,
+                "100.0" : 0.15833836359606068
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15706504334919663,
+                    0.15649936113241208,
+                    0.1573181563232495
+                ],
+                [
+                    0.15833836359606068,
+                    0.1577511874211257,
+                    0.15791720808198845
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04736742684261397,
+            "scoreError" : 0.002276718799384987,
+            "scoreConfidence" : [
+                0.04509070804322898,
+                0.049644145641998955
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04662741623731169,
+                "50.0" : 0.04729379364500512,
+                "90.0" : 0.04840267978199736,
+                "95.0" : 0.04840267978199736,
+                "99.0" : 0.04840267978199736,
+                "99.9" : 0.04840267978199736,
+                "99.99" : 0.04840267978199736,
+                "99.999" : 0.04840267978199736,
+                "99.9999" : 0.04840267978199736,
+                "100.0" : 0.04840267978199736
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04662741623731169,
+                    0.04667224145092713,
+                    0.04662932437284342
+                ],
+                [
+                    0.04840267978199736,
+                    0.04791534583908311,
+                    0.04795755337352113
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8715278.344356546,
+            "scoreError" : 268967.2857934212,
+            "scoreConfidence" : [
+                8446311.058563124,
+                8984245.630149968
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8578997.613207547,
+                "50.0" : 8733380.771417294,
+                "90.0" : 8831115.071491616,
+                "95.0" : 8831115.071491616,
+                "99.0" : 8831115.071491616,
+                "99.9" : 8831115.071491616,
+                "99.99" : 8831115.071491616,
+                "99.999" : 8831115.071491616,
+                "99.9999" : 8831115.071491616,
+                "100.0" : 8831115.071491616
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8831115.071491616,
+                    8753289.434820648,
+                    8786254.797190517
+                ],
+                [
+                    8713472.108013937,
+                    8628541.041415013,
+                    8578997.613207547
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-22T00-19-02Z-1a802055029550ad1e8a2ad48fb72e56f2e7a987-jdk17.json
+++ b/performance-results/2026-01-22T00-19-02Z-1a802055029550ad1e8a2ad48fb72e56f2e7a987-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3278737927286803,
+            "scoreError" : 0.020648334962655054,
+            "scoreConfidence" : [
+                3.3072254577660254,
+                3.3485221276913353
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3240632960894203,
+                "50.0" : 3.327915335830242,
+                "90.0" : 3.3316012031648166,
+                "95.0" : 3.3316012031648166,
+                "99.0" : 3.3316012031648166,
+                "99.9" : 3.3316012031648166,
+                "99.99" : 3.3316012031648166,
+                "99.999" : 3.3316012031648166,
+                "99.9999" : 3.3316012031648166,
+                "100.0" : 3.3316012031648166
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3240632960894203,
+                    3.3316012031648166
+                ],
+                [
+                    3.3268632161557585,
+                    3.328967455504725
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6823278675702384,
+            "scoreError" : 0.05851371302688093,
+            "scoreConfidence" : [
+                1.6238141545433575,
+                1.7408415805971194
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6712520057523574,
+                "50.0" : 1.6839940339892085,
+                "90.0" : 1.6900713965501784,
+                "95.0" : 1.6900713965501784,
+                "99.0" : 1.6900713965501784,
+                "99.9" : 1.6900713965501784,
+                "99.99" : 1.6900713965501784,
+                "99.999" : 1.6900713965501784,
+                "99.9999" : 1.6900713965501784,
+                "100.0" : 1.6900713965501784
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6900713965501784,
+                    1.6893695925095416
+                ],
+                [
+                    1.6712520057523574,
+                    1.6786184754688758
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8444237896018283,
+            "scoreError" : 0.031602450231014365,
+            "scoreConfidence" : [
+                0.8128213393708139,
+                0.8760262398328427
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8412240865354095,
+                "50.0" : 0.8423803555628786,
+                "90.0" : 0.8517103607461468,
+                "95.0" : 0.8517103607461468,
+                "99.0" : 0.8517103607461468,
+                "99.9" : 0.8517103607461468,
+                "99.99" : 0.8517103607461468,
+                "99.999" : 0.8517103607461468,
+                "99.9999" : 0.8517103607461468,
+                "100.0" : 0.8517103607461468
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8421960704521537,
+                    0.8517103607461468
+                ],
+                [
+                    0.8412240865354095,
+                    0.8425646406736034
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.894980804573613,
+            "scoreError" : 0.1910160123090207,
+            "scoreConfidence" : [
+                15.703964792264593,
+                16.085996816882634
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.824195309444478,
+                "50.0" : 15.87713952022369,
+                "90.0" : 16.011491586419766,
+                "95.0" : 16.011491586419766,
+                "99.0" : 16.011491586419766,
+                "99.9" : 16.011491586419766,
+                "99.99" : 16.011491586419766,
+                "99.999" : 16.011491586419766,
+                "99.9999" : 16.011491586419766,
+                "100.0" : 16.011491586419766
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.896712032507914,
+                    16.011491586419766,
+                    15.857567007939465
+                ],
+                [
+                    15.929720266806703,
+                    15.824195309444478,
+                    15.850198624323356
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2636.994120342664,
+            "scoreError" : 73.58903325224918,
+            "scoreConfidence" : [
+                2563.405087090415,
+                2710.583153594913
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2590.197071554095,
+                "50.0" : 2639.1009762651647,
+                "90.0" : 2662.600889155975,
+                "95.0" : 2662.600889155975,
+                "99.0" : 2662.600889155975,
+                "99.9" : 2662.600889155975,
+                "99.99" : 2662.600889155975,
+                "99.999" : 2662.600889155975,
+                "99.9999" : 2662.600889155975,
+                "100.0" : 2662.600889155975
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2660.2675857915756,
+                    2637.1636956231914,
+                    2662.600889155975
+                ],
+                [
+                    2590.197071554095,
+                    2641.0382569071385,
+                    2630.6972230240085
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73393.18702430766,
+            "scoreError" : 3922.8815061748555,
+            "scoreConfidence" : [
+                69470.3055181328,
+                77316.06853048252
+            ],
+            "scorePercentiles" : {
+                "0.0" : 71801.05216233437,
+                "50.0" : 73405.33496252401,
+                "90.0" : 74947.83598975647,
+                "95.0" : 74947.83598975647,
+                "99.0" : 74947.83598975647,
+                "99.9" : 74947.83598975647,
+                "99.99" : 74947.83598975647,
+                "99.999" : 74947.83598975647,
+                "99.9999" : 74947.83598975647,
+                "100.0" : 74947.83598975647
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72322.61906710619,
+                    72284.35118663516,
+                    71801.05216233437
+                ],
+                [
+                    74488.05085794181,
+                    74515.21288207191,
+                    74947.83598975647
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 352.56552515004927,
+            "scoreError" : 6.844508130790971,
+            "scoreConfidence" : [
+                345.7210170192583,
+                359.41003328084025
+            ],
+            "scorePercentiles" : {
+                "0.0" : 348.0871444455813,
+                "50.0" : 353.6281124753715,
+                "90.0" : 354.5160577941903,
+                "95.0" : 354.5160577941903,
+                "99.0" : 354.5160577941903,
+                "99.9" : 354.5160577941903,
+                "99.99" : 354.5160577941903,
+                "99.999" : 354.5160577941903,
+                "99.9999" : 354.5160577941903,
+                "100.0" : 354.5160577941903
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    348.0871444455813,
+                    354.5160577941903,
+                    354.0976520749712
+                ],
+                [
+                    353.78012894847325,
+                    353.4760960022698,
+                    351.4360716348096
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 106.65268324897222,
+            "scoreError" : 8.293977926670063,
+            "scoreConfidence" : [
+                98.35870532230216,
+                114.94666117564229
+            ],
+            "scorePercentiles" : {
+                "0.0" : 101.45381629519991,
+                "50.0" : 107.26071145438675,
+                "90.0" : 110.53144184525307,
+                "95.0" : 110.53144184525307,
+                "99.0" : 110.53144184525307,
+                "99.9" : 110.53144184525307,
+                "99.99" : 110.53144184525307,
+                "99.999" : 110.53144184525307,
+                "99.9999" : 110.53144184525307,
+                "100.0" : 110.53144184525307
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    106.02640789728447,
+                    107.22655940358561,
+                    107.29486350518788
+                ],
+                [
+                    101.45381629519991,
+                    107.38301054732247,
+                    110.53144184525307
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.062241418592269025,
+            "scoreError" : 7.268727237538457E-4,
+            "scoreConfidence" : [
+                0.06151454586851518,
+                0.06296829131602287
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061886966315359525,
+                "50.0" : 0.062237891148284555,
+                "90.0" : 0.06258389530502917,
+                "95.0" : 0.06258389530502917,
+                "99.0" : 0.06258389530502917,
+                "99.9" : 0.06258389530502917,
+                "99.99" : 0.06258389530502917,
+                "99.999" : 0.06258389530502917,
+                "99.9999" : 0.06258389530502917,
+                "100.0" : 0.06258389530502917
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.062036179765383156,
+                    0.061886966315359525,
+                    0.06258389530502917
+                ],
+                [
+                    0.06246568787127321,
+                    0.062220900634644104,
+                    0.062254881661925006
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.756576631961574E-4,
+            "scoreError" : 8.15343595691419E-6,
+            "scoreConfidence" : [
+                3.675042272392432E-4,
+                3.8381109915307157E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.721372590297141E-4,
+                "50.0" : 3.750516763523352E-4,
+                "90.0" : 3.792418460047185E-4,
+                "95.0" : 3.792418460047185E-4,
+                "99.0" : 3.792418460047185E-4,
+                "99.9" : 3.792418460047185E-4,
+                "99.99" : 3.792418460047185E-4,
+                "99.999" : 3.792418460047185E-4,
+                "99.9999" : 3.792418460047185E-4,
+                "100.0" : 3.792418460047185E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.753535669742947E-4,
+                    3.792418460047185E-4,
+                    3.790115992787347E-4
+                ],
+                [
+                    3.7474978573037563E-4,
+                    3.7345192215910647E-4,
+                    3.721372590297141E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.3115979649933815,
+            "scoreError" : 0.05659675878307261,
+            "scoreConfidence" : [
+                2.255001206210309,
+                2.3681947237764542
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2616408760741744,
+                "50.0" : 2.3111724450214535,
+                "90.0" : 2.3822095953017883,
+                "95.0" : 2.386553276306371,
+                "99.0" : 2.386553276306371,
+                "99.9" : 2.386553276306371,
+                "99.99" : 2.386553276306371,
+                "99.999" : 2.386553276306371,
+                "99.9999" : 2.386553276306371,
+                "100.0" : 2.386553276306371
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.386553276306371,
+                    2.3296137074307013,
+                    2.3431164662605437,
+                    2.2881355573095403,
+                    2.3047422277022354
+                ],
+                [
+                    2.317602662340672,
+                    2.29574781932966,
+                    2.32361294098513,
+                    2.2616408760741744,
+                    2.2652141161947905
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013634890372955413,
+            "scoreError" : 1.455764887692496E-4,
+            "scoreConfidence" : [
+                0.013489313884186165,
+                0.013780466861724662
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013573017181822748,
+                "50.0" : 0.013643683636652795,
+                "90.0" : 0.01370201364836517,
+                "95.0" : 0.01370201364836517,
+                "99.0" : 0.01370201364836517,
+                "99.9" : 0.01370201364836517,
+                "99.99" : 0.01370201364836517,
+                "99.999" : 0.01370201364836517,
+                "99.9999" : 0.01370201364836517,
+                "100.0" : 0.01370201364836517
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013670960089461726,
+                    0.01370201364836517,
+                    0.013654072498061148
+                ],
+                [
+                    0.013633294775244442,
+                    0.013573017181822748,
+                    0.013575984044777254
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0237968678686071,
+            "scoreError" : 0.030270888971530945,
+            "scoreConfidence" : [
+                0.9935259788970762,
+                1.054067756840138
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0127419270886076,
+                "50.0" : 1.0227455085705066,
+                "90.0" : 1.038022842760768,
+                "95.0" : 1.038022842760768,
+                "99.0" : 1.038022842760768,
+                "99.9" : 1.038022842760768,
+                "99.99" : 1.038022842760768,
+                "99.999" : 1.038022842760768,
+                "99.9999" : 1.038022842760768,
+                "100.0" : 1.038022842760768
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0315310027849407,
+                    1.0304444549201444,
+                    1.038022842760768
+                ],
+                [
+                    1.0150465622208689,
+                    1.014994417436314,
+                    1.0127419270886076
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010869365910428868,
+            "scoreError" : 4.7112138725483233E-4,
+            "scoreConfidence" : [
+                0.010398244523174036,
+                0.0113404872976837
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010686985534474246,
+                "50.0" : 0.010852915030916033,
+                "90.0" : 0.011058198834056518,
+                "95.0" : 0.011058198834056518,
+                "99.0" : 0.011058198834056518,
+                "99.9" : 0.011058198834056518,
+                "99.99" : 0.011058198834056518,
+                "99.999" : 0.011058198834056518,
+                "99.9999" : 0.011058198834056518,
+                "100.0" : 0.011058198834056518
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.011058198834056518,
+                    0.011057954745397247,
+                    0.010922965193703279
+                ],
+                [
+                    0.010707226286813124,
+                    0.010686985534474246,
+                    0.010782864868128787
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.2529122989912573,
+            "scoreError" : 0.35986502900414824,
+            "scoreConfidence" : [
+                2.8930472699871093,
+                3.6127773279954054
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1189870860349127,
+                "50.0" : 3.2435463907718964,
+                "90.0" : 3.4264540287671235,
+                "95.0" : 3.4264540287671235,
+                "99.0" : 3.4264540287671235,
+                "99.9" : 3.4264540287671235,
+                "99.99" : 3.4264540287671235,
+                "99.999" : 3.4264540287671235,
+                "99.9999" : 3.4264540287671235,
+                "100.0" : 3.4264540287671235
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.3555035922199865,
+                    3.4264540287671235,
+                    3.308142169973545
+                ],
+                [
+                    3.1789506115702477,
+                    3.129436305381727,
+                    3.1189870860349127
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7840666864167463,
+            "scoreError" : 0.033309454647409246,
+            "scoreConfidence" : [
+                2.750757231769337,
+                2.8173761410641553
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7661257829092922,
+                "50.0" : 2.7868612138215054,
+                "90.0" : 2.797196886185682,
+                "95.0" : 2.797196886185682,
+                "99.0" : 2.797196886185682,
+                "99.9" : 2.797196886185682,
+                "99.99" : 2.797196886185682,
+                "99.999" : 2.797196886185682,
+                "99.9999" : 2.797196886185682,
+                "100.0" : 2.797196886185682
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.784667412026726,
+                    2.793312477240994,
+                    2.797196886185682
+                ],
+                [
+                    2.7661257829092922,
+                    2.774042544521498,
+                    2.7890550156162854
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18093085204292111,
+            "scoreError" : 9.235233110041135E-4,
+            "scoreConfidence" : [
+                0.180007328731917,
+                0.18185437535392524
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.18046890630188406,
+                "50.0" : 0.18090955658381097,
+                "90.0" : 0.18140498663087054,
+                "95.0" : 0.18140498663087054,
+                "99.0" : 0.18140498663087054,
+                "99.9" : 0.18140498663087054,
+                "99.99" : 0.18140498663087054,
+                "99.999" : 0.18140498663087054,
+                "99.9999" : 0.18140498663087054,
+                "100.0" : 0.18140498663087054
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18095116151271148,
+                    0.18140498663087054,
+                    0.18116886102757346
+                ],
+                [
+                    0.18072324512957674,
+                    0.18086795165491046,
+                    0.18046890630188406
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.334239836801175,
+            "scoreError" : 0.023632729244322043,
+            "scoreConfidence" : [
+                0.310607107556853,
+                0.35787256604549705
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.325581458407944,
+                "50.0" : 0.33488280318613184,
+                "90.0" : 0.34312318044261453,
+                "95.0" : 0.34312318044261453,
+                "99.0" : 0.34312318044261453,
+                "99.9" : 0.34312318044261453,
+                "99.99" : 0.34312318044261453,
+                "99.999" : 0.34312318044261453,
+                "99.9999" : 0.34312318044261453,
+                "100.0" : 0.34312318044261453
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.34312318044261453,
+                    0.3412160838678859,
+                    0.34119625691767036
+                ],
+                [
+                    0.325581458407944,
+                    0.32856934945459326,
+                    0.3257526917163426
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14799213341982903,
+            "scoreError" : 0.003246715702081381,
+            "scoreConfidence" : [
+                0.14474541771774765,
+                0.1512388491219104
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14663946012962636,
+                "50.0" : 0.1479459626170069,
+                "90.0" : 0.14960863760809073,
+                "95.0" : 0.14960863760809073,
+                "99.0" : 0.14960863760809073,
+                "99.9" : 0.14960863760809073,
+                "99.99" : 0.14960863760809073,
+                "99.999" : 0.14960863760809073,
+                "99.9999" : 0.14960863760809073,
+                "100.0" : 0.14960863760809073
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14797539599887544,
+                    0.14791652923513837,
+                    0.14960863760809073
+                ],
+                [
+                    0.14684829855063952,
+                    0.14663946012962636,
+                    0.1489644789966037
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4104013546783276,
+            "scoreError" : 0.020433722268782355,
+            "scoreConfidence" : [
+                0.38996763240954524,
+                0.43083507694711
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4027819592395682,
+                "50.0" : 0.4100550363271226,
+                "90.0" : 0.4210505414087828,
+                "95.0" : 0.4210505414087828,
+                "99.0" : 0.4210505414087828,
+                "99.9" : 0.4210505414087828,
+                "99.99" : 0.4210505414087828,
+                "99.999" : 0.4210505414087828,
+                "99.9999" : 0.4210505414087828,
+                "100.0" : 0.4210505414087828
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4210505414087828,
+                    0.414763577454274,
+                    0.41392032553807945
+                ],
+                [
+                    0.40618974711616573,
+                    0.40370197731309543,
+                    0.4027819592395682
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16089355138842218,
+            "scoreError" : 0.005713431867885166,
+            "scoreConfidence" : [
+                0.155180119520537,
+                0.16660698325630735
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1587928964367378,
+                "50.0" : 0.16063784278905163,
+                "90.0" : 0.16391164361580068,
+                "95.0" : 0.16391164361580068,
+                "99.0" : 0.16391164361580068,
+                "99.9" : 0.16391164361580068,
+                "99.99" : 0.16391164361580068,
+                "99.999" : 0.16391164361580068,
+                "99.9999" : 0.16391164361580068,
+                "100.0" : 0.16391164361580068
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15929865762938655,
+                    0.15938348987138007,
+                    0.1587928964367378
+                ],
+                [
+                    0.16391164361580068,
+                    0.16208242507050472,
+                    0.16189219570672322
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04739784936645506,
+            "scoreError" : 8.390908581402119E-4,
+            "scoreConfidence" : [
+                0.04655875850831485,
+                0.04823694022459527
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04700293639222211,
+                "50.0" : 0.04740138964793335,
+                "90.0" : 0.04775846450642342,
+                "95.0" : 0.04775846450642342,
+                "99.0" : 0.04775846450642342,
+                "99.9" : 0.04775846450642342,
+                "99.99" : 0.04775846450642342,
+                "99.999" : 0.04775846450642342,
+                "99.9999" : 0.04775846450642342,
+                "100.0" : 0.04775846450642342
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04721123541075551,
+                    0.04720053814929318,
+                    0.04700293639222211
+                ],
+                [
+                    0.04775846450642342,
+                    0.04759154388511118,
+                    0.04762237785492504
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8760966.098879872,
+            "scoreError" : 116256.4697678146,
+            "scoreConfidence" : [
+                8644709.629112057,
+                8877222.568647686
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8706899.489120975,
+                "50.0" : 8762789.612084063,
+                "90.0" : 8818550.746031746,
+                "95.0" : 8818550.746031746,
+                "99.0" : 8818550.746031746,
+                "99.9" : 8818550.746031746,
+                "99.99" : 8818550.746031746,
+                "99.999" : 8818550.746031746,
+                "99.9999" : 8818550.746031746,
+                "100.0" : 8818550.746031746
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8818550.746031746,
+                    8723323.617262423,
+                    8706899.489120975
+                ],
+                [
+                    8761733.081436077,
+                    8763846.142732048,
+                    8791443.516695958
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-22T05-49-20Z-e860aff5292e1227e57e35f251b345cbc9a9ac9c-jdk17.json
+++ b/performance-results/2026-01-22T05-49-20Z-e860aff5292e1227e57e35f251b345cbc9a9ac9c-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.356072778154297,
+            "scoreError" : 0.04879710067268286,
+            "scoreConfidence" : [
+                3.307275677481614,
+                3.4048698788269802
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3463040592901208,
+                "50.0" : 3.3570048774004837,
+                "90.0" : 3.3639772985261005,
+                "95.0" : 3.3639772985261005,
+                "99.0" : 3.3639772985261005,
+                "99.9" : 3.3639772985261005,
+                "99.99" : 3.3639772985261005,
+                "99.999" : 3.3639772985261005,
+                "99.9999" : 3.3639772985261005,
+                "100.0" : 3.3639772985261005
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3463040592901208,
+                    3.3593948815272516
+                ],
+                [
+                    3.354614873273716,
+                    3.3639772985261005
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6966536865434252,
+            "scoreError" : 0.04874501730093941,
+            "scoreConfidence" : [
+                1.6479086692424858,
+                1.7453987038443646
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6896120496929514,
+                "50.0" : 1.6962219334797393,
+                "90.0" : 1.7045588295212704,
+                "95.0" : 1.7045588295212704,
+                "99.0" : 1.7045588295212704,
+                "99.9" : 1.7045588295212704,
+                "99.99" : 1.7045588295212704,
+                "99.999" : 1.7045588295212704,
+                "99.9999" : 1.7045588295212704,
+                "100.0" : 1.7045588295212704
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7016190355878809,
+                    1.7045588295212704
+                ],
+                [
+                    1.6896120496929514,
+                    1.690824831371598
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8477504290547168,
+            "scoreError" : 0.039163735080332024,
+            "scoreConfidence" : [
+                0.8085866939743848,
+                0.8869141641350488
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.838667932942429,
+                "50.0" : 0.8506674095423363,
+                "90.0" : 0.8509989641917656,
+                "95.0" : 0.8509989641917656,
+                "99.0" : 0.8509989641917656,
+                "99.9" : 0.8509989641917656,
+                "99.99" : 0.8509989641917656,
+                "99.999" : 0.8509989641917656,
+                "99.9999" : 0.8509989641917656,
+                "100.0" : 0.8509989641917656
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8509989641917656,
+                    0.8504110009059737
+                ],
+                [
+                    0.838667932942429,
+                    0.8509238181786989
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.421196206773676,
+            "scoreError" : 0.4456776172887821,
+            "scoreConfidence" : [
+                15.975518589484894,
+                16.86687382406246
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.22546352360442,
+                "50.0" : 16.442435085323893,
+                "90.0" : 16.569749117428614,
+                "95.0" : 16.569749117428614,
+                "99.0" : 16.569749117428614,
+                "99.9" : 16.569749117428614,
+                "99.99" : 16.569749117428614,
+                "99.999" : 16.569749117428614,
+                "99.9999" : 16.569749117428614,
+                "100.0" : 16.569749117428614
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.333946590252413,
+                    16.22546352360442,
+                    16.279556951533067
+                ],
+                [
+                    16.567537477428147,
+                    16.550923580395374,
+                    16.569749117428614
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2729.651760631002,
+            "scoreError" : 479.15186068560513,
+            "scoreConfidence" : [
+                2250.499899945397,
+                3208.8036213166074
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2572.255314837568,
+                "50.0" : 2730.105866073441,
+                "90.0" : 2887.2991136406217,
+                "95.0" : 2887.2991136406217,
+                "99.0" : 2887.2991136406217,
+                "99.9" : 2887.2991136406217,
+                "99.99" : 2887.2991136406217,
+                "99.999" : 2887.2991136406217,
+                "99.9999" : 2887.2991136406217,
+                "100.0" : 2887.2991136406217
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2885.874873750486,
+                    2883.6986790665846,
+                    2887.2991136406217
+                ],
+                [
+                    2576.5130530802976,
+                    2572.255314837568,
+                    2572.2695294104524
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74472.20163354692,
+            "scoreError" : 428.1215521560909,
+            "scoreConfidence" : [
+                74044.08008139083,
+                74900.32318570302
+            ],
+            "scorePercentiles" : {
+                "0.0" : 74314.67853948056,
+                "50.0" : 74445.76929637184,
+                "90.0" : 74649.19622218134,
+                "95.0" : 74649.19622218134,
+                "99.0" : 74649.19622218134,
+                "99.9" : 74649.19622218134,
+                "99.99" : 74649.19622218134,
+                "99.999" : 74649.19622218134,
+                "99.9999" : 74649.19622218134,
+                "100.0" : 74649.19622218134
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74649.19622218134,
+                    74529.01313594854,
+                    74638.21255165276
+                ],
+                [
+                    74362.52545679513,
+                    74314.67853948056,
+                    74339.58389522323
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 365.2470263837037,
+            "scoreError" : 9.674737739230336,
+            "scoreConfidence" : [
+                355.57228864447336,
+                374.92176412293406
+            ],
+            "scorePercentiles" : {
+                "0.0" : 361.949952528554,
+                "50.0" : 364.95997237815186,
+                "90.0" : 368.79375129471885,
+                "95.0" : 368.79375129471885,
+                "99.0" : 368.79375129471885,
+                "99.9" : 368.79375129471885,
+                "99.99" : 368.79375129471885,
+                "99.999" : 368.79375129471885,
+                "99.9999" : 368.79375129471885,
+                "100.0" : 368.79375129471885
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    367.6301055393637,
+                    368.6947913012054,
+                    368.79375129471885
+                ],
+                [
+                    362.1237184214403,
+                    361.949952528554,
+                    362.28983921694
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 114.7865379939441,
+            "scoreError" : 5.335916837584028,
+            "scoreConfidence" : [
+                109.45062115636007,
+                120.12245483152812
+            ],
+            "scorePercentiles" : {
+                "0.0" : 112.7668907274706,
+                "50.0" : 114.79638208100047,
+                "90.0" : 116.73208789773308,
+                "95.0" : 116.73208789773308,
+                "99.0" : 116.73208789773308,
+                "99.9" : 116.73208789773308,
+                "99.99" : 116.73208789773308,
+                "99.999" : 116.73208789773308,
+                "99.9999" : 116.73208789773308,
+                "100.0" : 116.73208789773308
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    116.73208789773308,
+                    116.65955007423692,
+                    116.10484756094523
+                ],
+                [
+                    112.96793510222302,
+                    112.7668907274706,
+                    113.48791660105573
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06091728908408006,
+            "scoreError" : 4.937654101223677E-4,
+            "scoreConfidence" : [
+                0.060423523673957695,
+                0.06141105449420243
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.060656731766789596,
+                "50.0" : 0.06095769129679665,
+                "90.0" : 0.06108182639554842,
+                "95.0" : 0.06108182639554842,
+                "99.0" : 0.06108182639554842,
+                "99.9" : 0.06108182639554842,
+                "99.99" : 0.06108182639554842,
+                "99.999" : 0.06108182639554842,
+                "99.9999" : 0.06108182639554842,
+                "100.0" : 0.06108182639554842
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.060867525503061584,
+                    0.06078273383660643,
+                    0.060656731766789596
+                ],
+                [
+                    0.06104785709053171,
+                    0.06108182639554842,
+                    0.061067059911942695
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.735266863350778E-4,
+            "scoreError" : 9.999588834052364E-6,
+            "scoreConfidence" : [
+                3.635270975010254E-4,
+                3.835262751691302E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6994951259676067E-4,
+                "50.0" : 3.737844663498893E-4,
+                "90.0" : 3.7679291928526405E-4,
+                "95.0" : 3.7679291928526405E-4,
+                "99.0" : 3.7679291928526405E-4,
+                "99.9" : 3.7679291928526405E-4,
+                "99.99" : 3.7679291928526405E-4,
+                "99.999" : 3.7679291928526405E-4,
+                "99.9999" : 3.7679291928526405E-4,
+                "100.0" : 3.7679291928526405E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.7082379098598954E-4,
+                    3.700754586764927E-4,
+                    3.6994951259676067E-4
+                ],
+                [
+                    3.7679291928526405E-4,
+                    3.767451417137891E-4,
+                    3.7677329475217065E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.24887059641011,
+            "scoreError" : 0.06085819084305931,
+            "scoreConfidence" : [
+                2.1880124055670507,
+                2.309728787253169
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2017265770585643,
+                "50.0" : 2.237207435748891,
+                "90.0" : 2.315403103895139,
+                "95.0" : 2.3177483580533025,
+                "99.0" : 2.3177483580533025,
+                "99.9" : 2.3177483580533025,
+                "99.99" : 2.3177483580533025,
+                "99.999" : 2.3177483580533025,
+                "99.9999" : 2.3177483580533025,
+                "100.0" : 2.3177483580533025
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3177483580533025,
+                    2.2670198481414325,
+                    2.284361736866149,
+                    2.2252773793947487,
+                    2.226219876892253
+                ],
+                [
+                    2.294295816471668,
+                    2.2481949946055293,
+                    2.2210128065733956,
+                    2.2017265770585643,
+                    2.2028485700440528
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013844668536826537,
+            "scoreError" : 7.468663452737802E-4,
+            "scoreConfidence" : [
+                0.013097802191552757,
+                0.014591534882100318
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01359919449275796,
+                "50.0" : 0.013843976453640848,
+                "90.0" : 0.01409363191934054,
+                "95.0" : 0.01409363191934054,
+                "99.0" : 0.01409363191934054,
+                "99.9" : 0.01409363191934054,
+                "99.99" : 0.01409363191934054,
+                "99.999" : 0.01409363191934054,
+                "99.9999" : 0.01409363191934054,
+                "100.0" : 0.01409363191934054
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01359919449275796,
+                    0.013605197915717153,
+                    0.013600294721252081
+                ],
+                [
+                    0.01409363191934054,
+                    0.014086937180326945,
+                    0.014082754991564545
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.162053060639564,
+            "scoreError" : 0.0622112525221922,
+            "scoreConfidence" : [
+                1.0998418081173718,
+                1.2242643131617563
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.141318466446017,
+                "50.0" : 1.1620117461341875,
+                "90.0" : 1.182736914143803,
+                "95.0" : 1.182736914143803,
+                "99.0" : 1.182736914143803,
+                "99.9" : 1.182736914143803,
+                "99.99" : 1.182736914143803,
+                "99.999" : 1.182736914143803,
+                "99.9999" : 1.182736914143803,
+                "100.0" : 1.182736914143803
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.141318466446017,
+                    1.1422388785836666,
+                    1.1418563509933775
+                ],
+                [
+                    1.1823831399858122,
+                    1.182736914143803,
+                    1.181784613684708
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010690056797737513,
+            "scoreError" : 0.0016239476472300106,
+            "scoreConfidence" : [
+                0.009066109150507502,
+                0.012314004444967525
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01015472836848465,
+                "50.0" : 0.010689695673849739,
+                "90.0" : 0.01122943936137481,
+                "95.0" : 0.01122943936137481,
+                "99.0" : 0.01122943936137481,
+                "99.9" : 0.01122943936137481,
+                "99.99" : 0.01122943936137481,
+                "99.999" : 0.01122943936137481,
+                "99.9999" : 0.01122943936137481,
+                "100.0" : 0.01122943936137481
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010166166956394445,
+                    0.01015472836848465,
+                    0.010163418207059722
+                ],
+                [
+                    0.01121336350180643,
+                    0.01121322439130503,
+                    0.01122943936137481
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.9529682868336296,
+            "scoreError" : 0.13350049495648406,
+            "scoreConfidence" : [
+                2.8194677918771456,
+                3.0864687817901135
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.903061491004063,
+                "50.0" : 2.9519751246575767,
+                "90.0" : 3.002134931572629,
+                "95.0" : 3.002134931572629,
+                "99.0" : 3.002134931572629,
+                "99.9" : 3.002134931572629,
+                "99.99" : 3.002134931572629,
+                "99.999" : 3.002134931572629,
+                "99.9999" : 3.002134931572629,
+                "100.0" : 3.002134931572629
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.002134931572629,
+                    2.9903561835026897,
+                    2.9959995692031156
+                ],
+                [
+                    2.912663479906814,
+                    2.9135940658124637,
+                    2.903061491004063
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.757492692489848,
+            "scoreError" : 0.1254008123008976,
+            "scoreConfidence" : [
+                2.6320918801889506,
+                2.882893504790746
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.709604551612029,
+                "50.0" : 2.7589360346946767,
+                "90.0" : 2.7995016994122586,
+                "95.0" : 2.7995016994122586,
+                "99.0" : 2.7995016994122586,
+                "99.9" : 2.7995016994122586,
+                "99.99" : 2.7995016994122586,
+                "99.999" : 2.7995016994122586,
+                "99.9999" : 2.7995016994122586,
+                "100.0" : 2.7995016994122586
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7197139553984226,
+                    2.7212048370068027,
+                    2.709604551612029
+                ],
+                [
+                    2.7966672323825503,
+                    2.7982638791270285,
+                    2.7995016994122586
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.175549430241544,
+            "scoreError" : 0.009929909887173074,
+            "scoreConfidence" : [
+                0.16561952035437094,
+                0.18547934012871709
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1722965032993918,
+                "50.0" : 0.1755114153898193,
+                "90.0" : 0.1789112968244029,
+                "95.0" : 0.1789112968244029,
+                "99.0" : 0.1789112968244029,
+                "99.9" : 0.1789112968244029,
+                "99.99" : 0.1789112968244029,
+                "99.999" : 0.1789112968244029,
+                "99.9999" : 0.1789112968244029,
+                "100.0" : 0.1789112968244029
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1789112968244029,
+                    0.1787672688952449,
+                    0.1786648719895662
+                ],
+                [
+                    0.17229868165058582,
+                    0.1722965032993918,
+                    0.1723579587900724
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.34707202379749497,
+            "scoreError" : 0.06568923054125557,
+            "scoreConfidence" : [
+                0.2813827932562394,
+                0.41276125433875055
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3243411543151818,
+                "50.0" : 0.3482137206061249,
+                "90.0" : 0.36862222625234986,
+                "95.0" : 0.36862222625234986,
+                "99.0" : 0.36862222625234986,
+                "99.9" : 0.36862222625234986,
+                "99.99" : 0.36862222625234986,
+                "99.999" : 0.36862222625234986,
+                "99.9999" : 0.36862222625234986,
+                "100.0" : 0.36862222625234986
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3282864420589587,
+                    0.3245520662058222,
+                    0.3243411543151818
+                ],
+                [
+                    0.36862222625234986,
+                    0.36848925479936623,
+                    0.3681409991532911
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14688271993624277,
+            "scoreError" : 0.0015158556766680467,
+            "scoreConfidence" : [
+                0.14536686425957474,
+                0.1483985756129108
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1463213337674119,
+                "50.0" : 0.14690133299851127,
+                "90.0" : 0.14740332814480706,
+                "95.0" : 0.14740332814480706,
+                "99.0" : 0.14740332814480706,
+                "99.9" : 0.14740332814480706,
+                "99.99" : 0.14740332814480706,
+                "99.999" : 0.14740332814480706,
+                "99.9999" : 0.14740332814480706,
+                "100.0" : 0.14740332814480706
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14737797723052437,
+                    0.14740332814480706,
+                    0.14734129806544768
+                ],
+                [
+                    0.1463910144776906,
+                    0.14646136793157485,
+                    0.1463213337674119
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4113355870150864,
+            "scoreError" : 0.03131074672070999,
+            "scoreConfidence" : [
+                0.3800248402943764,
+                0.44264633373579637
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4007858652212247,
+                "50.0" : 0.4102602997959408,
+                "90.0" : 0.42496947042325345,
+                "95.0" : 0.42496947042325345,
+                "99.0" : 0.42496947042325345,
+                "99.9" : 0.42496947042325345,
+                "99.99" : 0.42496947042325345,
+                "99.999" : 0.42496947042325345,
+                "99.9999" : 0.42496947042325345,
+                "100.0" : 0.42496947042325345
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.42496947042325345,
+                    0.42020964908815867,
+                    0.4188897546181879
+                ],
+                [
+                    0.4007858652212247,
+                    0.40152793776600015,
+                    0.4016308449736937
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15522713057462953,
+            "scoreError" : 0.0019142540259712898,
+            "scoreConfidence" : [
+                0.15331287654865824,
+                0.15714138460060081
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1545811803159587,
+                "50.0" : 0.15520790277956148,
+                "90.0" : 0.15588691456095774,
+                "95.0" : 0.15588691456095774,
+                "99.0" : 0.15588691456095774,
+                "99.9" : 0.15588691456095774,
+                "99.99" : 0.15588691456095774,
+                "99.999" : 0.15588691456095774,
+                "99.9999" : 0.15588691456095774,
+                "100.0" : 0.15588691456095774
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15588691456095774,
+                    0.15588075491403364,
+                    0.15577966393021264
+                ],
+                [
+                    0.15459812809770426,
+                    0.1546361416289103,
+                    0.1545811803159587
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04682862356967482,
+            "scoreError" : 0.0021914830145630297,
+            "scoreConfidence" : [
+                0.04463714055511179,
+                0.04902010658423785
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04609715695340122,
+                "50.0" : 0.046821811550712376,
+                "90.0" : 0.04755947654648614,
+                "95.0" : 0.04755947654648614,
+                "99.0" : 0.04755947654648614,
+                "99.9" : 0.04755947654648614,
+                "99.99" : 0.04755947654648614,
+                "99.999" : 0.04755947654648614,
+                "99.9999" : 0.04755947654648614,
+                "100.0" : 0.04755947654648614
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04751867465442605,
+                    0.04755947654648614,
+                    0.04754747344272272
+                ],
+                [
+                    0.0461249484469987,
+                    0.04609715695340122,
+                    0.04612401137401411
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8488093.018583084,
+            "scoreError" : 110935.00275963475,
+            "scoreConfidence" : [
+                8377158.015823449,
+                8599028.021342719
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8443152.994092828,
+                "50.0" : 8482042.673564818,
+                "90.0" : 8535959.828498293,
+                "95.0" : 8535959.828498293,
+                "99.0" : 8535959.828498293,
+                "99.9" : 8535959.828498293,
+                "99.99" : 8535959.828498293,
+                "99.999" : 8535959.828498293,
+                "99.9999" : 8535959.828498293,
+                "100.0" : 8535959.828498293
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8533091.588737201,
+                    8535959.828498293,
+                    8490192.320033956
+                ],
+                [
+                    8452268.35304054,
+                    8473893.027095681,
+                    8443152.994092828
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-22T21-23-52Z-6c2cdb084069426339a2c27a724dcbddd8ca7a11-jdk17.json
+++ b/performance-results/2026-01-22T21-23-52Z-6c2cdb084069426339a2c27a724dcbddd8ca7a11-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3539671949035803,
+            "scoreError" : 0.052012284761742904,
+            "scoreConfidence" : [
+                3.3019549101418373,
+                3.4059794796653233
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3460270837838304,
+                "50.0" : 3.3543544241215235,
+                "90.0" : 3.361132847587443,
+                "95.0" : 3.361132847587443,
+                "99.0" : 3.361132847587443,
+                "99.9" : 3.361132847587443,
+                "99.99" : 3.361132847587443,
+                "99.999" : 3.361132847587443,
+                "99.9999" : 3.361132847587443,
+                "100.0" : 3.361132847587443
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.34804311008648,
+                    3.360665738156567
+                ],
+                [
+                    3.3460270837838304,
+                    3.361132847587443
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6982925749454096,
+            "scoreError" : 0.010256701158563902,
+            "scoreConfidence" : [
+                1.6880358737868457,
+                1.7085492761039736
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6971081147048106,
+                "50.0" : 1.6977280308704237,
+                "90.0" : 1.7006061233359808,
+                "95.0" : 1.7006061233359808,
+                "99.0" : 1.7006061233359808,
+                "99.9" : 1.7006061233359808,
+                "99.99" : 1.7006061233359808,
+                "99.999" : 1.7006061233359808,
+                "99.9999" : 1.7006061233359808,
+                "100.0" : 1.7006061233359808
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6971081147048106,
+                    1.698015329288653
+                ],
+                [
+                    1.6974407324521943,
+                    1.7006061233359808
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8481923124250403,
+            "scoreError" : 0.04414391531604327,
+            "scoreConfidence" : [
+                0.8040483971089971,
+                0.8923362277410836
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8421795725129485,
+                "50.0" : 0.8468528609094553,
+                "90.0" : 0.8568839553683023,
+                "95.0" : 0.8568839553683023,
+                "99.0" : 0.8568839553683023,
+                "99.9" : 0.8568839553683023,
+                "99.99" : 0.8568839553683023,
+                "99.999" : 0.8568839553683023,
+                "99.9999" : 0.8568839553683023,
+                "100.0" : 0.8568839553683023
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8421795725129485,
+                    0.8433375494054439
+                ],
+                [
+                    0.8503681724134667,
+                    0.8568839553683023
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.614093702932877,
+            "scoreError" : 0.22178079190360797,
+            "scoreConfidence" : [
+                16.39231291102927,
+                16.835874494836485
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.51639338982853,
+                "50.0" : 16.619869618660296,
+                "90.0" : 16.691177883819428,
+                "95.0" : 16.691177883819428,
+                "99.0" : 16.691177883819428,
+                "99.9" : 16.691177883819428,
+                "99.99" : 16.691177883819428,
+                "99.999" : 16.691177883819428,
+                "99.9999" : 16.691177883819428,
+                "100.0" : 16.691177883819428
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.51639338982853,
+                    16.56081055512136,
+                    16.552654608550693
+                ],
+                [
+                    16.684597098078026,
+                    16.678928682199235,
+                    16.691177883819428
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2673.1336157572464,
+            "scoreError" : 12.201409980708313,
+            "scoreConfidence" : [
+                2660.932205776538,
+                2685.3350257379548
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2668.296693041804,
+                "50.0" : 2673.2479991020664,
+                "90.0" : 2678.3254536471795,
+                "95.0" : 2678.3254536471795,
+                "99.0" : 2678.3254536471795,
+                "99.9" : 2678.3254536471795,
+                "99.99" : 2678.3254536471795,
+                "99.999" : 2678.3254536471795,
+                "99.9999" : 2678.3254536471795,
+                "100.0" : 2678.3254536471795
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2668.296693041804,
+                    2668.4537984971307,
+                    2678.3254536471795
+                ],
+                [
+                    2671.573793733389,
+                    2677.22975115323,
+                    2674.9222044707435
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73387.95200145595,
+            "scoreError" : 1461.928397079723,
+            "scoreConfidence" : [
+                71926.02360437623,
+                74849.88039853568
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72883.66606509288,
+                "50.0" : 73399.45836814685,
+                "90.0" : 73880.0384331558,
+                "95.0" : 73880.0384331558,
+                "99.0" : 73880.0384331558,
+                "99.9" : 73880.0384331558,
+                "99.99" : 73880.0384331558,
+                "99.999" : 73880.0384331558,
+                "99.9999" : 73880.0384331558,
+                "100.0" : 73880.0384331558
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73851.39632998331,
+                    73858.82932743126,
+                    73880.0384331558
+                ],
+                [
+                    72883.66606509288,
+                    72947.52040631039,
+                    72906.26144676209
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 364.5862290002035,
+            "scoreError" : 5.16468074395809,
+            "scoreConfidence" : [
+                359.4215482562454,
+                369.7509097441616
+            ],
+            "scorePercentiles" : {
+                "0.0" : 362.6147462634511,
+                "50.0" : 364.4857432220938,
+                "90.0" : 366.52397490073054,
+                "95.0" : 366.52397490073054,
+                "99.0" : 366.52397490073054,
+                "99.9" : 366.52397490073054,
+                "99.99" : 366.52397490073054,
+                "99.999" : 366.52397490073054,
+                "99.9999" : 366.52397490073054,
+                "100.0" : 366.52397490073054
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    362.98342562236417,
+                    363.1908595030007,
+                    362.6147462634511
+                ],
+                [
+                    365.78062694118694,
+                    366.4237407704878,
+                    366.52397490073054
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 116.39846582144575,
+            "scoreError" : 0.6795702264907655,
+            "scoreConfidence" : [
+                115.71889559495499,
+                117.07803604793652
+            ],
+            "scorePercentiles" : {
+                "0.0" : 116.01918725278814,
+                "50.0" : 116.38693049974357,
+                "90.0" : 116.71739802361863,
+                "95.0" : 116.71739802361863,
+                "99.0" : 116.71739802361863,
+                "99.9" : 116.71739802361863,
+                "99.99" : 116.71739802361863,
+                "99.999" : 116.71739802361863,
+                "99.9999" : 116.71739802361863,
+                "100.0" : 116.71739802361863
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    116.71739802361863,
+                    116.44024543936995,
+                    116.57918193087629
+                ],
+                [
+                    116.3336155601172,
+                    116.01918725278814,
+                    116.30116672190424
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.0605275933975658,
+            "scoreError" : 6.68464296499081E-4,
+            "scoreConfidence" : [
+                0.059859129101066715,
+                0.06119605769406488
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06014187751088552,
+                "50.0" : 0.060641262410001714,
+                "90.0" : 0.06074786161210568,
+                "95.0" : 0.06074786161210568,
+                "99.0" : 0.06074786161210568,
+                "99.9" : 0.06074786161210568,
+                "99.99" : 0.06074786161210568,
+                "99.999" : 0.06074786161210568,
+                "99.9999" : 0.06074786161210568,
+                "100.0" : 0.06074786161210568
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.060668424896713646,
+                    0.060646797127816995,
+                    0.06074786161210568
+                ],
+                [
+                    0.06014187751088552,
+                    0.06063572769218643,
+                    0.06032487154568652
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.650568100205985E-4,
+            "scoreError" : 2.810592097067934E-5,
+            "scoreConfidence" : [
+                3.3695088904991916E-4,
+                3.9316273099127783E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5543634950000087E-4,
+                "50.0" : 3.6524165968512595E-4,
+                "90.0" : 3.7461675587923353E-4,
+                "95.0" : 3.7461675587923353E-4,
+                "99.0" : 3.7461675587923353E-4,
+                "99.9" : 3.7461675587923353E-4,
+                "99.99" : 3.7461675587923353E-4,
+                "99.999" : 3.7461675587923353E-4,
+                "99.9999" : 3.7461675587923353E-4,
+                "100.0" : 3.7461675587923353E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.7461675587923353E-4,
+                    3.738229145499167E-4,
+                    3.741474595275294E-4
+                ],
+                [
+                    3.5543634950000087E-4,
+                    3.566604048203352E-4,
+                    3.5565697584657584E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.136340707278812,
+            "scoreError" : 0.04938676914871058,
+            "scoreConfidence" : [
+                2.0869539381301014,
+                2.1857274764275227
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.095160885187513,
+                "50.0" : 2.133324455215742,
+                "90.0" : 2.1972025261292547,
+                "95.0" : 2.199824463044435,
+                "99.0" : 2.199824463044435,
+                "99.9" : 2.199824463044435,
+                "99.99" : 2.199824463044435,
+                "99.999" : 2.199824463044435,
+                "99.9999" : 2.199824463044435,
+                "100.0" : 2.199824463044435
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.173605093892632,
+                    2.1368220636752135,
+                    2.132799903817445,
+                    2.095160885187513,
+                    2.096875970230608
+                ],
+                [
+                    2.199824463044435,
+                    2.1551512268907564,
+                    2.1338490066140388,
+                    2.120744798982188,
+                    2.118573660453294
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013590240425952924,
+            "scoreError" : 7.913265408460593E-4,
+            "scoreConfidence" : [
+                0.012798913885106865,
+                0.014381566966798983
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013329261659633343,
+                "50.0" : 0.013589832813651177,
+                "90.0" : 0.013851899788345716,
+                "95.0" : 0.013851899788345716,
+                "99.0" : 0.013851899788345716,
+                "99.9" : 0.013851899788345716,
+                "99.99" : 0.013851899788345716,
+                "99.999" : 0.013851899788345716,
+                "99.9999" : 0.013851899788345716,
+                "100.0" : 0.013851899788345716
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013843986026087222,
+                    0.013851899788345716,
+                    0.013847606750083776
+                ],
+                [
+                    0.013335679601215131,
+                    0.013329261659633343,
+                    0.013333008730352374
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0993413815892823,
+            "scoreError" : 0.2020786772578502,
+            "scoreConfidence" : [
+                0.8972627043314321,
+                1.3014200588471325
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.032980949282099,
+                "50.0" : 1.099607813003491,
+                "90.0" : 1.1656220198135199,
+                "95.0" : 1.1656220198135199,
+                "99.0" : 1.1656220198135199,
+                "99.9" : 1.1656220198135199,
+                "99.99" : 1.1656220198135199,
+                "99.999" : 1.1656220198135199,
+                "99.9999" : 1.1656220198135199,
+                "100.0" : 1.1656220198135199
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.1649315395457194,
+                    1.1656220198135199,
+                    1.1648181554856742
+                ],
+                [
+                    1.0343974705213075,
+                    1.032980949282099,
+                    1.0332981548873734
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010693010581486946,
+            "scoreError" : 2.942085951827991E-4,
+            "scoreConfidence" : [
+                0.010398801986304147,
+                0.010987219176669746
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0105859875533255,
+                "50.0" : 0.010694501546518598,
+                "90.0" : 0.010795860972508006,
+                "95.0" : 0.010795860972508006,
+                "99.0" : 0.010795860972508006,
+                "99.9" : 0.010795860972508006,
+                "99.99" : 0.010795860972508006,
+                "99.999" : 0.010795860972508006,
+                "99.9999" : 0.010795860972508006,
+                "100.0" : 0.010795860972508006
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010795860972508006,
+                    0.010787948370087013,
+                    0.010781680264187804
+                ],
+                [
+                    0.010607322828849393,
+                    0.0105859875533255,
+                    0.010599263499963964
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.9934910909548518,
+            "scoreError" : 0.100788289065239,
+            "scoreConfidence" : [
+                2.892702801889613,
+                3.0942793800200907
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.95589820035461,
+                "50.0" : 2.9951980035267645,
+                "90.0" : 3.0307336442424244,
+                "95.0" : 3.0307336442424244,
+                "99.0" : 3.0307336442424244,
+                "99.9" : 3.0307336442424244,
+                "99.99" : 3.0307336442424244,
+                "99.999" : 3.0307336442424244,
+                "99.9999" : 3.0307336442424244,
+                "100.0" : 3.0307336442424244
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9590498609467457,
+                    2.96797354421365,
+                    2.95589820035461
+                ],
+                [
+                    3.022422462839879,
+                    3.0307336442424244,
+                    3.024868833131802
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.725370006101419,
+            "scoreError" : 0.010497600938469466,
+            "scoreConfidence" : [
+                2.7148724051629496,
+                2.735867607039889
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.720816597116431,
+                "50.0" : 2.7258331323316245,
+                "90.0" : 2.730412338793339,
+                "95.0" : 2.730412338793339,
+                "99.0" : 2.730412338793339,
+                "99.9" : 2.730412338793339,
+                "99.99" : 2.730412338793339,
+                "99.999" : 2.730412338793339,
+                "99.9999" : 2.730412338793339,
+                "100.0" : 2.730412338793339
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7278432700491,
+                    2.730412338793339,
+                    2.7268928595965103
+                ],
+                [
+                    2.720816597116431,
+                    2.724773405066739,
+                    2.7214815659863945
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17698634507029407,
+            "scoreError" : 0.005060542590409644,
+            "scoreConfidence" : [
+                0.17192580247988443,
+                0.1820468876607037
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17532392550580314,
+                "50.0" : 0.17669878175154596,
+                "90.0" : 0.17984017040407127,
+                "95.0" : 0.17984017040407127,
+                "99.0" : 0.17984017040407127,
+                "99.9" : 0.17984017040407127,
+                "99.99" : 0.17984017040407127,
+                "99.999" : 0.17984017040407127,
+                "99.9999" : 0.17984017040407127,
+                "100.0" : 0.17984017040407127
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17562896369863013,
+                    0.17550958851506696,
+                    0.17532392550580314
+                ],
+                [
+                    0.17984017040407127,
+                    0.17776859980446183,
+                    0.177846822493731
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32799196063499475,
+            "scoreError" : 0.022318355160140822,
+            "scoreConfidence" : [
+                0.30567360547485395,
+                0.35031031579513555
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.32035081321075054,
+                "50.0" : 0.32814802983432934,
+                "90.0" : 0.33538443478552504,
+                "95.0" : 0.33538443478552504,
+                "99.0" : 0.33538443478552504,
+                "99.9" : 0.33538443478552504,
+                "99.99" : 0.33538443478552504,
+                "99.999" : 0.33538443478552504,
+                "99.9999" : 0.33538443478552504,
+                "100.0" : 0.33538443478552504
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3205823380778355,
+                    0.32035081321075054,
+                    0.3212643314700591
+                ],
+                [
+                    0.33538443478552504,
+                    0.3353381180671987,
+                    0.3350317281985996
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15379449859871797,
+            "scoreError" : 0.023905468431697555,
+            "scoreConfidence" : [
+                0.12988903016702041,
+                0.17769996703041552
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14582712602076528,
+                "50.0" : 0.15387308961171947,
+                "90.0" : 0.16173293142709277,
+                "95.0" : 0.16173293142709277,
+                "99.0" : 0.16173293142709277,
+                "99.9" : 0.16173293142709277,
+                "99.99" : 0.16173293142709277,
+                "99.999" : 0.16173293142709277,
+                "99.9999" : 0.16173293142709277,
+                "100.0" : 0.16173293142709277
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14627281953281554,
+                    0.14582712602076528,
+                    0.14594177024897112
+                ],
+                [
+                    0.16147335969062343,
+                    0.16173293142709277,
+                    0.1615189846720398
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4019228520741071,
+            "scoreError" : 0.00550920602106045,
+            "scoreConfidence" : [
+                0.39641364605304663,
+                0.4074320580951676
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4002242006243246,
+                "50.0" : 0.4013860817911993,
+                "90.0" : 0.40580507012133266,
+                "95.0" : 0.40580507012133266,
+                "99.0" : 0.40580507012133266,
+                "99.9" : 0.40580507012133266,
+                "99.99" : 0.40580507012133266,
+                "99.999" : 0.40580507012133266,
+                "99.9999" : 0.40580507012133266,
+                "100.0" : 0.40580507012133266
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40580507012133266,
+                    0.4010962227970962,
+                    0.4002242006243246
+                ],
+                [
+                    0.40163945531949075,
+                    0.40141820476075785,
+                    0.4013539588216407
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1601263559709778,
+            "scoreError" : 8.785113176035121E-4,
+            "scoreConfidence" : [
+                0.15924784465337427,
+                0.16100486728858132
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15968804177378917,
+                "50.0" : 0.160260232685714,
+                "90.0" : 0.16040904794520547,
+                "95.0" : 0.16040904794520547,
+                "99.0" : 0.16040904794520547,
+                "99.9" : 0.16040904794520547,
+                "99.99" : 0.16040904794520547,
+                "99.999" : 0.16040904794520547,
+                "99.9999" : 0.16040904794520547,
+                "100.0" : 0.16040904794520547
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16040904794520547,
+                    0.15977335559993608,
+                    0.15968804177378917
+                ],
+                [
+                    0.1602494605474008,
+                    0.16036722513550788,
+                    0.16027100482402717
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.046535353478643016,
+            "scoreError" : 4.617407736684544E-4,
+            "scoreConfidence" : [
+                0.04607361270497456,
+                0.046997094252311473
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.046398407631491036,
+                "50.0" : 0.046484360952016766,
+                "90.0" : 0.04682161234197959,
+                "95.0" : 0.04682161234197959,
+                "99.0" : 0.04682161234197959,
+                "99.9" : 0.04682161234197959,
+                "99.99" : 0.04682161234197959,
+                "99.999" : 0.04682161234197959,
+                "99.9999" : 0.04682161234197959,
+                "100.0" : 0.04682161234197959
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.046398407631491036,
+                    0.04640880052441062,
+                    0.04642363393992851
+                ],
+                [
+                    0.04661457846994332,
+                    0.04682161234197959,
+                    0.046545087964105024
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8436527.042277412,
+            "scoreError" : 73916.93224117145,
+            "scoreConfidence" : [
+                8362610.110036241,
+                8510443.974518584
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8402323.390428212,
+                "50.0" : 8437625.64065066,
+                "90.0" : 8466660.448392555,
+                "95.0" : 8466660.448392555,
+                "99.0" : 8466660.448392555,
+                "99.9" : 8466660.448392555,
+                "99.99" : 8466660.448392555,
+                "99.999" : 8466660.448392555,
+                "99.9999" : 8466660.448392555,
+                "100.0" : 8466660.448392555
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8418167.803872054,
+                    8419634.244107744,
+                    8402323.390428212
+                ],
+                [
+                    8466660.448392555,
+                    8456759.32967033,
+                    8455617.037193576
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-26T06-15-07Z-f1c521c1f824a506e89fe75d09fb0ec2c71cb6ea-jdk17.json
+++ b/performance-results/2026-01-26T06-15-07Z-f1c521c1f824a506e89fe75d09fb0ec2c71cb6ea-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3255792021484885,
+            "scoreError" : 0.030943416207498256,
+            "scoreConfidence" : [
+                3.29463578594099,
+                3.356522618355987
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.321981739051725,
+                "50.0" : 3.3238841593486295,
+                "90.0" : 3.33256675084497,
+                "95.0" : 3.33256675084497,
+                "99.0" : 3.33256675084497,
+                "99.9" : 3.33256675084497,
+                "99.99" : 3.33256675084497,
+                "99.999" : 3.33256675084497,
+                "99.9999" : 3.33256675084497,
+                "100.0" : 3.33256675084497
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.321981739051725,
+                    3.323085384993577
+                ],
+                [
+                    3.324682933703682,
+                    3.33256675084497
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6698637445439362,
+            "scoreError" : 0.01241912310246037,
+            "scoreConfidence" : [
+                1.6574446214414758,
+                1.6822828676463966
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.667332766433785,
+                "50.0" : 1.6702380875841427,
+                "90.0" : 1.6716460365736747,
+                "95.0" : 1.6716460365736747,
+                "99.0" : 1.6716460365736747,
+                "99.9" : 1.6716460365736747,
+                "99.99" : 1.6716460365736747,
+                "99.999" : 1.6716460365736747,
+                "99.9999" : 1.6716460365736747,
+                "100.0" : 1.6716460365736747
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6710185065524696,
+                    1.6716460365736747
+                ],
+                [
+                    1.6694576686158158,
+                    1.667332766433785
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8403772291727019,
+            "scoreError" : 0.035477049407354924,
+            "scoreConfidence" : [
+                0.8049001797653469,
+                0.8758542785800568
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8336251067519471,
+                "50.0" : 0.8404374756612556,
+                "90.0" : 0.8470088586163493,
+                "95.0" : 0.8470088586163493,
+                "99.0" : 0.8470088586163493,
+                "99.9" : 0.8470088586163493,
+                "99.99" : 0.8470088586163493,
+                "99.999" : 0.8470088586163493,
+                "99.9999" : 0.8470088586163493,
+                "100.0" : 0.8470088586163493
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8336251067519471,
+                    0.839786673951556
+                ],
+                [
+                    0.841088277370955,
+                    0.8470088586163493
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.180576776857674,
+            "scoreError" : 0.056110611146515145,
+            "scoreConfidence" : [
+                16.12446616571116,
+                16.23668738800419
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.144559334852435,
+                "50.0" : 16.183443619458266,
+                "90.0" : 16.20140736207952,
+                "95.0" : 16.20140736207952,
+                "99.0" : 16.20140736207952,
+                "99.9" : 16.20140736207952,
+                "99.99" : 16.20140736207952,
+                "99.999" : 16.20140736207952,
+                "99.9999" : 16.20140736207952,
+                "100.0" : 16.20140736207952
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.176611363958756,
+                    16.178034023413833,
+                    16.188853215502697
+                ],
+                [
+                    16.193995361338818,
+                    16.144559334852435,
+                    16.20140736207952
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2698.042017846455,
+            "scoreError" : 39.521982054844095,
+            "scoreConfidence" : [
+                2658.520035791611,
+                2737.563999901299
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2679.493000196544,
+                "50.0" : 2696.0665233189193,
+                "90.0" : 2716.9309182952056,
+                "95.0" : 2716.9309182952056,
+                "99.0" : 2716.9309182952056,
+                "99.9" : 2716.9309182952056,
+                "99.99" : 2716.9309182952056,
+                "99.999" : 2716.9309182952056,
+                "99.9999" : 2716.9309182952056,
+                "100.0" : 2716.9309182952056
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2696.5479951330826,
+                    2679.493000196544,
+                    2688.0673462422637
+                ],
+                [
+                    2695.5850515047555,
+                    2716.9309182952056,
+                    2711.6277957068783
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73956.27198316394,
+            "scoreError" : 838.119661731252,
+            "scoreConfidence" : [
+                73118.15232143269,
+                74794.3916448952
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73631.64506383201,
+                "50.0" : 73946.25748392902,
+                "90.0" : 74367.50085427257,
+                "95.0" : 74367.50085427257,
+                "99.0" : 74367.50085427257,
+                "99.9" : 74367.50085427257,
+                "99.99" : 74367.50085427257,
+                "99.999" : 74367.50085427257,
+                "99.9999" : 74367.50085427257,
+                "100.0" : 74367.50085427257
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73690.66146099751,
+                    73770.48264929416,
+                    73631.64506383201
+                ],
+                [
+                    74122.03231856387,
+                    74367.50085427257,
+                    74155.3095520235
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 352.9264707008706,
+            "scoreError" : 7.61468612862562,
+            "scoreConfidence" : [
+                345.31178457224496,
+                360.54115682949623
+            ],
+            "scorePercentiles" : {
+                "0.0" : 350.1854208004129,
+                "50.0" : 352.3575521219541,
+                "90.0" : 356.7513613042528,
+                "95.0" : 356.7513613042528,
+                "99.0" : 356.7513613042528,
+                "99.9" : 356.7513613042528,
+                "99.99" : 356.7513613042528,
+                "99.999" : 356.7513613042528,
+                "99.9999" : 356.7513613042528,
+                "100.0" : 356.7513613042528
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    356.7513613042528,
+                    355.4474087478412,
+                    353.2623972314104
+                ],
+                [
+                    351.45270701249774,
+                    350.1854208004129,
+                    350.4595291088083
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 110.59153786371921,
+            "scoreError" : 4.317188427055433,
+            "scoreConfidence" : [
+                106.27434943666378,
+                114.90872629077464
+            ],
+            "scorePercentiles" : {
+                "0.0" : 109.20829330764872,
+                "50.0" : 110.34974689980092,
+                "90.0" : 112.70122687535718,
+                "95.0" : 112.70122687535718,
+                "99.0" : 112.70122687535718,
+                "99.9" : 112.70122687535718,
+                "99.99" : 112.70122687535718,
+                "99.999" : 112.70122687535718,
+                "99.9999" : 112.70122687535718,
+                "100.0" : 112.70122687535718
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    109.2650089079883,
+                    109.2479766925133,
+                    109.20829330764872
+                ],
+                [
+                    111.43448489161355,
+                    112.70122687535718,
+                    111.69223650719408
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06315000650788397,
+            "scoreError" : 8.898295940598566E-4,
+            "scoreConfidence" : [
+                0.06226017691382411,
+                0.06403983610194382
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06272025277847466,
+                "50.0" : 0.06315230820540296,
+                "90.0" : 0.06349924984760356,
+                "95.0" : 0.06349924984760356,
+                "99.0" : 0.06349924984760356,
+                "99.9" : 0.06349924984760356,
+                "99.99" : 0.06349924984760356,
+                "99.999" : 0.06349924984760356,
+                "99.9999" : 0.06349924984760356,
+                "100.0" : 0.06349924984760356
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06295743351170989,
+                    0.06294509930698491,
+                    0.06272025277847466
+                ],
+                [
+                    0.06334718289909605,
+                    0.06343082070343471,
+                    0.06349924984760356
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7462561651509517E-4,
+            "scoreError" : 1.389679204797119E-5,
+            "scoreConfidence" : [
+                3.6072882446712396E-4,
+                3.885224085630664E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6830719536721433E-4,
+                "50.0" : 3.749072779576539E-4,
+                "90.0" : 3.7956816548747105E-4,
+                "95.0" : 3.7956816548747105E-4,
+                "99.0" : 3.7956816548747105E-4,
+                "99.9" : 3.7956816548747105E-4,
+                "99.99" : 3.7956816548747105E-4,
+                "99.999" : 3.7956816548747105E-4,
+                "99.9999" : 3.7956816548747105E-4,
+                "100.0" : 3.7956816548747105E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.6830719536721433E-4,
+                    3.7092745097581014E-4,
+                    3.7142421782651423E-4
+                ],
+                [
+                    3.791363313447675E-4,
+                    3.7839033808879366E-4,
+                    3.7956816548747105E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.3614340467643644,
+            "scoreError" : 0.07233328554236627,
+            "scoreConfidence" : [
+                2.2891007612219982,
+                2.4337673323067306
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2779588403189064,
+                "50.0" : 2.3697403152518968,
+                "90.0" : 2.4168754624674964,
+                "95.0" : 2.4185704718258765,
+                "99.0" : 2.4185704718258765,
+                "99.9" : 2.4185704718258765,
+                "99.99" : 2.4185704718258765,
+                "99.999" : 2.4185704718258765,
+                "99.9999" : 2.4185704718258765,
+                "100.0" : 2.4185704718258765
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.4185704718258765,
+                    2.400659751320211,
+                    2.401620378242075,
+                    2.3606134352135943,
+                    2.354435627118644
+                ],
+                [
+                    2.3897370788530465,
+                    2.3788671952901996,
+                    2.346929920441211,
+                    2.2779588403189064,
+                    2.2849477690198765
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013805495491198735,
+            "scoreError" : 4.96777216888981E-4,
+            "scoreConfidence" : [
+                0.013308718274309754,
+                0.014302272708087716
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013633000249477188,
+                "50.0" : 0.013805565573168609,
+                "90.0" : 0.013983197005396047,
+                "95.0" : 0.013983197005396047,
+                "99.0" : 0.013983197005396047,
+                "99.9" : 0.013983197005396047,
+                "99.99" : 0.013983197005396047,
+                "99.999" : 0.013983197005396047,
+                "99.9999" : 0.013983197005396047,
+                "100.0" : 0.013983197005396047
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013958427107236375,
+                    0.013983197005396047,
+                    0.013959091900289784
+                ],
+                [
+                    0.013652704039100844,
+                    0.013646552645692178,
+                    0.013633000249477188
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0621447958996637,
+            "scoreError" : 0.2842954118663456,
+            "scoreConfidence" : [
+                0.777849384033318,
+                1.3464402077660094
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9687210333204185,
+                "50.0" : 1.0621220087102885,
+                "90.0" : 1.1556444730760342,
+                "95.0" : 1.1556444730760342,
+                "99.0" : 1.1556444730760342,
+                "99.9" : 1.1556444730760342,
+                "99.99" : 1.1556444730760342,
+                "99.999" : 1.1556444730760342,
+                "99.9999" : 1.1556444730760342,
+                "100.0" : 1.1556444730760342
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.1556444730760342,
+                    1.1539799180706207,
+                    1.154449984416484
+                ],
+                [
+                    0.9702640993499564,
+                    0.9698092671644686,
+                    0.9687210333204185
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01087590280293402,
+            "scoreError" : 7.528645413864993E-4,
+            "scoreConfidence" : [
+                0.01012303826154752,
+                0.011628767344320518
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010610595099302053,
+                "50.0" : 0.01087446841404885,
+                "90.0" : 0.011136185711294927,
+                "95.0" : 0.011136185711294927,
+                "99.0" : 0.011136185711294927,
+                "99.9" : 0.011136185711294927,
+                "99.99" : 0.011136185711294927,
+                "99.999" : 0.011136185711294927,
+                "99.9999" : 0.011136185711294927,
+                "100.0" : 0.011136185711294927
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.011136185711294927,
+                    0.01109269756293424,
+                    0.01113182739428373
+                ],
+                [
+                    0.010627871784625717,
+                    0.010656239265163462,
+                    0.010610595099302053
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0847388545822745,
+            "scoreError" : 0.18828102338002245,
+            "scoreConfidence" : [
+                2.896457831202252,
+                3.2730198779622968
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0229980145015105,
+                "50.0" : 3.073460310597862,
+                "90.0" : 3.176988040660737,
+                "95.0" : 3.176988040660737,
+                "99.0" : 3.176988040660737,
+                "99.9" : 3.176988040660737,
+                "99.99" : 3.176988040660737,
+                "99.999" : 3.176988040660737,
+                "99.9999" : 3.176988040660737,
+                "100.0" : 3.176988040660737
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0229980145015105,
+                    3.029075821320412,
+                    3.026023093768905
+                ],
+                [
+                    3.135503357366771,
+                    3.176988040660737,
+                    3.1178447998753116
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8123267556683094,
+            "scoreError" : 0.212524609966958,
+            "scoreConfidence" : [
+                2.5998021457013514,
+                3.0248513656352674
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.736026940902873,
+                "50.0" : 2.810499267653415,
+                "90.0" : 2.891107692196532,
+                "95.0" : 2.891107692196532,
+                "99.0" : 2.891107692196532,
+                "99.9" : 2.891107692196532,
+                "99.99" : 2.891107692196532,
+                "99.999" : 2.891107692196532,
+                "99.9999" : 2.891107692196532,
+                "100.0" : 2.891107692196532
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.742121123389087,
+                    2.736026940902873,
+                    2.7527900368841176
+                ],
+                [
+                    2.883706242214533,
+                    2.891107692196532,
+                    2.868208498422713
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1796565644043425,
+            "scoreError" : 0.0028556034950312755,
+            "scoreConfidence" : [
+                0.17680096090931122,
+                0.18251216789937377
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17866679199942828,
+                "50.0" : 0.1796430086686101,
+                "90.0" : 0.1806354948790665,
+                "95.0" : 0.1806354948790665,
+                "99.0" : 0.1806354948790665,
+                "99.9" : 0.1806354948790665,
+                "99.99" : 0.1806354948790665,
+                "99.999" : 0.1806354948790665,
+                "99.9999" : 0.1806354948790665,
+                "100.0" : 0.1806354948790665
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18059767843533853,
+                    0.18052201992923678,
+                    0.1806354948790665
+                ],
+                [
+                    0.17875340377500135,
+                    0.1787639974079834,
+                    0.17866679199942828
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3531715343457582,
+            "scoreError" : 0.062017798002138164,
+            "scoreConfidence" : [
+                0.2911537363436201,
+                0.41518933234789634
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3329337755102041,
+                "50.0" : 0.3527203426321657,
+                "90.0" : 0.37465334982954335,
+                "95.0" : 0.37465334982954335,
+                "99.0" : 0.37465334982954335,
+                "99.9" : 0.37465334982954335,
+                "99.99" : 0.37465334982954335,
+                "99.999" : 0.37465334982954335,
+                "99.9999" : 0.37465334982954335,
+                "100.0" : 0.37465334982954335
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.33304674815998936,
+                    0.3330004760747228,
+                    0.3329337755102041
+                ],
+                [
+                    0.37465334982954335,
+                    0.372393937104342,
+                    0.37300091939574787
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14602852923623763,
+            "scoreError" : 0.0012474330936010536,
+            "scoreConfidence" : [
+                0.14478109614263657,
+                0.1472759623298387
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14561684214051693,
+                "50.0" : 0.14591026053911044,
+                "90.0" : 0.14665277194603316,
+                "95.0" : 0.14665277194603316,
+                "99.0" : 0.14665277194603316,
+                "99.9" : 0.14665277194603316,
+                "99.99" : 0.14665277194603316,
+                "99.999" : 0.14665277194603316,
+                "99.9999" : 0.14665277194603316,
+                "100.0" : 0.14665277194603316
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1456314176763558,
+                    0.14561684214051693,
+                    0.14572684113198198
+                ],
+                [
+                    0.14665277194603316,
+                    0.14644962257629898,
+                    0.14609367994623892
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40489048289524027,
+            "scoreError" : 0.0314890254056046,
+            "scoreConfidence" : [
+                0.37340145748963566,
+                0.4363795083008449
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3925907288894123,
+                "50.0" : 0.40661056928849526,
+                "90.0" : 0.4163576519838461,
+                "95.0" : 0.4163576519838461,
+                "99.0" : 0.4163576519838461,
+                "99.9" : 0.4163576519838461,
+                "99.99" : 0.4163576519838461,
+                "99.999" : 0.4163576519838461,
+                "99.9999" : 0.4163576519838461,
+                "100.0" : 0.4163576519838461
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3993931341906626,
+                    0.39276529947763245,
+                    0.3925907288894123
+                ],
+                [
+                    0.4163576519838461,
+                    0.4144080784435604,
+                    0.4138280043863279
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1586976652211163,
+            "scoreError" : 0.00459253145860114,
+            "scoreConfidence" : [
+                0.15410513376251517,
+                0.16329019667971745
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15758095416082318,
+                "50.0" : 0.15820764044720587,
+                "90.0" : 0.161907089047195,
+                "95.0" : 0.161907089047195,
+                "99.0" : 0.161907089047195,
+                "99.9" : 0.161907089047195,
+                "99.99" : 0.161907089047195,
+                "99.999" : 0.161907089047195,
+                "99.9999" : 0.161907089047195,
+                "100.0" : 0.161907089047195
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.161907089047195,
+                    0.15868113390774505,
+                    0.1576015333165227
+                ],
+                [
+                    0.15790638859939995,
+                    0.1585088922950118,
+                    0.15758095416082318
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.047311754998549234,
+            "scoreError" : 0.0017573180646579588,
+            "scoreConfidence" : [
+                0.045554436933891274,
+                0.049069073063207194
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04649134960971097,
+                "50.0" : 0.04757077523270539,
+                "90.0" : 0.04784111508506037,
+                "95.0" : 0.04784111508506037,
+                "99.0" : 0.04784111508506037,
+                "99.9" : 0.04784111508506037,
+                "99.99" : 0.04784111508506037,
+                "99.999" : 0.04784111508506037,
+                "99.9999" : 0.04784111508506037,
+                "100.0" : 0.04784111508506037
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04737565983361916,
+                    0.04657606613229253,
+                    0.04649134960971097
+                ],
+                [
+                    0.04784111508506037,
+                    0.04776589063179163,
+                    0.04782044869882076
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8939575.39772369,
+            "scoreError" : 242246.52868703194,
+            "scoreConfidence" : [
+                8697328.869036658,
+                9181821.926410722
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8828245.684907326,
+                "50.0" : 8930580.570904598,
+                "90.0" : 9091856.277272727,
+                "95.0" : 9091856.277272727,
+                "99.0" : 9091856.277272727,
+                "99.9" : 9091856.277272727,
+                "99.99" : 9091856.277272727,
+                "99.999" : 9091856.277272727,
+                "99.9999" : 9091856.277272727,
+                "100.0" : 9091856.277272727
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8917943.771836007,
+                    9091856.277272727,
+                    8950291.216457961
+                ],
+                [
+                    8828245.684907326,
+                    8943217.36997319,
+                    8905898.065894924
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-27T06-03-51Z-9f18071096fa3cb62ee938bb9d91985627a96de7-jdk17.json
+++ b/performance-results/2026-01-27T06-03-51Z-9f18071096fa3cb62ee938bb9d91985627a96de7-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3515177552348328,
+            "scoreError" : 0.038192154394868366,
+            "scoreConfidence" : [
+                3.3133256008399643,
+                3.389709909629701
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.345347263810109,
+                "50.0" : 3.3509844563035953,
+                "90.0" : 3.35875484452203,
+                "95.0" : 3.35875484452203,
+                "99.0" : 3.35875484452203,
+                "99.9" : 3.35875484452203,
+                "99.99" : 3.35875484452203,
+                "99.999" : 3.35875484452203,
+                "99.9999" : 3.35875484452203,
+                "100.0" : 3.35875484452203
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.345347263810109,
+                    3.348360058961138
+                ],
+                [
+                    3.353608853646052,
+                    3.35875484452203
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6861911728249566,
+            "scoreError" : 0.005799098340930298,
+            "scoreConfidence" : [
+                1.6803920744840262,
+                1.691990271165887
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6848830234523913,
+                "50.0" : 1.6864997023172834,
+                "90.0" : 1.686882263212868,
+                "95.0" : 1.686882263212868,
+                "99.0" : 1.686882263212868,
+                "99.9" : 1.686882263212868,
+                "99.99" : 1.686882263212868,
+                "99.999" : 1.686882263212868,
+                "99.9999" : 1.686882263212868,
+                "100.0" : 1.686882263212868
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6848830234523913,
+                    1.686882263212868
+                ],
+                [
+                    1.6863640011579872,
+                    1.6866354034765794
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8518370448990449,
+            "scoreError" : 0.03385995269817706,
+            "scoreConfidence" : [
+                0.8179770922008678,
+                0.885696997597222
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8443633414941492,
+                "50.0" : 0.8531871184675959,
+                "90.0" : 0.8566106011668386,
+                "95.0" : 0.8566106011668386,
+                "99.0" : 0.8566106011668386,
+                "99.9" : 0.8566106011668386,
+                "99.99" : 0.8566106011668386,
+                "99.999" : 0.8566106011668386,
+                "99.9999" : 0.8566106011668386,
+                "100.0" : 0.8566106011668386
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8443633414941492,
+                    0.8566106011668386
+                ],
+                [
+                    0.852987016742716,
+                    0.8533872201924756
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.414189029616466,
+            "scoreError" : 0.16900624388626592,
+            "scoreConfidence" : [
+                16.2451827857302,
+                16.58319527350273
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.353619111873495,
+                "50.0" : 16.399114481065318,
+                "90.0" : 16.52677646025527,
+                "95.0" : 16.52677646025527,
+                "99.0" : 16.52677646025527,
+                "99.9" : 16.52677646025527,
+                "99.99" : 16.52677646025527,
+                "99.999" : 16.52677646025527,
+                "99.9999" : 16.52677646025527,
+                "100.0" : 16.52677646025527
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.426815354382008,
+                    16.379694289057394,
+                    16.396518757800607
+                ],
+                [
+                    16.52677646025527,
+                    16.40171020433003,
+                    16.353619111873495
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2765.476579896427,
+            "scoreError" : 34.28065727376219,
+            "scoreConfidence" : [
+                2731.195922622665,
+                2799.7572371701895
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2750.8036370835134,
+                "50.0" : 2767.2300021395254,
+                "90.0" : 2776.97955271172,
+                "95.0" : 2776.97955271172,
+                "99.0" : 2776.97955271172,
+                "99.9" : 2776.97955271172,
+                "99.99" : 2776.97955271172,
+                "99.999" : 2776.97955271172,
+                "99.9999" : 2776.97955271172,
+                "100.0" : 2776.97955271172
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2776.97955271172,
+                    2776.8453629278138,
+                    2775.2048362424434
+                ],
+                [
+                    2759.2551680366073,
+                    2750.8036370835134,
+                    2753.7709223764646
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73942.11875600425,
+            "scoreError" : 489.7216821746324,
+            "scoreConfidence" : [
+                73452.39707382962,
+                74431.84043817887
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73778.13630886949,
+                "50.0" : 73921.70313807637,
+                "90.0" : 74131.61834555672,
+                "95.0" : 74131.61834555672,
+                "99.0" : 74131.61834555672,
+                "99.9" : 74131.61834555672,
+                "99.99" : 74131.61834555672,
+                "99.999" : 74131.61834555672,
+                "99.9999" : 74131.61834555672,
+                "100.0" : 74131.61834555672
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74131.61834555672,
+                    74045.66110842171,
+                    74120.08782737062
+                ],
+                [
+                    73778.13630886949,
+                    73797.74516773102,
+                    73779.46377807591
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 366.93705470831964,
+            "scoreError" : 2.296341516289568,
+            "scoreConfidence" : [
+                364.6407131920301,
+                369.2333962246092
+            ],
+            "scorePercentiles" : {
+                "0.0" : 366.01639504746623,
+                "50.0" : 366.9397228856309,
+                "90.0" : 368.34905717805265,
+                "95.0" : 368.34905717805265,
+                "99.0" : 368.34905717805265,
+                "99.9" : 368.34905717805265,
+                "99.99" : 368.34905717805265,
+                "99.999" : 368.34905717805265,
+                "99.9999" : 368.34905717805265,
+                "100.0" : 368.34905717805265
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    366.2593667463419,
+                    366.01639504746623,
+                    367.0386193976009
+                ],
+                [
+                    368.34905717805265,
+                    367.11806350679484,
+                    366.84082637366095
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 115.99905231184034,
+            "scoreError" : 3.2437101116710547,
+            "scoreConfidence" : [
+                112.7553422001693,
+                119.2427624235114
+            ],
+            "scorePercentiles" : {
+                "0.0" : 114.74800108269936,
+                "50.0" : 116.01491097150542,
+                "90.0" : 117.40029390271336,
+                "95.0" : 117.40029390271336,
+                "99.0" : 117.40029390271336,
+                "99.9" : 117.40029390271336,
+                "99.99" : 117.40029390271336,
+                "99.999" : 117.40029390271336,
+                "99.9999" : 117.40029390271336,
+                "100.0" : 117.40029390271336
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    116.87552049235819,
+                    116.81264245966251,
+                    117.40029390271336
+                ],
+                [
+                    114.74800108269936,
+                    114.94067645026033,
+                    115.21717948334832
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.060995461581177045,
+            "scoreError" : 4.11140712250292E-4,
+            "scoreConfidence" : [
+                0.060584320868926754,
+                0.061406602293427336
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.060840746875874575,
+                "50.0" : 0.06099383985547188,
+                "90.0" : 0.0612078175847717,
+                "95.0" : 0.0612078175847717,
+                "99.0" : 0.0612078175847717,
+                "99.9" : 0.0612078175847717,
+                "99.99" : 0.0612078175847717,
+                "99.999" : 0.0612078175847717,
+                "99.9999" : 0.0612078175847717,
+                "100.0" : 0.0612078175847717
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0608531567497505,
+                    0.060840746875874575,
+                    0.060921496698101714
+                ],
+                [
+                    0.06106618301284204,
+                    0.06108336856572172,
+                    0.0612078175847717
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6965782182916816E-4,
+            "scoreError" : 3.196827208582621E-5,
+            "scoreConfidence" : [
+                3.3768954974334195E-4,
+                4.0162609391499436E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5913956481809493E-4,
+                "50.0" : 3.693457892589183E-4,
+                "90.0" : 3.8060872487099043E-4,
+                "95.0" : 3.8060872487099043E-4,
+                "99.0" : 3.8060872487099043E-4,
+                "99.9" : 3.8060872487099043E-4,
+                "99.99" : 3.8060872487099043E-4,
+                "99.999" : 3.8060872487099043E-4,
+                "99.9999" : 3.8060872487099043E-4,
+                "100.0" : 3.8060872487099043E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.5913956481809493E-4,
+                    3.594880961273895E-4,
+                    3.591538897400387E-4
+                ],
+                [
+                    3.8060872487099043E-4,
+                    3.8035317302804826E-4,
+                    3.792034823904471E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.237453962146747,
+            "scoreError" : 0.0768119422943829,
+            "scoreConfidence" : [
+                2.1606420198523644,
+                2.31426590444113
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.169470551409978,
+                "50.0" : 2.2358923811641755,
+                "90.0" : 2.3271935475305385,
+                "95.0" : 2.3322867404384326,
+                "99.0" : 2.3322867404384326,
+                "99.9" : 2.3322867404384326,
+                "99.99" : 2.3322867404384326,
+                "99.999" : 2.3322867404384326,
+                "99.9999" : 2.3322867404384326,
+                "100.0" : 2.3322867404384326
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3322867404384326,
+                    2.2813548113594893,
+                    2.275914953573054,
+                    2.23347539169272,
+                    2.238309370635631
+                ],
+                [
+                    2.253886053853087,
+                    2.2118254736842107,
+                    2.205929118217909,
+                    2.172087156602954,
+                    2.169470551409978
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013611892917202745,
+            "scoreError" : 4.1657146732823575E-5,
+            "scoreConfidence" : [
+                0.01357023577046992,
+                0.013653550063935569
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013595482392719441,
+                "50.0" : 0.01361330216473729,
+                "90.0" : 0.013627346775611213,
+                "95.0" : 0.013627346775611213,
+                "99.0" : 0.013627346775611213,
+                "99.9" : 0.013627346775611213,
+                "99.99" : 0.013627346775611213,
+                "99.999" : 0.013627346775611213,
+                "99.9999" : 0.013627346775611213,
+                "100.0" : 0.013627346775611213
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013623142243135032,
+                    0.013627346775611213,
+                    0.013625031812663753
+                ],
+                [
+                    0.013595482392719441,
+                    0.013596892192747494,
+                    0.013603462086339547
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0244395327718185,
+            "scoreError" : 0.038454622558123694,
+            "scoreConfidence" : [
+                0.9859849102136948,
+                1.0628941553299422
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0106150226354083,
+                "50.0" : 1.0247757458504212,
+                "90.0" : 1.0371166083169139,
+                "95.0" : 1.0371166083169139,
+                "99.0" : 1.0371166083169139,
+                "99.9" : 1.0371166083169139,
+                "99.99" : 1.0371166083169139,
+                "99.999" : 1.0371166083169139,
+                "99.9999" : 1.0371166083169139,
+                "100.0" : 1.0371166083169139
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0369860032144338,
+                    1.036714881816297,
+                    1.0371166083169139
+                ],
+                [
+                    1.0128366098845454,
+                    1.0106150226354083,
+                    1.0123680707633125
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01051796232173507,
+            "scoreError" : 9.455136946120718E-4,
+            "scoreConfidence" : [
+                0.009572448627122998,
+                0.011463476016347141
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010203198285906684,
+                "50.0" : 0.010520645545798705,
+                "90.0" : 0.010830633850805883,
+                "95.0" : 0.010830633850805883,
+                "99.0" : 0.010830633850805883,
+                "99.9" : 0.010830633850805883,
+                "99.99" : 0.010830633850805883,
+                "99.999" : 0.010830633850805883,
+                "99.9999" : 0.010830633850805883,
+                "100.0" : 0.010830633850805883
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010819307595602285,
+                    0.010830633850805883,
+                    0.010827124073492633
+                ],
+                [
+                    0.010221983495995126,
+                    0.010205526628607818,
+                    0.010203198285906684
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.9064303440184776,
+            "scoreError" : 0.16253094342605906,
+            "scoreConfidence" : [
+                2.7438994005924187,
+                3.0689612874445364
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8485791412300685,
+                "50.0" : 2.9080250557805662,
+                "90.0" : 2.965152710729105,
+                "95.0" : 2.965152710729105,
+                "99.0" : 2.965152710729105,
+                "99.9" : 2.965152710729105,
+                "99.99" : 2.965152710729105,
+                "99.999" : 2.965152710729105,
+                "99.9999" : 2.965152710729105,
+                "100.0" : 2.965152710729105
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.861077838672769,
+                    2.851577823831243,
+                    2.8485791412300685
+                ],
+                [
+                    2.965152710729105,
+                    2.957222276759314,
+                    2.954972272888364
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.711233740089549,
+            "scoreError" : 0.08745540126404243,
+            "scoreConfidence" : [
+                2.623778338825507,
+                2.7986891413535915
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6810347171581768,
+                "50.0" : 2.7078225555923465,
+                "90.0" : 2.752518182993946,
+                "95.0" : 2.752518182993946,
+                "99.0" : 2.752518182993946,
+                "99.9" : 2.752518182993946,
+                "99.99" : 2.752518182993946,
+                "99.999" : 2.752518182993946,
+                "99.9999" : 2.752518182993946,
+                "100.0" : 2.752518182993946
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.6810347171581768,
+                    2.6848237205369125,
+                    2.685066834362416
+                ],
+                [
+                    2.752518182993946,
+                    2.7305782768222766,
+                    2.733380708663569
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18071371384008814,
+            "scoreError" : 0.003918820681426418,
+            "scoreConfidence" : [
+                0.17679489315866173,
+                0.18463253452151454
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17933050854478616,
+                "50.0" : 0.18076208686108414,
+                "90.0" : 0.18203659051606444,
+                "95.0" : 0.18203659051606444,
+                "99.0" : 0.18203659051606444,
+                "99.9" : 0.18203659051606444,
+                "99.99" : 0.18203659051606444,
+                "99.999" : 0.18203659051606444,
+                "99.9999" : 0.18203659051606444,
+                "100.0" : 0.18203659051606444
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17961836429277053,
+                    0.17933050854478616,
+                    0.1793764002869955
+                ],
+                [
+                    0.18190580942939774,
+                    0.18201460997051436,
+                    0.18203659051606444
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32305748740101187,
+            "scoreError" : 0.015477388661858072,
+            "scoreConfidence" : [
+                0.3075800987391538,
+                0.3385348760628699
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.31755303321478473,
+                "50.0" : 0.3230499906890101,
+                "90.0" : 0.32844708033632214,
+                "95.0" : 0.32844708033632214,
+                "99.0" : 0.32844708033632214,
+                "99.9" : 0.32844708033632214,
+                "99.99" : 0.32844708033632214,
+                "99.999" : 0.32844708033632214,
+                "99.9999" : 0.32844708033632214,
+                "100.0" : 0.32844708033632214
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.31755303321478473,
+                    0.3182743640038192,
+                    0.3182567384634969
+                ],
+                [
+                    0.32798809101344706,
+                    0.32844708033632214,
+                    0.32782561737420096
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14847608142550286,
+            "scoreError" : 0.007795533809268726,
+            "scoreConfidence" : [
+                0.14068054761623414,
+                0.1562716152347716
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1456370837398966,
+                "50.0" : 0.14859754127116492,
+                "90.0" : 0.15103278860327432,
+                "95.0" : 0.15103278860327432,
+                "99.0" : 0.15103278860327432,
+                "99.9" : 0.15103278860327432,
+                "99.99" : 0.15103278860327432,
+                "99.999" : 0.15103278860327432,
+                "99.9999" : 0.15103278860327432,
+                "100.0" : 0.15103278860327432
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14598029336973023,
+                    0.14621439175951106,
+                    0.1456370837398966
+                ],
+                [
+                    0.15098069078281875,
+                    0.15103278860327432,
+                    0.15101124029778623
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.41397325262033974,
+            "scoreError" : 0.0149998244683009,
+            "scoreConfidence" : [
+                0.39897342815203884,
+                0.42897307708864063
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4093244812328599,
+                "50.0" : 0.4132251001807263,
+                "90.0" : 0.42389609677009155,
+                "95.0" : 0.42389609677009155,
+                "99.0" : 0.42389609677009155,
+                "99.9" : 0.42389609677009155,
+                "99.99" : 0.42389609677009155,
+                "99.999" : 0.42389609677009155,
+                "99.9999" : 0.42389609677009155,
+                "100.0" : 0.42389609677009155
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.413894061046271,
+                    0.42389609677009155,
+                    0.41471488458986483
+                ],
+                [
+                    0.41255613931518154,
+                    0.4094538527677694,
+                    0.4093244812328599
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15487242418456457,
+            "scoreError" : 0.01244385319989207,
+            "scoreConfidence" : [
+                0.1424285709846725,
+                0.16731627738445665
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14977236048166065,
+                "50.0" : 0.1559160804339709,
+                "90.0" : 0.1588993229256046,
+                "95.0" : 0.1588993229256046,
+                "99.0" : 0.1588993229256046,
+                "99.9" : 0.1588993229256046,
+                "99.99" : 0.1588993229256046,
+                "99.999" : 0.1588993229256046,
+                "99.9999" : 0.1588993229256046,
+                "100.0" : 0.1588993229256046
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15339613757823045,
+                    0.14984639560982918,
+                    0.14977236048166065
+                ],
+                [
+                    0.15888430522235109,
+                    0.15843602328971135,
+                    0.1588993229256046
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.047243912484202434,
+            "scoreError" : 0.0010901715999076663,
+            "scoreConfidence" : [
+                0.04615374088429477,
+                0.0483340840841101
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.046883705738946166,
+                "50.0" : 0.04720964357513622,
+                "90.0" : 0.04771560312628234,
+                "95.0" : 0.04771560312628234,
+                "99.0" : 0.04771560312628234,
+                "99.9" : 0.04771560312628234,
+                "99.99" : 0.04771560312628234,
+                "99.999" : 0.04771560312628234,
+                "99.9999" : 0.04771560312628234,
+                "100.0" : 0.04771560312628234
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.046896827243864805,
+                    0.046883705738946166,
+                    0.046902939031654385
+                ],
+                [
+                    0.04771560312628234,
+                    0.04751634811861805,
+                    0.04754805164584888
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8736079.112228265,
+            "scoreError" : 98196.20211212394,
+            "scoreConfidence" : [
+                8637882.910116142,
+                8834275.314340388
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8685792.061631944,
+                "50.0" : 8742912.357080419,
+                "90.0" : 8780630.419666374,
+                "95.0" : 8780630.419666374,
+                "99.0" : 8780630.419666374,
+                "99.9" : 8780630.419666374,
+                "99.99" : 8780630.419666374,
+                "99.999" : 8780630.419666374,
+                "99.9999" : 8780630.419666374,
+                "100.0" : 8780630.419666374
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8759428.588441331,
+                    8780630.419666374,
+                    8743440.24562937
+                ],
+                [
+                    8685792.061631944,
+                    8742384.468531469,
+                    8704798.889469104
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-28T07-09-08Z-7ba1647e46dbd6f6db53869afe85db5a6d3e4600-jdk17.json
+++ b/performance-results/2026-01-28T07-09-08Z-7ba1647e46dbd6f6db53869afe85db5a6d3e4600-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.324636728061601,
+            "scoreError" : 0.06137707326257825,
+            "scoreConfidence" : [
+                3.2632596547990227,
+                3.3860138013241796
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3136823852614197,
+                "50.0" : 3.325623598127371,
+                "90.0" : 3.333617330730243,
+                "95.0" : 3.333617330730243,
+                "99.0" : 3.333617330730243,
+                "99.9" : 3.333617330730243,
+                "99.99" : 3.333617330730243,
+                "99.999" : 3.333617330730243,
+                "99.9999" : 3.333617330730243,
+                "100.0" : 3.333617330730243
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.319790544634827,
+                    3.333617330730243
+                ],
+                [
+                    3.3136823852614197,
+                    3.331456651619915
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6765237710141985,
+            "scoreError" : 0.02588885491131626,
+            "scoreConfidence" : [
+                1.6506349161028822,
+                1.7024126259255148
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6705498624423845,
+                "50.0" : 1.6783184088467962,
+                "90.0" : 1.6789084039208166,
+                "95.0" : 1.6789084039208166,
+                "99.0" : 1.6789084039208166,
+                "99.9" : 1.6789084039208166,
+                "99.99" : 1.6789084039208166,
+                "99.999" : 1.6789084039208166,
+                "99.9999" : 1.6789084039208166,
+                "100.0" : 1.6789084039208166
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6779082214160457,
+                    1.6705498624423845
+                ],
+                [
+                    1.6789084039208166,
+                    1.6787285962775467
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8458036049528319,
+            "scoreError" : 0.014931686193274783,
+            "scoreConfidence" : [
+                0.8308719187595571,
+                0.8607352911461067
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.84254892305047,
+                "50.0" : 0.8463316537746801,
+                "90.0" : 0.8480021892114971,
+                "95.0" : 0.8480021892114971,
+                "99.0" : 0.8480021892114971,
+                "99.9" : 0.8480021892114971,
+                "99.99" : 0.8480021892114971,
+                "99.999" : 0.8480021892114971,
+                "99.9999" : 0.8480021892114971,
+                "100.0" : 0.8480021892114971
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.84254892305047,
+                    0.8462021633426834
+                ],
+                [
+                    0.846461144206677,
+                    0.8480021892114971
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.959028324010072,
+            "scoreError" : 0.3174991661400926,
+            "scoreConfidence" : [
+                15.641529157869979,
+                16.276527490150166
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.805214462691136,
+                "50.0" : 15.985488009230174,
+                "90.0" : 16.104159838664327,
+                "95.0" : 16.104159838664327,
+                "99.0" : 16.104159838664327,
+                "99.9" : 16.104159838664327,
+                "99.99" : 16.104159838664327,
+                "99.999" : 16.104159838664327,
+                "99.9999" : 16.104159838664327,
+                "100.0" : 16.104159838664327
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.104159838664327,
+                    15.999489625910806,
+                    16.028027582834795
+                ],
+                [
+                    15.845792041409828,
+                    15.805214462691136,
+                    15.97148639254954
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2594.9583152562527,
+            "scoreError" : 137.41834340772246,
+            "scoreConfidence" : [
+                2457.53997184853,
+                2732.3766586639754
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2526.550745067666,
+                "50.0" : 2597.2873849735915,
+                "90.0" : 2651.1077533648613,
+                "95.0" : 2651.1077533648613,
+                "99.0" : 2651.1077533648613,
+                "99.9" : 2651.1077533648613,
+                "99.99" : 2651.1077533648613,
+                "99.999" : 2651.1077533648613,
+                "99.9999" : 2651.1077533648613,
+                "100.0" : 2651.1077533648613
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2555.617025862769,
+                    2582.9193584859495,
+                    2526.550745067666
+                ],
+                [
+                    2651.1077533648613,
+                    2611.655411461234,
+                    2641.899597295038
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73659.79126932002,
+            "scoreError" : 1187.537113415211,
+            "scoreConfidence" : [
+                72472.25415590481,
+                74847.32838273523
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73246.79639436984,
+                "50.0" : 73570.51815959124,
+                "90.0" : 74225.19142809887,
+                "95.0" : 74225.19142809887,
+                "99.0" : 74225.19142809887,
+                "99.9" : 74225.19142809887,
+                "99.99" : 74225.19142809887,
+                "99.999" : 74225.19142809887,
+                "99.9999" : 74225.19142809887,
+                "100.0" : 74225.19142809887
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73292.96840879894,
+                    73246.79639436984,
+                    73345.1896268505
+                ],
+                [
+                    74225.19142809887,
+                    74052.75506546997,
+                    73795.846692332
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 345.7105074828019,
+            "scoreError" : 1.282643265793025,
+            "scoreConfidence" : [
+                344.4278642170089,
+                346.9931507485949
+            ],
+            "scorePercentiles" : {
+                "0.0" : 345.20995950763955,
+                "50.0" : 345.62433431557713,
+                "90.0" : 346.4048142616085,
+                "95.0" : 346.4048142616085,
+                "99.0" : 346.4048142616085,
+                "99.9" : 346.4048142616085,
+                "99.99" : 346.4048142616085,
+                "99.999" : 346.4048142616085,
+                "99.9999" : 346.4048142616085,
+                "100.0" : 346.4048142616085
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    345.3444499983744,
+                    345.47292891402674,
+                    346.05515249803483
+                ],
+                [
+                    346.4048142616085,
+                    345.20995950763955,
+                    345.7757397171275
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 113.57065134749489,
+            "scoreError" : 2.4607822946009623,
+            "scoreConfidence" : [
+                111.10986905289393,
+                116.03143364209585
+            ],
+            "scorePercentiles" : {
+                "0.0" : 112.40706060581344,
+                "50.0" : 113.6580774160948,
+                "90.0" : 114.69011490487239,
+                "95.0" : 114.69011490487239,
+                "99.0" : 114.69011490487239,
+                "99.9" : 114.69011490487239,
+                "99.99" : 114.69011490487239,
+                "99.999" : 114.69011490487239,
+                "99.9999" : 114.69011490487239,
+                "100.0" : 114.69011490487239
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    114.69011490487239,
+                    114.19821264354977,
+                    112.40706060581344
+                ],
+                [
+                    112.81236509854415,
+                    113.29813945194336,
+                    114.01801538024624
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06250213026481481,
+            "scoreError" : 9.525292225849929E-4,
+            "scoreConfidence" : [
+                0.06154960104222982,
+                0.06345465948739981
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06203502906291485,
+                "50.0" : 0.0625518756081447,
+                "90.0" : 0.06290685417099147,
+                "95.0" : 0.06290685417099147,
+                "99.0" : 0.06290685417099147,
+                "99.9" : 0.06290685417099147,
+                "99.99" : 0.06290685417099147,
+                "99.999" : 0.06290685417099147,
+                "99.9999" : 0.06290685417099147,
+                "100.0" : 0.06290685417099147
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06218182696289664,
+                    0.0624919117251895,
+                    0.06203502906291485
+                ],
+                [
+                    0.06278532017579658,
+                    0.06261183949109989,
+                    0.06290685417099147
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.690090506512249E-4,
+            "scoreError" : 5.948531387425141E-6,
+            "scoreConfidence" : [
+                3.630605192637998E-4,
+                3.7495758203865006E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.663442533497336E-4,
+                "50.0" : 3.68747053613398E-4,
+                "90.0" : 3.7160971963305856E-4,
+                "95.0" : 3.7160971963305856E-4,
+                "99.0" : 3.7160971963305856E-4,
+                "99.9" : 3.7160971963305856E-4,
+                "99.99" : 3.7160971963305856E-4,
+                "99.999" : 3.7160971963305856E-4,
+                "99.9999" : 3.7160971963305856E-4,
+                "100.0" : 3.7160971963305856E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.672955655645531E-4,
+                    3.683835237861511E-4,
+                    3.663442533497336E-4
+                ],
+                [
+                    3.7160971963305856E-4,
+                    3.7131065813320827E-4,
+                    3.691105834406449E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2664363185933465,
+            "scoreError" : 0.07206166186568859,
+            "scoreConfidence" : [
+                2.194374656727658,
+                2.338497980459035
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.217122740855686,
+                "50.0" : 2.250882679325083,
+                "90.0" : 2.350109925789678,
+                "95.0" : 2.3531859494117646,
+                "99.0" : 2.3531859494117646,
+                "99.9" : 2.3531859494117646,
+                "99.99" : 2.3531859494117646,
+                "99.999" : 2.3531859494117646,
+                "99.9999" : 2.3531859494117646,
+                "100.0" : 2.3531859494117646
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3090796497344726,
+                    2.3224257131908965,
+                    2.247676282247191,
+                    2.221077150344215,
+                    2.217122740855686
+                ],
+                [
+                    2.3531859494117646,
+                    2.254089076402975,
+                    2.280968341847206,
+                    2.2321459355054674,
+                    2.2265923463935886
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.01374190862711923,
+            "scoreError" : 3.402588866736822E-4,
+            "scoreConfidence" : [
+                0.013401649740445548,
+                0.014082167513792912
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013585438170772133,
+                "50.0" : 0.013769919353771889,
+                "90.0" : 0.013903111965198823,
+                "95.0" : 0.013903111965198823,
+                "99.0" : 0.013903111965198823,
+                "99.9" : 0.013903111965198823,
+                "99.99" : 0.013903111965198823,
+                "99.999" : 0.013903111965198823,
+                "99.9999" : 0.013903111965198823,
+                "100.0" : 0.013903111965198823
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013903111965198823,
+                    0.013791745170891016,
+                    0.013808432156043998
+                ],
+                [
+                    0.013614630763156641,
+                    0.013585438170772133,
+                    0.013748093536652763
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.040618346226695,
+            "scoreError" : 0.013773277140800564,
+            "scoreConfidence" : [
+                1.0268450690858943,
+                1.0543916233674955
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0346320316573556,
+                "50.0" : 1.041690465374446,
+                "90.0" : 1.047279808775788,
+                "95.0" : 1.047279808775788,
+                "99.0" : 1.047279808775788,
+                "99.9" : 1.047279808775788,
+                "99.99" : 1.047279808775788,
+                "99.999" : 1.047279808775788,
+                "99.9999" : 1.047279808775788,
+                "100.0" : 1.047279808775788
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0409075550582847,
+                    1.047279808775788,
+                    1.0432653064886293
+                ],
+                [
+                    1.0424733756906077,
+                    1.0351519996895053,
+                    1.0346320316573556
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010451745458460315,
+            "scoreError" : 9.392177239728925E-4,
+            "scoreConfidence" : [
+                0.009512527734487422,
+                0.011390963182433208
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010127508978773394,
+                "50.0" : 0.010456281653266408,
+                "90.0" : 0.010785313719653584,
+                "95.0" : 0.010785313719653584,
+                "99.0" : 0.010785313719653584,
+                "99.9" : 0.010785313719653584,
+                "99.99" : 0.010785313719653584,
+                "99.999" : 0.010785313719653584,
+                "99.9999" : 0.010785313719653584,
+                "100.0" : 0.010785313719653584
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010180977692079018,
+                    0.010132130676890406,
+                    0.010127508978773394
+                ],
+                [
+                    0.010731585614453797,
+                    0.01075295606891168,
+                    0.010785313719653584
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1555551737023677,
+            "scoreError" : 0.03243662374506814,
+            "scoreConfidence" : [
+                3.1231185499572995,
+                3.187991797447436
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1444639836580768,
+                "50.0" : 3.153472900426971,
+                "90.0" : 3.1763209473015874,
+                "95.0" : 3.1763209473015874,
+                "99.0" : 3.1763209473015874,
+                "99.9" : 3.1763209473015874,
+                "99.99" : 3.1763209473015874,
+                "99.999" : 3.1763209473015874,
+                "99.9999" : 3.1763209473015874,
+                "100.0" : 3.1763209473015874
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.152207323251418,
+                    3.1594226481364496,
+                    3.1444639836580768
+                ],
+                [
+                    3.154738477602524,
+                    3.146177662264151,
+                    3.1763209473015874
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8603700308307363,
+            "scoreError" : 0.03575560644197469,
+            "scoreConfidence" : [
+                2.8246144243887614,
+                2.896125637272711
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8475032437357632,
+                "50.0" : 2.8583826792631384,
+                "90.0" : 2.88117180610775,
+                "95.0" : 2.88117180610775,
+                "99.0" : 2.88117180610775,
+                "99.9" : 2.88117180610775,
+                "99.99" : 2.88117180610775,
+                "99.999" : 2.88117180610775,
+                "99.9999" : 2.88117180610775,
+                "100.0" : 2.88117180610775
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8475032437357632,
+                    2.8523135733029092,
+                    2.8504767195782272
+                ],
+                [
+                    2.88117180610775,
+                    2.8644517852233675,
+                    2.8663030570364003
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18009834505026148,
+            "scoreError" : 0.004945930068088446,
+            "scoreConfidence" : [
+                0.17515241498217304,
+                0.18504427511834992
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1789399009054146,
+                "50.0" : 0.17916604389670915,
+                "90.0" : 0.18328082199211948,
+                "95.0" : 0.18328082199211948,
+                "99.0" : 0.18328082199211948,
+                "99.9" : 0.18328082199211948,
+                "99.99" : 0.18328082199211948,
+                "99.999" : 0.18328082199211948,
+                "99.9999" : 0.18328082199211948,
+                "100.0" : 0.18328082199211948
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.178940195648284,
+                    0.17910652407135438,
+                    0.1789399009054146
+                ],
+                [
+                    0.18328082199211948,
+                    0.1792255637220639,
+                    0.1810970639623325
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3340531990988492,
+            "scoreError" : 0.009621140991985633,
+            "scoreConfidence" : [
+                0.32443205810686354,
+                0.3436743400908348
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3303545817779393,
+                "50.0" : 0.3341602411559922,
+                "90.0" : 0.33743488551086515,
+                "95.0" : 0.33743488551086515,
+                "99.0" : 0.33743488551086515,
+                "99.9" : 0.33743488551086515,
+                "99.99" : 0.33743488551086515,
+                "99.999" : 0.33743488551086515,
+                "99.9999" : 0.33743488551086515,
+                "100.0" : 0.33743488551086515
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.33743488551086515,
+                    0.33725637687171184,
+                    0.33679155511399994
+                ],
+                [
+                    0.3309528681205944,
+                    0.3315289271979844,
+                    0.3303545817779393
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1525227409153148,
+            "scoreError" : 0.0011038634810786358,
+            "scoreConfidence" : [
+                0.15141887743423615,
+                0.15362660439639342
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15206027972325706,
+                "50.0" : 0.1525507574183419,
+                "90.0" : 0.15316763820858031,
+                "95.0" : 0.15316763820858031,
+                "99.0" : 0.15316763820858031,
+                "99.9" : 0.15316763820858031,
+                "99.99" : 0.15316763820858031,
+                "99.999" : 0.15316763820858031,
+                "99.9999" : 0.15316763820858031,
+                "100.0" : 0.15316763820858031
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15206027972325706,
+                    0.15248157357851883,
+                    0.15217388075963237
+                ],
+                [
+                    0.15261994125816494,
+                    0.15263313196373515,
+                    0.15316763820858031
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4131775180996214,
+            "scoreError" : 0.02517508977256836,
+            "scoreConfidence" : [
+                0.388002428327053,
+                0.43835260787218977
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40430061002627854,
+                "50.0" : 0.4136258672110107,
+                "90.0" : 0.42163727864912726,
+                "95.0" : 0.42163727864912726,
+                "99.0" : 0.42163727864912726,
+                "99.9" : 0.42163727864912726,
+                "99.99" : 0.42163727864912726,
+                "99.999" : 0.42163727864912726,
+                "99.9999" : 0.42163727864912726,
+                "100.0" : 0.42163727864912726
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4062635441803778,
+                    0.40430061002627854,
+                    0.40446124630940344
+                ],
+                [
+                    0.42163727864912726,
+                    0.4214142391908976,
+                    0.4209881902416435
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16079455878997537,
+            "scoreError" : 0.002500183994889596,
+            "scoreConfidence" : [
+                0.15829437479508576,
+                0.16329474278486497
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1595961033992978,
+                "50.0" : 0.16118015331216834,
+                "90.0" : 0.16172916452379799,
+                "95.0" : 0.16172916452379799,
+                "99.0" : 0.16172916452379799,
+                "99.9" : 0.16172916452379799,
+                "99.99" : 0.16172916452379799,
+                "99.999" : 0.16172916452379799,
+                "99.9999" : 0.16172916452379799,
+                "100.0" : 0.16172916452379799
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16113269258161195,
+                    0.15975529702701408,
+                    0.1595961033992978
+                ],
+                [
+                    0.16172916452379799,
+                    0.16132648116540566,
+                    0.1612276140427247
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04805388472304756,
+            "scoreError" : 7.218497658824588E-4,
+            "scoreConfidence" : [
+                0.0473320349571651,
+                0.048775734488930016
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04778132707248316,
+                "50.0" : 0.04809249116176639,
+                "90.0" : 0.04828893735573905,
+                "95.0" : 0.04828893735573905,
+                "99.0" : 0.04828893735573905,
+                "99.9" : 0.04828893735573905,
+                "99.99" : 0.04828893735573905,
+                "99.999" : 0.04828893735573905,
+                "99.9999" : 0.04828893735573905,
+                "100.0" : 0.04828893735573905
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04778206971288231,
+                    0.04778132707248316,
+                    0.04790401547275741
+                ],
+                [
+                    0.04828096685077538,
+                    0.04828893735573905,
+                    0.04828599187364802
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8786771.153242486,
+            "scoreError" : 582285.6254333647,
+            "scoreConfidence" : [
+                8204485.527809121,
+                9369056.77867585
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8561032.074422583,
+                "50.0" : 8791131.21037274,
+                "90.0" : 9074887.130671507,
+                "95.0" : 9074887.130671507,
+                "99.0" : 9074887.130671507,
+                "99.9" : 9074887.130671507,
+                "99.99" : 9074887.130671507,
+                "99.999" : 9074887.130671507,
+                "99.9999" : 9074887.130671507,
+                "100.0" : 9074887.130671507
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8570779.471293917,
+                    8707656.673629243,
+                    8561032.074422583
+                ],
+                [
+                    9074887.130671507,
+                    8931665.822321428,
+                    8874605.747116238
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-29T20-14-37Z-51d16e7857eb9aeb4bca9f7e1f129ca2437d00e2-jdk17.json
+++ b/performance-results/2026-01-29T20-14-37Z-51d16e7857eb9aeb4bca9f7e1f129ca2437d00e2-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3598290863473026,
+            "scoreError" : 0.027118837840526842,
+            "scoreConfidence" : [
+                3.3327102485067757,
+                3.3869479241878295
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3564412579561727,
+                "50.0" : 3.358524325703048,
+                "90.0" : 3.365826436026941,
+                "95.0" : 3.365826436026941,
+                "99.0" : 3.365826436026941,
+                "99.9" : 3.365826436026941,
+                "99.99" : 3.365826436026941,
+                "99.999" : 3.365826436026941,
+                "99.9999" : 3.365826436026941,
+                "100.0" : 3.365826436026941
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.357527897934331,
+                    3.3595207534717653
+                ],
+                [
+                    3.3564412579561727,
+                    3.365826436026941
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.697975257300198,
+            "scoreError" : 0.01462400020401965,
+            "scoreConfidence" : [
+                1.6833512570961784,
+                1.7125992575042177
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6953780293908567,
+                "50.0" : 1.6978115416251465,
+                "90.0" : 1.7008999165596426,
+                "95.0" : 1.7008999165596426,
+                "99.0" : 1.7008999165596426,
+                "99.9" : 1.7008999165596426,
+                "99.99" : 1.7008999165596426,
+                "99.999" : 1.7008999165596426,
+                "99.9999" : 1.7008999165596426,
+                "100.0" : 1.7008999165596426
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6978882423300055,
+                    1.7008999165596426
+                ],
+                [
+                    1.6953780293908567,
+                    1.6977348409202875
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8534651468791383,
+            "scoreError" : 0.020144306416485066,
+            "scoreConfidence" : [
+                0.8333208404626533,
+                0.8736094532956233
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8494795042423002,
+                "50.0" : 0.8537119615582847,
+                "90.0" : 0.8569571601576838,
+                "95.0" : 0.8569571601576838,
+                "99.0" : 0.8569571601576838,
+                "99.9" : 0.8569571601576838,
+                "99.99" : 0.8569571601576838,
+                "99.999" : 0.8569571601576838,
+                "99.9999" : 0.8569571601576838,
+                "100.0" : 0.8569571601576838
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8494795042423002,
+                    0.8530219095165853
+                ],
+                [
+                    0.8544020135999839,
+                    0.8569571601576838
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.432090504036868,
+            "scoreError" : 0.20197399005353647,
+            "scoreConfidence" : [
+                16.230116513983333,
+                16.634064494090403
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.36273653703392,
+                "50.0" : 16.419423400662332,
+                "90.0" : 16.542651057915556,
+                "95.0" : 16.542651057915556,
+                "99.0" : 16.542651057915556,
+                "99.9" : 16.542651057915556,
+                "99.99" : 16.542651057915556,
+                "99.999" : 16.542651057915556,
+                "99.9999" : 16.542651057915556,
+                "100.0" : 16.542651057915556
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.45848194980189,
+                    16.542651057915556,
+                    16.476149522984493
+                ],
+                [
+                    16.372159104962577,
+                    16.380364851522774,
+                    16.36273653703392
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2760.7287116301563,
+            "scoreError" : 43.81022880260409,
+            "scoreConfidence" : [
+                2716.9184828275525,
+                2804.5389404327602
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2741.498584619419,
+                "50.0" : 2759.2574277879776,
+                "90.0" : 2778.955477822761,
+                "95.0" : 2778.955477822761,
+                "99.0" : 2778.955477822761,
+                "99.9" : 2778.955477822761,
+                "99.99" : 2778.955477822761,
+                "99.999" : 2778.955477822761,
+                "99.9999" : 2778.955477822761,
+                "100.0" : 2778.955477822761
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2741.498584619419,
+                    2748.1305529714223,
+                    2752.8679264195457
+                ],
+                [
+                    2778.955477822761,
+                    2765.6469291564094,
+                    2777.272798791382
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74921.60457534828,
+            "scoreError" : 2081.299526652722,
+            "scoreConfidence" : [
+                72840.30504869555,
+                77002.904102001
+            ],
+            "scorePercentiles" : {
+                "0.0" : 74135.36773794207,
+                "50.0" : 74960.28187975,
+                "90.0" : 75603.67702932721,
+                "95.0" : 75603.67702932721,
+                "99.0" : 75603.67702932721,
+                "99.9" : 75603.67702932721,
+                "99.99" : 75603.67702932721,
+                "99.999" : 75603.67702932721,
+                "99.9999" : 75603.67702932721,
+                "100.0" : 75603.67702932721
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74135.36773794207,
+                    74268.95534030108,
+                    74335.62572383773
+                ],
+                [
+                    75603.67702932721,
+                    75601.0635850193,
+                    75584.93803566226
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 364.70721614979243,
+            "scoreError" : 13.140046996831574,
+            "scoreConfidence" : [
+                351.56716915296084,
+                377.847263146624
+            ],
+            "scorePercentiles" : {
+                "0.0" : 359.4549246400141,
+                "50.0" : 364.95760564959,
+                "90.0" : 369.1244118472276,
+                "95.0" : 369.1244118472276,
+                "99.0" : 369.1244118472276,
+                "99.9" : 369.1244118472276,
+                "99.99" : 369.1244118472276,
+                "99.999" : 369.1244118472276,
+                "99.9999" : 369.1244118472276,
+                "100.0" : 369.1244118472276
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    359.4549246400141,
+                    361.05015724242276,
+                    360.8761874765065
+                ],
+                [
+                    368.87256163582623,
+                    369.1244118472276,
+                    368.86505405675723
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 115.77528137932985,
+            "scoreError" : 7.787689194770137,
+            "scoreConfidence" : [
+                107.98759218455972,
+                123.56297057409999
+            ],
+            "scorePercentiles" : {
+                "0.0" : 113.23645627549102,
+                "50.0" : 115.5588810622726,
+                "90.0" : 119.14733439993067,
+                "95.0" : 119.14733439993067,
+                "99.0" : 119.14733439993067,
+                "99.9" : 119.14733439993067,
+                "99.99" : 119.14733439993067,
+                "99.999" : 119.14733439993067,
+                "99.9999" : 119.14733439993067,
+                "100.0" : 119.14733439993067
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    117.7864352194171,
+                    117.8825585917375,
+                    119.14733439993067
+                ],
+                [
+                    113.33132690512811,
+                    113.26757688427469,
+                    113.23645627549102
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06049346387580512,
+            "scoreError" : 7.859587470598575E-4,
+            "scoreConfidence" : [
+                0.059707505128745265,
+                0.061279422622864975
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06017511353680258,
+                "50.0" : 0.060454173513933646,
+                "90.0" : 0.060855889408184996,
+                "95.0" : 0.060855889408184996,
+                "99.0" : 0.060855889408184996,
+                "99.9" : 0.060855889408184996,
+                "99.99" : 0.060855889408184996,
+                "99.999" : 0.060855889408184996,
+                "99.9999" : 0.060855889408184996,
+                "100.0" : 0.060855889408184996
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06026878445813194,
+                    0.06017511353680258,
+                    0.06031392135800533
+                ],
+                [
+                    0.060594425669861965,
+                    0.060752648823843895,
+                    0.060855889408184996
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.729188599058461E-4,
+            "scoreError" : 1.3726291888036013E-5,
+            "scoreConfidence" : [
+                3.591925680178101E-4,
+                3.866451517938821E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6817120662905586E-4,
+                "50.0" : 3.729718127923688E-4,
+                "90.0" : 3.7772497079961243E-4,
+                "95.0" : 3.7772497079961243E-4,
+                "99.0" : 3.7772497079961243E-4,
+                "99.9" : 3.7772497079961243E-4,
+                "99.99" : 3.7772497079961243E-4,
+                "99.999" : 3.7772497079961243E-4,
+                "99.9999" : 3.7772497079961243E-4,
+                "100.0" : 3.7772497079961243E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.770763980619547E-4,
+                    3.7733380655560506E-4,
+                    3.7772497079961243E-4
+                ],
+                [
+                    3.6833954986606585E-4,
+                    3.6817120662905586E-4,
+                    3.6886722752278283E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.216902428826293,
+            "scoreError" : 0.05451825340960591,
+            "scoreConfidence" : [
+                2.162384175416687,
+                2.271420682235899
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1693895078091106,
+                "50.0" : 2.205861210141822,
+                "90.0" : 2.2829139326881083,
+                "95.0" : 2.2872456162817287,
+                "99.0" : 2.2872456162817287,
+                "99.9" : 2.2872456162817287,
+                "99.99" : 2.2872456162817287,
+                "99.999" : 2.2872456162817287,
+                "99.9999" : 2.2872456162817287,
+                "100.0" : 2.2872456162817287
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.2872456162817287,
+                    2.2439287803455237,
+                    2.2436241720502466,
+                    2.204091635962979,
+                    2.2030550044052863
+                ],
+                [
+                    2.2351169865921787,
+                    2.2052204271223816,
+                    2.206501993161262,
+                    2.1693895078091106,
+                    2.1708501645322333
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013695978705737737,
+            "scoreError" : 8.606419870460759E-4,
+            "scoreConfidence" : [
+                0.012835336718691661,
+                0.014556620692783812
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013411003473400325,
+                "50.0" : 0.013691157007393954,
+                "90.0" : 0.01398595846648942,
+                "95.0" : 0.01398595846648942,
+                "99.0" : 0.01398595846648942,
+                "99.9" : 0.01398595846648942,
+                "99.99" : 0.01398595846648942,
+                "99.999" : 0.01398595846648942,
+                "99.9999" : 0.01398595846648942,
+                "100.0" : 0.01398595846648942
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013960090403233124,
+                    0.01398595846648942,
+                    0.01398199858783525
+                ],
+                [
+                    0.013422223611554785,
+                    0.013414597691913515,
+                    0.013411003473400325
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1447335566666024,
+            "scoreError" : 0.3304089706284979,
+            "scoreConfidence" : [
+                0.8143245860381045,
+                1.4751425272951002
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0366665711620193,
+                "50.0" : 1.1450084331606174,
+                "90.0" : 1.2524749054477144,
+                "95.0" : 1.2524749054477144,
+                "99.0" : 1.2524749054477144,
+                "99.9" : 1.2524749054477144,
+                "99.99" : 1.2524749054477144,
+                "99.999" : 1.2524749054477144,
+                "99.9999" : 1.2524749054477144,
+                "100.0" : 1.2524749054477144
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.2524749054477144,
+                    1.2521755517716289,
+                    1.2522309889807162
+                ],
+                [
+                    1.0366665711620193,
+                    1.0378413145496057,
+                    1.0370120080879304
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010872338060748618,
+            "scoreError" : 7.875489511301444E-4,
+            "scoreConfidence" : [
+                0.010084789109618474,
+                0.011659887011878763
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010609659684264132,
+                "50.0" : 0.010874077615500622,
+                "90.0" : 0.011137752716985755,
+                "95.0" : 0.011137752716985755,
+                "99.0" : 0.011137752716985755,
+                "99.9" : 0.011137752716985755,
+                "99.99" : 0.011137752716985755,
+                "99.999" : 0.011137752716985755,
+                "99.9999" : 0.011137752716985755,
+                "100.0" : 0.011137752716985755
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.011137752716985755,
+                    0.011123760862649304,
+                    0.011124399943044537
+                ],
+                [
+                    0.010609659684264132,
+                    0.01061406078919605,
+                    0.01062439436835194
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.9032238353375113,
+            "scoreError" : 0.029065069458538192,
+            "scoreConfidence" : [
+                2.874158765878973,
+                2.9322889047960494
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8922685546558706,
+                "50.0" : 2.901881152490569,
+                "90.0" : 2.917420096849475,
+                "95.0" : 2.917420096849475,
+                "99.0" : 2.917420096849475,
+                "99.9" : 2.917420096849475,
+                "99.99" : 2.917420096849475,
+                "99.999" : 2.917420096849475,
+                "99.9999" : 2.917420096849475,
+                "100.0" : 2.917420096849475
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8922685546558706,
+                    2.8980130254924683,
+                    2.89340880335454
+                ],
+                [
+                    2.917420096849475,
+                    2.912483252184042,
+                    2.9057492794886692
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.766060846646537,
+            "scoreError" : 0.03905353712146018,
+            "scoreConfidence" : [
+                2.7270073095250766,
+                2.805114383767997
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.747877988736264,
+                "50.0" : 2.7678371166711218,
+                "90.0" : 2.7810199571746383,
+                "95.0" : 2.7810199571746383,
+                "99.0" : 2.7810199571746383,
+                "99.9" : 2.7810199571746383,
+                "99.99" : 2.7810199571746383,
+                "99.999" : 2.7810199571746383,
+                "99.9999" : 2.7810199571746383,
+                "100.0" : 2.7810199571746383
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7590000217931037,
+                    2.7546526948499035,
+                    2.747877988736264
+                ],
+                [
+                    2.7810199571746383,
+                    2.777140205776173,
+                    2.7766742115491394
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18262130116096573,
+            "scoreError" : 0.0026071335660772044,
+            "scoreConfidence" : [
+                0.18001416759488853,
+                0.18522843472704292
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.18074981560540063,
+                "50.0" : 0.1830183406186363,
+                "90.0" : 0.1831431706285254,
+                "95.0" : 0.1831431706285254,
+                "99.0" : 0.1831431706285254,
+                "99.9" : 0.1831431706285254,
+                "99.99" : 0.1831431706285254,
+                "99.999" : 0.1831431706285254,
+                "99.9999" : 0.1831431706285254,
+                "100.0" : 0.1831431706285254
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18301184828520187,
+                    0.1831431706285254,
+                    0.18309591726019372
+                ],
+                [
+                    0.18302483295207073,
+                    0.18074981560540063,
+                    0.1827022222344021
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32618476215492626,
+            "scoreError" : 0.005779750330450696,
+            "scoreConfidence" : [
+                0.32040501182447556,
+                0.33196451248537695
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3232461241555419,
+                "50.0" : 0.32669302834870045,
+                "90.0" : 0.3281562675395419,
+                "95.0" : 0.3281562675395419,
+                "99.0" : 0.3281562675395419,
+                "99.9" : 0.3281562675395419,
+                "99.99" : 0.3281562675395419,
+                "99.999" : 0.3281562675395419,
+                "99.9999" : 0.3281562675395419,
+                "100.0" : 0.3281562675395419
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3281562675395419,
+                    0.32786587377463033,
+                    0.3277841438591891
+                ],
+                [
+                    0.3232461241555419,
+                    0.3256019128382118,
+                    0.3244542507624424
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1501116655451558,
+            "scoreError" : 0.017195866710150855,
+            "scoreConfidence" : [
+                0.13291579883500493,
+                0.16730753225530665
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1444767848505425,
+                "50.0" : 0.15005635325329159,
+                "90.0" : 0.1559065325756513,
+                "95.0" : 0.1559065325756513,
+                "99.0" : 0.1559065325756513,
+                "99.9" : 0.1559065325756513,
+                "99.99" : 0.1559065325756513,
+                "99.999" : 0.1559065325756513,
+                "99.9999" : 0.1559065325756513,
+                "100.0" : 0.1559065325756513
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14457071159267343,
+                    0.14449699932087795,
+                    0.1444767848505425
+                ],
+                [
+                    0.1559065325756513,
+                    0.15554199491390977,
+                    0.15567697001727976
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.41109512545593235,
+            "scoreError" : 0.02560439032892376,
+            "scoreConfidence" : [
+                0.3854907351270086,
+                0.4366995157848561
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4000532424290915,
+                "50.0" : 0.41107266356412986,
+                "90.0" : 0.4205459009209807,
+                "95.0" : 0.4205459009209807,
+                "99.0" : 0.4205459009209807,
+                "99.9" : 0.4205459009209807,
+                "99.99" : 0.4205459009209807,
+                "99.999" : 0.4205459009209807,
+                "99.9999" : 0.4205459009209807,
+                "100.0" : 0.4205459009209807
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4205459009209807,
+                    0.42006693438904524,
+                    0.4170437050752742
+                ],
+                [
+                    0.4051016220529855,
+                    0.40375934786821704,
+                    0.4000532424290915
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15625677940501717,
+            "scoreError" : 0.0033627302014880727,
+            "scoreConfidence" : [
+                0.1528940492035291,
+                0.15961950960650526
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15420729247945228,
+                "50.0" : 0.15672190467866648,
+                "90.0" : 0.15735531199647532,
+                "95.0" : 0.15735531199647532,
+                "99.0" : 0.15735531199647532,
+                "99.9" : 0.15735531199647532,
+                "99.99" : 0.15735531199647532,
+                "99.999" : 0.15735531199647532,
+                "99.9999" : 0.15735531199647532,
+                "100.0" : 0.15735531199647532
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15708646554405367,
+                    0.15544779705278866,
+                    0.15420729247945228
+                ],
+                [
+                    0.15666065903750354,
+                    0.15678315031982942,
+                    0.15735531199647532
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04690906078072993,
+            "scoreError" : 0.0026304886439702684,
+            "scoreConfidence" : [
+                0.04427857213675966,
+                0.049539549424700194
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04591221742344245,
+                "50.0" : 0.04695827998021913,
+                "90.0" : 0.047964355861883724,
+                "95.0" : 0.047964355861883724,
+                "99.0" : 0.047964355861883724,
+                "99.9" : 0.047964355861883724,
+                "99.99" : 0.047964355861883724,
+                "99.999" : 0.047964355861883724,
+                "99.9999" : 0.047964355861883724,
+                "100.0" : 0.047964355861883724
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.047964355861883724,
+                    0.047666461366864636,
+                    0.04762084605897255
+                ],
+                [
+                    0.0462957139014657,
+                    0.04591221742344245,
+                    0.045994770071750526
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8838320.439725092,
+            "scoreError" : 262226.2029382935,
+            "scoreConfidence" : [
+                8576094.236786798,
+                9100546.642663386
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8752911.867016623,
+                "50.0" : 8824053.922188774,
+                "90.0" : 8978221.642728904,
+                "95.0" : 8978221.642728904,
+                "99.0" : 8978221.642728904,
+                "99.9" : 8978221.642728904,
+                "99.99" : 8978221.642728904,
+                "99.999" : 8978221.642728904,
+                "99.9999" : 8978221.642728904,
+                "100.0" : 8978221.642728904
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8978221.642728904,
+                    8880609.316770187,
+                    8895035.770666666
+                ],
+                [
+                    8752911.867016623,
+                    8755645.513560805,
+                    8767498.527607363
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-01-31T05-21-04Z-cf25f3dcd5ae9f5aa43898f6164593dcc11e748d-jdk17.json
+++ b/performance-results/2026-01-31T05-21-04Z-cf25f3dcd5ae9f5aa43898f6164593dcc11e748d-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.339969287314002,
+            "scoreError" : 0.05159769878499655,
+            "scoreConfidence" : [
+                3.2883715885290052,
+                3.3915669860989985
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.331522612905315,
+                "50.0" : 3.340529374926411,
+                "90.0" : 3.3472957864978716,
+                "95.0" : 3.3472957864978716,
+                "99.0" : 3.3472957864978716,
+                "99.9" : 3.3472957864978716,
+                "99.99" : 3.3472957864978716,
+                "99.999" : 3.3472957864978716,
+                "99.9999" : 3.3472957864978716,
+                "100.0" : 3.3472957864978716
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.33480138025083,
+                    3.3472957864978716
+                ],
+                [
+                    3.331522612905315,
+                    3.3462573696019913
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6771830588638232,
+            "scoreError" : 0.021963111604210824,
+            "scoreConfidence" : [
+                1.6552199472596125,
+                1.699146170468034
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.672505157037573,
+                "50.0" : 1.6781887553230634,
+                "90.0" : 1.6798495677715934,
+                "95.0" : 1.6798495677715934,
+                "99.0" : 1.6798495677715934,
+                "99.9" : 1.6798495677715934,
+                "99.99" : 1.6798495677715934,
+                "99.999" : 1.6798495677715934,
+                "99.9999" : 1.6798495677715934,
+                "100.0" : 1.6798495677715934
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6768396887567114,
+                    1.6795378218894155
+                ],
+                [
+                    1.672505157037573,
+                    1.6798495677715934
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8447812270552875,
+            "scoreError" : 0.018338426835167912,
+            "scoreConfidence" : [
+                0.8264428002201195,
+                0.8631196538904554
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8418095547392459,
+                "50.0" : 0.8444958959300572,
+                "90.0" : 0.8483235616217898,
+                "95.0" : 0.8483235616217898,
+                "99.0" : 0.8483235616217898,
+                "99.9" : 0.8483235616217898,
+                "99.99" : 0.8483235616217898,
+                "99.999" : 0.8483235616217898,
+                "99.9999" : 0.8483235616217898,
+                "100.0" : 0.8483235616217898
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8433515419078327,
+                    0.8483235616217898
+                ],
+                [
+                    0.8418095547392459,
+                    0.8456402499522817
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.17234518940149,
+            "scoreError" : 0.1585507168175455,
+            "scoreConfidence" : [
+                16.013794472583946,
+                16.330895906219034
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.085288300891833,
+                "50.0" : 16.185056533347886,
+                "90.0" : 16.225930070295128,
+                "95.0" : 16.225930070295128,
+                "99.0" : 16.225930070295128,
+                "99.9" : 16.225930070295128,
+                "99.99" : 16.225930070295128,
+                "99.999" : 16.225930070295128,
+                "99.9999" : 16.225930070295128,
+                "100.0" : 16.225930070295128
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.21019104901636,
+                    16.225930070295128,
+                    16.220613378436003
+                ],
+                [
+                    16.085288300891833,
+                    16.159922017679413,
+                    16.132126320090194
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2605.252930080864,
+            "scoreError" : 222.44477910002448,
+            "scoreConfidence" : [
+                2382.80815098084,
+                2827.6977091808885
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2526.401875907637,
+                "50.0" : 2606.274956488788,
+                "90.0" : 2682.58055837545,
+                "95.0" : 2682.58055837545,
+                "99.0" : 2682.58055837545,
+                "99.9" : 2682.58055837545,
+                "99.99" : 2682.58055837545,
+                "99.999" : 2682.58055837545,
+                "99.9999" : 2682.58055837545,
+                "100.0" : 2682.58055837545
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2679.9366141141654,
+                    2669.6411603677006,
+                    2682.58055837545
+                ],
+                [
+                    2530.0486191103555,
+                    2526.401875907637,
+                    2542.908752609876
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74075.30782680227,
+            "scoreError" : 3251.8569226526083,
+            "scoreConfidence" : [
+                70823.45090414966,
+                77327.16474945487
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72999.09931078371,
+                "50.0" : 74073.57783728522,
+                "90.0" : 75157.13556108934,
+                "95.0" : 75157.13556108934,
+                "99.0" : 75157.13556108934,
+                "99.9" : 75157.13556108934,
+                "99.99" : 75157.13556108934,
+                "99.999" : 75157.13556108934,
+                "99.9999" : 75157.13556108934,
+                "100.0" : 75157.13556108934
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    75157.13556108934,
+                    75097.89027131636,
+                    75145.87390976453
+                ],
+                [
+                    73049.26540325409,
+                    73002.58250460557,
+                    72999.09931078371
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 356.3538942158634,
+            "scoreError" : 6.5438455536749744,
+            "scoreConfidence" : [
+                349.8100486621884,
+                362.8977397695384
+            ],
+            "scorePercentiles" : {
+                "0.0" : 353.62449526473193,
+                "50.0" : 356.0956479140817,
+                "90.0" : 359.3872100258217,
+                "95.0" : 359.3872100258217,
+                "99.0" : 359.3872100258217,
+                "99.9" : 359.3872100258217,
+                "99.99" : 359.3872100258217,
+                "99.999" : 359.3872100258217,
+                "99.9999" : 359.3872100258217,
+                "100.0" : 359.3872100258217
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    354.24749322400584,
+                    355.5344783376665,
+                    353.62449526473193
+                ],
+                [
+                    356.6568174904969,
+                    359.3872100258217,
+                    358.6728709524579
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 114.77880348245166,
+            "scoreError" : 1.4330607607938317,
+            "scoreConfidence" : [
+                113.34574272165783,
+                116.2118642432455
+            ],
+            "scorePercentiles" : {
+                "0.0" : 114.09414702730457,
+                "50.0" : 114.86508735976216,
+                "90.0" : 115.29231485640554,
+                "95.0" : 115.29231485640554,
+                "99.0" : 115.29231485640554,
+                "99.9" : 115.29231485640554,
+                "99.99" : 115.29231485640554,
+                "99.999" : 115.29231485640554,
+                "99.9999" : 115.29231485640554,
+                "100.0" : 115.29231485640554
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    114.2840296982651,
+                    114.67761535379012,
+                    114.09414702730457
+                ],
+                [
+                    115.2721545932105,
+                    115.05255936573421,
+                    115.29231485640554
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.062188839499992994,
+            "scoreError" : 0.0035150396810887234,
+            "scoreConfidence" : [
+                0.05867379981890427,
+                0.06570387918108171
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061004543663260635,
+                "50.0" : 0.06219866654016899,
+                "90.0" : 0.06340711974206475,
+                "95.0" : 0.06340711974206475,
+                "99.0" : 0.06340711974206475,
+                "99.9" : 0.06340711974206475,
+                "99.99" : 0.06340711974206475,
+                "99.999" : 0.06340711974206475,
+                "99.9999" : 0.06340711974206475,
+                "100.0" : 0.06340711974206475
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06101503895691859,
+                    0.06111775338128969,
+                    0.061004543663260635
+                ],
+                [
+                    0.06340711974206475,
+                    0.06330900155737601,
+                    0.0632795796990483
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.809710819304895E-4,
+            "scoreError" : 4.071703404971625E-5,
+            "scoreConfidence" : [
+                3.4025404788077325E-4,
+                4.216881159802057E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.67648958374387E-4,
+                "50.0" : 3.8028978003213374E-4,
+                "90.0" : 3.9583511110620283E-4,
+                "95.0" : 3.9583511110620283E-4,
+                "99.0" : 3.9583511110620283E-4,
+                "99.9" : 3.9583511110620283E-4,
+                "99.99" : 3.9583511110620283E-4,
+                "99.999" : 3.9583511110620283E-4,
+                "99.9999" : 3.9583511110620283E-4,
+                "100.0" : 3.9583511110620283E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.67648958374387E-4,
+                    3.6791045614285005E-4,
+                    3.6768471756470753E-4
+                ],
+                [
+                    3.926691039214175E-4,
+                    3.9407814447337203E-4,
+                    3.9583511110620283E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2958032907674144,
+            "scoreError" : 0.05567946959240448,
+            "scoreConfidence" : [
+                2.24012382117501,
+                2.351482760359819
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2508422151699303,
+                "50.0" : 2.2989132881986523,
+                "90.0" : 2.353194593470312,
+                "95.0" : 2.354859076760066,
+                "99.0" : 2.354859076760066,
+                "99.9" : 2.354859076760066,
+                "99.99" : 2.354859076760066,
+                "99.999" : 2.354859076760066,
+                "99.9999" : 2.354859076760066,
+                "100.0" : 2.354859076760066
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.354859076760066,
+                    2.290591558634906,
+                    2.307235017762399,
+                    2.2516512976136873,
+                    2.2508422151699303
+                ],
+                [
+                    2.3382142438625206,
+                    2.3109938433456563,
+                    2.322007300139276,
+                    2.2596327080885676,
+                    2.2720056462971376
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013569128311397149,
+            "scoreError" : 3.6020105169105155E-4,
+            "scoreConfidence" : [
+                0.013208927259706097,
+                0.0139293293630882
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013445212256762516,
+                "50.0" : 0.013570911748556971,
+                "90.0" : 0.01369654243748639,
+                "95.0" : 0.01369654243748639,
+                "99.0" : 0.01369654243748639,
+                "99.9" : 0.01369654243748639,
+                "99.99" : 0.01369654243748639,
+                "99.999" : 0.01369654243748639,
+                "99.9999" : 0.01369654243748639,
+                "100.0" : 0.01369654243748639
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013684817830868265,
+                    0.01369654243748639,
+                    0.013676859555809637
+                ],
+                [
+                    0.013446373846151778,
+                    0.013464963941304307,
+                    0.013445212256762516
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.013565065393729,
+            "scoreError" : 0.00638805592418559,
+            "scoreConfidence" : [
+                1.0071770094695434,
+                1.0199531213179145
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0105501372271626,
+                "50.0" : 1.0138759474759234,
+                "90.0" : 1.0158180670391062,
+                "95.0" : 1.0158180670391062,
+                "99.0" : 1.0158180670391062,
+                "99.9" : 1.0158180670391062,
+                "99.99" : 1.0158180670391062,
+                "99.999" : 1.0158180670391062,
+                "99.9999" : 1.0158180670391062,
+                "100.0" : 1.0158180670391062
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0156163350258962,
+                    1.0158180670391062,
+                    1.015241275532995
+                ],
+                [
+                    1.0105501372271626,
+                    1.0116539581183612,
+                    1.0125106194188518
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010933177851886773,
+            "scoreError" : 0.0011939826071591837,
+            "scoreConfidence" : [
+                0.00973919524472759,
+                0.012127160459045957
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010538789332911793,
+                "50.0" : 0.010926375114307909,
+                "90.0" : 0.011357291606285406,
+                "95.0" : 0.011357291606285406,
+                "99.0" : 0.011357291606285406,
+                "99.9" : 0.011357291606285406,
+                "99.99" : 0.011357291606285406,
+                "99.999" : 0.011357291606285406,
+                "99.9999" : 0.011357291606285406,
+                "100.0" : 0.011357291606285406
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010538789332911793,
+                    0.01054131230393645,
+                    0.010554745951297358
+                ],
+                [
+                    0.011298004277318462,
+                    0.011308923639571176,
+                    0.011357291606285406
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1647743171464673,
+            "scoreError" : 0.29372568977668706,
+            "scoreConfidence" : [
+                2.87104862736978,
+                3.4585000069231544
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.052023389871873,
+                "50.0" : 3.168568426839827,
+                "90.0" : 3.269058877777778,
+                "95.0" : 3.269058877777778,
+                "99.0" : 3.269058877777778,
+                "99.9" : 3.269058877777778,
+                "99.99" : 3.269058877777778,
+                "99.999" : 3.269058877777778,
+                "99.9999" : 3.269058877777778,
+                "100.0" : 3.269058877777778
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.052023389871873,
+                    3.0881836666666667,
+                    3.06951237607362
+                ],
+                [
+                    3.248953187012987,
+                    3.26091440547588,
+                    3.269058877777778
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.829973251182846,
+            "scoreError" : 0.24431121970780706,
+            "scoreConfidence" : [
+                2.5856620314750387,
+                3.074284470890653
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.744946099066959,
+                "50.0" : 2.8296507126732995,
+                "90.0" : 2.922139899795501,
+                "95.0" : 2.922139899795501,
+                "99.0" : 2.922139899795501,
+                "99.9" : 2.922139899795501,
+                "99.99" : 2.922139899795501,
+                "99.999" : 2.922139899795501,
+                "99.9999" : 2.922139899795501,
+                "100.0" : 2.922139899795501
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.922139899795501,
+                    2.9054659985473563,
+                    2.899676276891853
+                ],
+                [
+                    2.744946099066959,
+                    2.759625148454746,
+                    2.7479860843406594
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17752051019228357,
+            "scoreError" : 0.0035992435330778204,
+            "scoreConfidence" : [
+                0.17392126665920574,
+                0.1811197537253614
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17628506279086165,
+                "50.0" : 0.17749740794111818,
+                "90.0" : 0.17877866547482837,
+                "95.0" : 0.17877866547482837,
+                "99.0" : 0.17877866547482837,
+                "99.9" : 0.17877866547482837,
+                "99.99" : 0.17877866547482837,
+                "99.999" : 0.17877866547482837,
+                "99.9999" : 0.17877866547482837,
+                "100.0" : 0.17877866547482837
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17877866547482837,
+                    0.17871949586274685,
+                    0.17857153257977537
+                ],
+                [
+                    0.17642328330246096,
+                    0.17634502114302844,
+                    0.17628506279086165
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3308454126638525,
+            "scoreError" : 0.0417210971087841,
+            "scoreConfidence" : [
+                0.2891243155550684,
+                0.37256650977263656
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.316707128103623,
+                "50.0" : 0.3308686302660212,
+                "90.0" : 0.3449500232485944,
+                "95.0" : 0.3449500232485944,
+                "99.0" : 0.3449500232485944,
+                "99.9" : 0.3449500232485944,
+                "99.99" : 0.3449500232485944,
+                "99.999" : 0.3449500232485944,
+                "99.9999" : 0.3449500232485944,
+                "100.0" : 0.3449500232485944
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.34435682056403016,
+                    0.343954930556511,
+                    0.3449500232485944
+                ],
+                [
+                    0.316707128103623,
+                    0.31732124353482466,
+                    0.31778232997553146
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14515086665019858,
+            "scoreError" : 0.0024874308969490056,
+            "scoreConfidence" : [
+                0.14266343575324958,
+                0.14763829754714758
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1442505797187162,
+                "50.0" : 0.14508757111025114,
+                "90.0" : 0.1461046955556205,
+                "95.0" : 0.1461046955556205,
+                "99.0" : 0.1461046955556205,
+                "99.9" : 0.1461046955556205,
+                "99.99" : 0.1461046955556205,
+                "99.999" : 0.1461046955556205,
+                "99.9999" : 0.1461046955556205,
+                "100.0" : 0.1461046955556205
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1443530955597898,
+                    0.14445073100868133,
+                    0.1442505797187162
+                ],
+                [
+                    0.1461046955556205,
+                    0.14572441121182095,
+                    0.1460216868465627
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3920320712558662,
+            "scoreError" : 0.017304092440630525,
+            "scoreConfidence" : [
+                0.3747279788152357,
+                0.4093361636964967
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3859801712918291,
+                "50.0" : 0.3916867072142528,
+                "90.0" : 0.3992139409580838,
+                "95.0" : 0.3992139409580838,
+                "99.0" : 0.3992139409580838,
+                "99.9" : 0.3992139409580838,
+                "99.99" : 0.3992139409580838,
+                "99.999" : 0.3992139409580838,
+                "99.9999" : 0.3992139409580838,
+                "100.0" : 0.3992139409580838
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3866876234097676,
+                    0.3859801712918291,
+                    0.3867204828879694
+                ],
+                [
+                    0.3992139409580838,
+                    0.39665293154053627,
+                    0.3969372774470112
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16119357684555885,
+            "scoreError" : 0.00351495326374915,
+            "scoreConfidence" : [
+                0.1576786235818097,
+                0.164708530109308
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1586797305501341,
+                "50.0" : 0.1616064234475985,
+                "90.0" : 0.16210987273051486,
+                "95.0" : 0.16210987273051486,
+                "99.0" : 0.16210987273051486,
+                "99.9" : 0.16210987273051486,
+                "99.99" : 0.16210987273051486,
+                "99.999" : 0.16210987273051486,
+                "99.9999" : 0.16210987273051486,
+                "100.0" : 0.16210987273051486
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16174641845795526,
+                    0.1615719282632931,
+                    0.16141259243955192
+                ],
+                [
+                    0.16210987273051486,
+                    0.1616409186319039,
+                    0.1586797305501341
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.046149718913408196,
+            "scoreError" : 5.946494344506537E-4,
+            "scoreConfidence" : [
+                0.045555069478957544,
+                0.04674436834785885
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04592058230434723,
+                "50.0" : 0.04615525843311659,
+                "90.0" : 0.04637219860514076,
+                "95.0" : 0.04637219860514076,
+                "99.0" : 0.04637219860514076,
+                "99.9" : 0.04637219860514076,
+                "99.99" : 0.04637219860514076,
+                "99.999" : 0.04637219860514076,
+                "99.9999" : 0.04637219860514076,
+                "100.0" : 0.04637219860514076
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04631969323834845,
+                    0.04633283569241033,
+                    0.04637219860514076
+                ],
+                [
+                    0.04592058230434723,
+                    0.04599082362788473,
+                    0.045962180012317645
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8851415.471197268,
+            "scoreError" : 316632.3472142587,
+            "scoreConfidence" : [
+                8534783.123983009,
+                9168047.818411527
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8731515.690226875,
+                "50.0" : 8857350.113097524,
+                "90.0" : 8958873.234556848,
+                "95.0" : 8958873.234556848,
+                "99.0" : 8958873.234556848,
+                "99.9" : 8958873.234556848,
+                "99.99" : 8958873.234556848,
+                "99.999" : 8958873.234556848,
+                "99.9999" : 8958873.234556848,
+                "100.0" : 8958873.234556848
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8768367.744084137,
+                    8747015.247377623,
+                    8731515.690226875
+                ],
+                [
+                    8956388.428827215,
+                    8958873.234556848,
+                    8946332.482110912
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-05T07-24-24Z-99dd2fdcdd0f13b1a0f3569a3d03bdaab92e1aa5-jdk17.json
+++ b/performance-results/2026-02-05T07-24-24Z-99dd2fdcdd0f13b1a0f3569a3d03bdaab92e1aa5-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.337913184951492,
+            "scoreError" : 0.04698295182466038,
+            "scoreConfidence" : [
+                3.2909302331268315,
+                3.384896136776152
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3280842068138554,
+                "50.0" : 3.3400518921320828,
+                "90.0" : 3.3434647487279467,
+                "95.0" : 3.3434647487279467,
+                "99.0" : 3.3434647487279467,
+                "99.9" : 3.3434647487279467,
+                "99.99" : 3.3434647487279467,
+                "99.999" : 3.3434647487279467,
+                "99.9999" : 3.3434647487279467,
+                "100.0" : 3.3434647487279467
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3367344497471576,
+                    3.3433693345170084
+                ],
+                [
+                    3.3280842068138554,
+                    3.3434647487279467
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6829631916900718,
+            "scoreError" : 0.04561612770511524,
+            "scoreConfidence" : [
+                1.6373470639849566,
+                1.728579319395187
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6749449616090664,
+                "50.0" : 1.6824546217536276,
+                "90.0" : 1.6919985616439663,
+                "95.0" : 1.6919985616439663,
+                "99.0" : 1.6919985616439663,
+                "99.9" : 1.6919985616439663,
+                "99.99" : 1.6919985616439663,
+                "99.999" : 1.6919985616439663,
+                "99.9999" : 1.6919985616439663,
+                "100.0" : 1.6919985616439663
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6749449616090664,
+                    1.6812202338467988
+                ],
+                [
+                    1.6836890096604562,
+                    1.6919985616439663
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8472557536184141,
+            "scoreError" : 0.037051789415153115,
+            "scoreConfidence" : [
+                0.810203964203261,
+                0.8843075430335672
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8414547230362381,
+                "50.0" : 0.8469267162011911,
+                "90.0" : 0.8537148590350364,
+                "95.0" : 0.8537148590350364,
+                "99.0" : 0.8537148590350364,
+                "99.9" : 0.8537148590350364,
+                "99.99" : 0.8537148590350364,
+                "99.999" : 0.8537148590350364,
+                "99.9999" : 0.8537148590350364,
+                "100.0" : 0.8537148590350364
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8435325267440884,
+                    0.8537148590350364
+                ],
+                [
+                    0.8414547230362381,
+                    0.8503209056582937
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.098731808165372,
+            "scoreError" : 0.2829182453402518,
+            "scoreConfidence" : [
+                15.81581356282512,
+                16.381650053505624
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.002008060713916,
+                "50.0" : 16.09787021188509,
+                "90.0" : 16.192914761878185,
+                "95.0" : 16.192914761878185,
+                "99.0" : 16.192914761878185,
+                "99.9" : 16.192914761878185,
+                "99.99" : 16.192914761878185,
+                "99.999" : 16.192914761878185,
+                "99.9999" : 16.192914761878185,
+                "100.0" : 16.192914761878185
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.00893681467966,
+                    16.009107283078794,
+                    16.002008060713916
+                ],
+                [
+                    16.19279078795028,
+                    16.192914761878185,
+                    16.186633140691388
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2821.656570116081,
+            "scoreError" : 114.86953507191554,
+            "scoreConfidence" : [
+                2706.787035044166,
+                2936.5261051879966
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2783.3116164476737,
+                "50.0" : 2821.6997555051234,
+                "90.0" : 2860.1310800192905,
+                "95.0" : 2860.1310800192905,
+                "99.0" : 2860.1310800192905,
+                "99.9" : 2860.1310800192905,
+                "99.99" : 2860.1310800192905,
+                "99.999" : 2860.1310800192905,
+                "99.9999" : 2860.1310800192905,
+                "100.0" : 2860.1310800192905
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2859.4818952465516,
+                    2860.1310800192905,
+                    2857.4877168928037
+                ],
+                [
+                    2783.6153179727257,
+                    2785.911794117443,
+                    2783.3116164476737
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74293.7975037027,
+            "scoreError" : 153.66091530384085,
+            "scoreConfidence" : [
+                74140.13658839886,
+                74447.45841900655
+            ],
+            "scorePercentiles" : {
+                "0.0" : 74220.93267644702,
+                "50.0" : 74305.15246753859,
+                "90.0" : 74373.59834381487,
+                "95.0" : 74373.59834381487,
+                "99.0" : 74373.59834381487,
+                "99.9" : 74373.59834381487,
+                "99.99" : 74373.59834381487,
+                "99.999" : 74373.59834381487,
+                "99.9999" : 74373.59834381487,
+                "100.0" : 74373.59834381487
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74242.94595062346,
+                    74220.93267644702,
+                    74300.5345908639
+                ],
+                [
+                    74373.59834381487,
+                    74309.77034421328,
+                    74315.00311625369
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 359.2321539523534,
+            "scoreError" : 11.902976531799458,
+            "scoreConfidence" : [
+                347.32917742055395,
+                371.1351304841529
+            ],
+            "scorePercentiles" : {
+                "0.0" : 354.39261998632435,
+                "50.0" : 359.7149017352075,
+                "90.0" : 363.80957214760423,
+                "95.0" : 363.80957214760423,
+                "99.0" : 363.80957214760423,
+                "99.9" : 363.80957214760423,
+                "99.99" : 363.80957214760423,
+                "99.999" : 363.80957214760423,
+                "99.9999" : 363.80957214760423,
+                "100.0" : 363.80957214760423
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    357.72324157121216,
+                    354.57538888679983,
+                    354.39261998632435
+                ],
+                [
+                    361.70656189920277,
+                    363.1855392229775,
+                    363.80957214760423
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 114.57181487539599,
+            "scoreError" : 3.4846974997905242,
+            "scoreConfidence" : [
+                111.08711737560546,
+                118.05651237518651
+            ],
+            "scorePercentiles" : {
+                "0.0" : 113.20731304074661,
+                "50.0" : 114.65613880184782,
+                "90.0" : 115.76680113767726,
+                "95.0" : 115.76680113767726,
+                "99.0" : 115.76680113767726,
+                "99.9" : 115.76680113767726,
+                "99.99" : 115.76680113767726,
+                "99.999" : 115.76680113767726,
+                "99.9999" : 115.76680113767726,
+                "100.0" : 115.76680113767726
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    113.46885082609023,
+                    113.20731304074661,
+                    113.66060524558794
+                ],
+                [
+                    115.6516723581077,
+                    115.6756466441661,
+                    115.76680113767726
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06175662638194653,
+            "scoreError" : 9.785339184429814E-4,
+            "scoreConfidence" : [
+                0.060778092463503554,
+                0.06273516030038952
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06142954632348424,
+                "50.0" : 0.061755833978105745,
+                "90.0" : 0.06208687702633066,
+                "95.0" : 0.06208687702633066,
+                "99.0" : 0.06208687702633066,
+                "99.9" : 0.06208687702633066,
+                "99.99" : 0.06208687702633066,
+                "99.999" : 0.06208687702633066,
+                "99.9999" : 0.06208687702633066,
+                "100.0" : 0.06208687702633066
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06145071864073494,
+                    0.061434425235596946,
+                    0.06142954632348424
+                ],
+                [
+                    0.06208687702633066,
+                    0.06207724175005587,
+                    0.06206094931547656
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.589507242498722E-4,
+            "scoreError" : 2.450183276805211E-5,
+            "scoreConfidence" : [
+                3.3444889148182005E-4,
+                3.834525570179243E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.506715746790437E-4,
+                "50.0" : 3.5842942137273814E-4,
+                "90.0" : 3.6883588308494184E-4,
+                "95.0" : 3.6883588308494184E-4,
+                "99.0" : 3.6883588308494184E-4,
+                "99.9" : 3.6883588308494184E-4,
+                "99.99" : 3.6883588308494184E-4,
+                "99.999" : 3.6883588308494184E-4,
+                "99.9999" : 3.6883588308494184E-4,
+                "100.0" : 3.6883588308494184E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.661262659405927E-4,
+                    3.6883588308494184E-4,
+                    3.65624679948481E-4
+                ],
+                [
+                    3.5121177904917856E-4,
+                    3.512341627969953E-4,
+                    3.506715746790437E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.245645970866973,
+            "scoreError" : 0.052287385954534006,
+            "scoreConfidence" : [
+                2.1933585849124393,
+                2.297933356821507
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.200470293729373,
+                "50.0" : 2.249532265715435,
+                "90.0" : 2.2949393657126707,
+                "95.0" : 2.295848073674547,
+                "99.0" : 2.295848073674547,
+                "99.9" : 2.295848073674547,
+                "99.99" : 2.295848073674547,
+                "99.999" : 2.295848073674547,
+                "99.9999" : 2.295848073674547,
+                "100.0" : 2.295848073674547
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.286760994055784,
+                    2.2664353723090866,
+                    2.267803903628118,
+                    2.2207466112344583,
+                    2.2175863354767182
+                ],
+                [
+                    2.295848073674547,
+                    2.23891717662861,
+                    2.26014735480226,
+                    2.200470293729373,
+                    2.2017435931307796
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013374662350233575,
+            "scoreError" : 5.7871215623291E-4,
+            "scoreConfidence" : [
+                0.012795950194000665,
+                0.013953374506466486
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013175417407664569,
+                "50.0" : 0.013377536183201026,
+                "90.0" : 0.013563753144374713,
+                "95.0" : 0.013563753144374713,
+                "99.0" : 0.013563753144374713,
+                "99.9" : 0.013563753144374713,
+                "99.99" : 0.013563753144374713,
+                "99.999" : 0.013563753144374713,
+                "99.9999" : 0.013563753144374713,
+                "100.0" : 0.013563753144374713
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01356154931040562,
+                    0.013563753144374713,
+                    0.01356361416025228
+                ],
+                [
+                    0.013190117022707847,
+                    0.013193523055996432,
+                    0.013175417407664569
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0015362889605457,
+            "scoreError" : 0.044794206803788726,
+            "scoreConfidence" : [
+                0.9567420821567569,
+                1.0463304957643345
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9866192574980268,
+                "50.0" : 1.001370611974522,
+                "90.0" : 1.0165950266341364,
+                "95.0" : 1.0165950266341364,
+                "99.0" : 1.0165950266341364,
+                "99.9" : 1.0165950266341364,
+                "99.99" : 1.0165950266341364,
+                "99.999" : 1.0165950266341364,
+                "99.9999" : 1.0165950266341364,
+                "100.0" : 1.0165950266341364
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.016181184229245,
+                    1.0155671824921295,
+                    1.0165950266341364
+                ],
+                [
+                    0.9871740414569145,
+                    0.9866192574980268,
+                    0.9870810414528227
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01021456288849794,
+            "scoreError" : 3.9764435707850826E-4,
+            "scoreConfidence" : [
+                0.009816918531419432,
+                0.010612207245576448
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0100808675537545,
+                "50.0" : 0.010213614416656035,
+                "90.0" : 0.010347857317582978,
+                "95.0" : 0.010347857317582978,
+                "99.0" : 0.010347857317582978,
+                "99.9" : 0.010347857317582978,
+                "99.99" : 0.010347857317582978,
+                "99.999" : 0.010347857317582978,
+                "99.9999" : 0.010347857317582978,
+                "100.0" : 0.010347857317582978
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010338767438879147,
+                    0.010347857317582978,
+                    0.010345266349281228
+                ],
+                [
+                    0.0100808675537545,
+                    0.010086157277056862,
+                    0.010088461394432922
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.105127116300686,
+            "scoreError" : 0.36011821857244763,
+            "scoreConfidence" : [
+                2.7450088977282383,
+                3.4652453348731336
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9821657471675613,
+                "50.0" : 3.107256533722902,
+                "90.0" : 3.225954078709677,
+                "95.0" : 3.225954078709677,
+                "99.0" : 3.225954078709677,
+                "99.9" : 3.225954078709677,
+                "99.99" : 3.225954078709677,
+                "99.999" : 3.225954078709677,
+                "99.9999" : 3.225954078709677,
+                "100.0" : 3.225954078709677
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.225954078709677,
+                    3.2190292554697555,
+                    3.221845012242268
+                ],
+                [
+                    2.9821657471675613,
+                    2.995483811976048,
+                    2.986284792238806
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7728752673789354,
+            "scoreError" : 0.053994835643592545,
+            "scoreConfidence" : [
+                2.718880431735343,
+                2.826870103022528
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7525437328013207,
+                "50.0" : 2.7726896377299677,
+                "90.0" : 2.792992748673555,
+                "95.0" : 2.792992748673555,
+                "99.0" : 2.792992748673555,
+                "99.9" : 2.792992748673555,
+                "99.99" : 2.792992748673555,
+                "99.999" : 2.792992748673555,
+                "99.9999" : 2.792992748673555,
+                "100.0" : 2.792992748673555
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7525437328013207,
+                    2.755595720385675,
+                    2.7582345170987312
+                ],
+                [
+                    2.792992748673555,
+                    2.790740126953125,
+                    2.787144758361204
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1739414075105891,
+            "scoreError" : 0.007443286888975881,
+            "scoreConfidence" : [
+                0.1664981206216132,
+                0.18138469439956498
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1708583240731249,
+                "50.0" : 0.1746627517808456,
+                "90.0" : 0.17641062557552878,
+                "95.0" : 0.17641062557552878,
+                "99.0" : 0.17641062557552878,
+                "99.9" : 0.17641062557552878,
+                "99.99" : 0.17641062557552878,
+                "99.999" : 0.17641062557552878,
+                "99.9999" : 0.17641062557552878,
+                "100.0" : 0.17641062557552878
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17323072974986142,
+                    0.1708680631685063,
+                    0.1708583240731249
+                ],
+                [
+                    0.1761859286846834,
+                    0.17641062557552878,
+                    0.17609477381182975
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.32095231506424987,
+            "scoreError" : 0.011380214361249842,
+            "scoreConfidence" : [
+                0.309572100703,
+                0.33233252942549973
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.31705647541295456,
+                "50.0" : 0.3209176767804187,
+                "90.0" : 0.3250397191380095,
+                "95.0" : 0.3250397191380095,
+                "99.0" : 0.3250397191380095,
+                "99.9" : 0.3250397191380095,
+                "99.99" : 0.3250397191380095,
+                "99.999" : 0.3250397191380095,
+                "99.9999" : 0.3250397191380095,
+                "100.0" : 0.3250397191380095
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.324597972507141,
+                    0.32430690128421324,
+                    0.3250397191380095
+                ],
+                [
+                    0.31718436976655673,
+                    0.31705647541295456,
+                    0.31752845227662413
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1469122668713768,
+            "scoreError" : 8.978563768972946E-4,
+            "scoreConfidence" : [
+                0.1460144104944795,
+                0.14781012324827408
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14649210349373765,
+                "50.0" : 0.14703431398293818,
+                "90.0" : 0.14730143133644627,
+                "95.0" : 0.14730143133644627,
+                "99.0" : 0.14730143133644627,
+                "99.9" : 0.14730143133644627,
+                "99.99" : 0.14730143133644627,
+                "99.999" : 0.14730143133644627,
+                "99.9999" : 0.14730143133644627,
+                "100.0" : 0.14730143133644627
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14706261233823528,
+                    0.14730143133644627,
+                    0.14704204437647958
+                ],
+                [
+                    0.14702658358939677,
+                    0.14654882609396525,
+                    0.14649210349373765
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.402253674579012,
+            "scoreError" : 0.0068383793693766615,
+            "scoreConfidence" : [
+                0.39541529520963536,
+                0.40909205394838866
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3994707869297755,
+                "50.0" : 0.4028215088616773,
+                "90.0" : 0.4059346802110818,
+                "95.0" : 0.4059346802110818,
+                "99.0" : 0.4059346802110818,
+                "99.9" : 0.4059346802110818,
+                "99.99" : 0.4059346802110818,
+                "99.999" : 0.4059346802110818,
+                "99.9999" : 0.4059346802110818,
+                "100.0" : 0.4059346802110818
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40292901696281075,
+                    0.40281800555868846,
+                    0.4028250121646661
+                ],
+                [
+                    0.4059346802110818,
+                    0.39954454564704944,
+                    0.3994707869297755
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1570812096190851,
+            "scoreError" : 0.004793792139944655,
+            "scoreConfidence" : [
+                0.15228741747914043,
+                0.16187500175902975
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1554312709440766,
+                "50.0" : 0.15692916411313823,
+                "90.0" : 0.1591352000413736,
+                "95.0" : 0.1591352000413736,
+                "99.0" : 0.1591352000413736,
+                "99.9" : 0.1591352000413736,
+                "99.99" : 0.1591352000413736,
+                "99.999" : 0.1591352000413736,
+                "99.9999" : 0.1591352000413736,
+                "100.0" : 0.1591352000413736
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1591352000413736,
+                    0.158537323837154,
+                    0.15817075912628115
+                ],
+                [
+                    0.15568756909999534,
+                    0.15552513466562987,
+                    0.1554312709440766
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04701487418875871,
+            "scoreError" : 0.002351399342614408,
+            "scoreConfidence" : [
+                0.0446634748461443,
+                0.049366273531373114
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04602969264547488,
+                "50.0" : 0.04711222601622828,
+                "90.0" : 0.04796012632967244,
+                "95.0" : 0.04796012632967244,
+                "99.0" : 0.04796012632967244,
+                "99.9" : 0.04796012632967244,
+                "99.99" : 0.04796012632967244,
+                "99.999" : 0.04796012632967244,
+                "99.9999" : 0.04796012632967244,
+                "100.0" : 0.04796012632967244
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04796012632967244,
+                    0.04765698062772832,
+                    0.04765320574878606
+                ],
+                [
+                    0.04657124628367051,
+                    0.04621799349722003,
+                    0.04602969264547488
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8587485.633567942,
+            "scoreError" : 78217.84537122243,
+            "scoreConfidence" : [
+                8509267.78819672,
+                8665703.478939164
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8552374.517948719,
+                "50.0" : 8592319.015186667,
+                "90.0" : 8622479.58448276,
+                "95.0" : 8622479.58448276,
+                "99.0" : 8622479.58448276,
+                "99.9" : 8622479.58448276,
+                "99.99" : 8622479.58448276,
+                "99.999" : 8622479.58448276,
+                "99.9999" : 8622479.58448276,
+                "100.0" : 8622479.58448276
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8622479.58448276,
+                    8605592.766122097,
+                    8604429.138435083
+                ],
+                [
+                    8559828.902480753,
+                    8580208.89193825,
+                    8552374.517948719
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-08T07-44-58Z-8e1c98a014a76455800b997b9c5aa06bf639dc5c-jdk17.json
+++ b/performance-results/2026-02-08T07-44-58Z-8e1c98a014a76455800b997b9c5aa06bf639dc5c-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.353762078832057,
+            "scoreError" : 0.023645375990814763,
+            "scoreConfidence" : [
+                3.3301167028412424,
+                3.3774074548228716
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.348857149103296,
+                "50.0" : 3.354656683998937,
+                "90.0" : 3.356877798227059,
+                "95.0" : 3.356877798227059,
+                "99.0" : 3.356877798227059,
+                "99.9" : 3.356877798227059,
+                "99.99" : 3.356877798227059,
+                "99.999" : 3.356877798227059,
+                "99.9999" : 3.356877798227059,
+                "100.0" : 3.356877798227059
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3531072623590608,
+                    3.3562061056388135
+                ],
+                [
+                    3.348857149103296,
+                    3.356877798227059
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6969852235490293,
+            "scoreError" : 0.021018640656345653,
+            "scoreConfidence" : [
+                1.6759665828926835,
+                1.718003864205375
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6942374109637852,
+                "50.0" : 1.696418636285378,
+                "90.0" : 1.7008662106615755,
+                "95.0" : 1.7008662106615755,
+                "99.0" : 1.7008662106615755,
+                "99.9" : 1.7008662106615755,
+                "99.99" : 1.7008662106615755,
+                "99.999" : 1.7008662106615755,
+                "99.9999" : 1.7008662106615755,
+                "100.0" : 1.7008662106615755
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6943589308247344,
+                    1.6942374109637852
+                ],
+                [
+                    1.6984783417460214,
+                    1.7008662106615755
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8515160556171816,
+            "scoreError" : 0.03239957909921152,
+            "scoreConfidence" : [
+                0.81911647651797,
+                0.8839156347163931
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8441941320629802,
+                "50.0" : 0.8533171293637379,
+                "90.0" : 0.85523583167827,
+                "95.0" : 0.85523583167827,
+                "99.0" : 0.85523583167827,
+                "99.9" : 0.85523583167827,
+                "99.99" : 0.85523583167827,
+                "99.999" : 0.85523583167827,
+                "99.9999" : 0.85523583167827,
+                "100.0" : 0.85523583167827
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8524564124170438,
+                    0.85523583167827
+                ],
+                [
+                    0.8441941320629802,
+                    0.854177846310432
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.075874648667654,
+            "scoreError" : 0.773707746758766,
+            "scoreConfidence" : [
+                15.302166901908887,
+                16.84958239542642
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.823253806194625,
+                "50.0" : 16.060644683142215,
+                "90.0" : 16.346675775917717,
+                "95.0" : 16.346675775917717,
+                "99.0" : 16.346675775917717,
+                "99.9" : 16.346675775917717,
+                "99.99" : 16.346675775917717,
+                "99.999" : 16.346675775917717,
+                "99.9999" : 16.346675775917717,
+                "100.0" : 16.346675775917717
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.340207680220683,
+                    16.346675775917717,
+                    16.294758809868522
+                ],
+                [
+                    15.823821263388446,
+                    15.826530556415904,
+                    15.823253806194625
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2634.707939676842,
+            "scoreError" : 101.39094532872654,
+            "scoreConfidence" : [
+                2533.3169943481157,
+                2736.0988850055687
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2600.66638622937,
+                "50.0" : 2634.806695252839,
+                "90.0" : 2668.4980309442753,
+                "95.0" : 2668.4980309442753,
+                "99.0" : 2668.4980309442753,
+                "99.9" : 2668.4980309442753,
+                "99.99" : 2668.4980309442753,
+                "99.999" : 2668.4980309442753,
+                "99.9999" : 2668.4980309442753,
+                "100.0" : 2668.4980309442753
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2600.66638622937,
+                    2602.138489221633,
+                    2602.3184952677216
+                ],
+                [
+                    2667.2948952379566,
+                    2668.4980309442753,
+                    2667.3313411600984
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73125.84077014723,
+            "scoreError" : 2226.189140045665,
+            "scoreConfidence" : [
+                70899.65163010157,
+                75352.0299101929
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72391.98745327149,
+                "50.0" : 73096.74320189923,
+                "90.0" : 73892.15319028431,
+                "95.0" : 73892.15319028431,
+                "99.0" : 73892.15319028431,
+                "99.9" : 73892.15319028431,
+                "99.99" : 73892.15319028431,
+                "99.999" : 73892.15319028431,
+                "99.9999" : 73892.15319028431,
+                "100.0" : 73892.15319028431
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72391.98745327149,
+                    72420.99405899973,
+                    72393.67273116409
+                ],
+                [
+                    73892.15319028431,
+                    73883.7448423651,
+                    73772.49234479871
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 357.4531136350584,
+            "scoreError" : 10.470150391066246,
+            "scoreConfidence" : [
+                346.9829632439922,
+                367.9232640261246
+            ],
+            "scorePercentiles" : {
+                "0.0" : 353.58948898669667,
+                "50.0" : 357.66289257230574,
+                "90.0" : 361.19570044326815,
+                "95.0" : 361.19570044326815,
+                "99.0" : 361.19570044326815,
+                "99.9" : 361.19570044326815,
+                "99.99" : 361.19570044326815,
+                "99.999" : 361.19570044326815,
+                "99.9999" : 361.19570044326815,
+                "100.0" : 361.19570044326815
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    354.9210935165841,
+                    353.72596034582654,
+                    353.58948898669667
+                ],
+                [
+                    361.19570044326815,
+                    360.4046916280274,
+                    360.8817468899477
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 117.6393883130104,
+            "scoreError" : 1.3958748165573025,
+            "scoreConfidence" : [
+                116.2435134964531,
+                119.0352631295677
+            ],
+            "scorePercentiles" : {
+                "0.0" : 117.01963547811941,
+                "50.0" : 117.69527142540392,
+                "90.0" : 118.362309357201,
+                "95.0" : 118.362309357201,
+                "99.0" : 118.362309357201,
+                "99.9" : 118.362309357201,
+                "99.99" : 118.362309357201,
+                "99.999" : 118.362309357201,
+                "99.9999" : 118.362309357201,
+                "100.0" : 118.362309357201
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    117.01963547811941,
+                    117.58035770740747,
+                    117.16011897668463
+                ],
+                [
+                    117.81018514340037,
+                    117.90372321524966,
+                    118.362309357201
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06053450332757981,
+            "scoreError" : 9.866753658804364E-4,
+            "scoreConfidence" : [
+                0.05954782796169937,
+                0.06152117869346024
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.060184997869484884,
+                "50.0" : 0.06052723883895378,
+                "90.0" : 0.060877550378347446,
+                "95.0" : 0.060877550378347446,
+                "99.0" : 0.060877550378347446,
+                "99.9" : 0.060877550378347446,
+                "99.99" : 0.060877550378347446,
+                "99.999" : 0.060877550378347446,
+                "99.9999" : 0.060877550378347446,
+                "100.0" : 0.060877550378347446
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.060877550378347446,
+                    0.06086609087201836,
+                    0.06082105544979595
+                ],
+                [
+                    0.060184997869484884,
+                    0.0602334222281116,
+                    0.06022390316772057
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6374772451191654E-4,
+            "scoreError" : 1.618529906717287E-5,
+            "scoreConfidence" : [
+                3.4756242544474366E-4,
+                3.799330235790894E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.57774222974398E-4,
+                "50.0" : 3.639590818475708E-4,
+                "90.0" : 3.6925016889309667E-4,
+                "95.0" : 3.6925016889309667E-4,
+                "99.0" : 3.6925016889309667E-4,
+                "99.9" : 3.6925016889309667E-4,
+                "99.99" : 3.6925016889309667E-4,
+                "99.999" : 3.6925016889309667E-4,
+                "99.9999" : 3.6925016889309667E-4,
+                "100.0" : 3.6925016889309667E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.57774222974398E-4,
+                    3.591467241692198E-4,
+                    3.5856600421977286E-4
+                ],
+                [
+                    3.6925016889309667E-4,
+                    3.6897778728909025E-4,
+                    3.6877143952592173E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2431924455145476,
+            "scoreError" : 0.055619762433884806,
+            "scoreConfidence" : [
+                2.1875726830806626,
+                2.2988122079484326
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2039345273248125,
+                "50.0" : 2.242841133669145,
+                "90.0" : 2.305524985840776,
+                "95.0" : 2.3081125250403876,
+                "99.0" : 2.3081125250403876,
+                "99.9" : 2.3081125250403876,
+                "99.99" : 2.3081125250403876,
+                "99.999" : 2.3081125250403876,
+                "99.9999" : 2.3081125250403876,
+                "100.0" : 2.3081125250403876
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.282237133044272,
+                    2.273538127756308,
+                    2.2423999385650224,
+                    2.2039345273248125,
+                    2.2046937788800705
+                ],
+                [
+                    2.3081125250403876,
+                    2.2557344278304012,
+                    2.2432823287732675,
+                    2.2096453530711444,
+                    2.2083463148597926
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013772084730278291,
+            "scoreError" : 4.511652283476078E-4,
+            "scoreConfidence" : [
+                0.013320919501930683,
+                0.0142232499586259
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013624286732589095,
+                "50.0" : 0.013771516524808122,
+                "90.0" : 0.013922323842579057,
+                "95.0" : 0.013922323842579057,
+                "99.0" : 0.013922323842579057,
+                "99.9" : 0.013922323842579057,
+                "99.99" : 0.013922323842579057,
+                "99.999" : 0.013922323842579057,
+                "99.9999" : 0.013922323842579057,
+                "100.0" : 0.013922323842579057
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013922323842579057,
+                    0.013917080865519635,
+                    0.013917432815735566
+                ],
+                [
+                    0.013625431941149782,
+                    0.013624286732589095,
+                    0.01362595218409661
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0483014755883777,
+            "scoreError" : 0.0825344397381302,
+            "scoreConfidence" : [
+                0.9657670358502475,
+                1.130835915326508
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0210934834592609,
+                "50.0" : 1.0457502628203792,
+                "90.0" : 1.0802096252970403,
+                "95.0" : 1.0802096252970403,
+                "99.0" : 1.0802096252970403,
+                "99.9" : 1.0802096252970403,
+                "99.99" : 1.0802096252970403,
+                "99.999" : 1.0802096252970403,
+                "99.9999" : 1.0802096252970403,
+                "100.0" : 1.0802096252970403
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0802096252970403,
+                    1.0694854755641108,
+                    1.0752716116546608
+                ],
+                [
+                    1.0210934834592609,
+                    1.0217336074785452,
+                    1.0220150500766478
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010491189529863503,
+            "scoreError" : 3.0271522880147706E-4,
+            "scoreConfidence" : [
+                0.010188474301062027,
+                0.01079390475866498
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010375411532180585,
+                "50.0" : 0.010493580520109663,
+                "90.0" : 0.010591602388557969,
+                "95.0" : 0.010591602388557969,
+                "99.0" : 0.010591602388557969,
+                "99.9" : 0.010591602388557969,
+                "99.99" : 0.010591602388557969,
+                "99.999" : 0.010591602388557969,
+                "99.9999" : 0.010591602388557969,
+                "100.0" : 0.010591602388557969
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010401746897772637,
+                    0.010402028873198415,
+                    0.010375411532180585
+                ],
+                [
+                    0.010591602388557969,
+                    0.010591215320450497,
+                    0.010585132167020908
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1438436133297842,
+            "scoreError" : 0.3679124435785626,
+            "scoreConfidence" : [
+                2.7759311697512215,
+                3.511756056908347
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.02159913836858,
+                "50.0" : 3.1447467954460793,
+                "90.0" : 3.2670719790986285,
+                "95.0" : 3.2670719790986285,
+                "99.0" : 3.2670719790986285,
+                "99.9" : 3.2670719790986285,
+                "99.99" : 3.2670719790986285,
+                "99.999" : 3.2670719790986285,
+                "99.9999" : 3.2670719790986285,
+                "100.0" : 3.2670719790986285
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.262340328114808,
+                    3.2670719790986285,
+                    3.26133602672751
+                ],
+                [
+                    3.02159913836858,
+                    3.028157564164649,
+                    3.0225566435045317
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7811337111439856,
+            "scoreError" : 0.07428398773147404,
+            "scoreConfidence" : [
+                2.7068497234125113,
+                2.85541769887546
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7513362096286107,
+                "50.0" : 2.7803259828001003,
+                "90.0" : 2.812747099550056,
+                "95.0" : 2.812747099550056,
+                "99.0" : 2.812747099550056,
+                "99.9" : 2.812747099550056,
+                "99.99" : 2.812747099550056,
+                "99.999" : 2.812747099550056,
+                "99.9999" : 2.812747099550056,
+                "100.0" : 2.812747099550056
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.758688495448276,
+                    2.7513362096286107,
+                    2.762698132872928
+                ],
+                [
+                    2.812747099550056,
+                    2.7979538327272726,
+                    2.803378496636771
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17695169687134474,
+            "scoreError" : 0.0013552531876827752,
+            "scoreConfidence" : [
+                0.17559644368366195,
+                0.17830695005902752
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17646185306417744,
+                "50.0" : 0.17690732247029162,
+                "90.0" : 0.17759561142583155,
+                "95.0" : 0.17759561142583155,
+                "99.0" : 0.17759561142583155,
+                "99.9" : 0.17759561142583155,
+                "99.99" : 0.17759561142583155,
+                "99.999" : 0.17759561142583155,
+                "99.9999" : 0.17759561142583155,
+                "100.0" : 0.17759561142583155
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17663111109933588,
+                    0.17646185306417744,
+                    0.17649793806809155
+                ],
+                [
+                    0.17759561142583155,
+                    0.17734013372938465,
+                    0.17718353384124735
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.33635471918453885,
+            "scoreError" : 0.00929511446828314,
+            "scoreConfidence" : [
+                0.3270596047162557,
+                0.345649833652822
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3329874035029302,
+                "50.0" : 0.3362681775989703,
+                "90.0" : 0.3400776567027137,
+                "95.0" : 0.3400776567027137,
+                "99.0" : 0.3400776567027137,
+                "99.9" : 0.3400776567027137,
+                "99.99" : 0.3400776567027137,
+                "99.999" : 0.3400776567027137,
+                "99.9999" : 0.3400776567027137,
+                "100.0" : 0.3400776567027137
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.33375822277475553,
+                    0.33333884533333336,
+                    0.3329874035029302
+                ],
+                [
+                    0.3400776567027137,
+                    0.33877813242318505,
+                    0.3391880543703151
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1494139459100212,
+            "scoreError" : 0.014652580342606386,
+            "scoreConfidence" : [
+                0.1347613655674148,
+                0.16406652625262758
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14441385004404522,
+                "50.0" : 0.14945417856504212,
+                "90.0" : 0.15429924498927652,
+                "95.0" : 0.15429924498927652,
+                "99.0" : 0.15429924498927652,
+                "99.9" : 0.15429924498927652,
+                "99.99" : 0.15429924498927652,
+                "99.999" : 0.15429924498927652,
+                "99.9999" : 0.15429924498927652,
+                "100.0" : 0.15429924498927652
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1446198934748655,
+                    0.14441385004404522,
+                    0.1449072189940734
+                ],
+                [
+                    0.15424232982185548,
+                    0.15429924498927652,
+                    0.15400113813601085
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4057909122614541,
+            "scoreError" : 0.02494323121683372,
+            "scoreConfidence" : [
+                0.38084768104462036,
+                0.4307341434782878
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3973910268229684,
+                "50.0" : 0.4048809197090019,
+                "90.0" : 0.4151890159013535,
+                "95.0" : 0.4151890159013535,
+                "99.0" : 0.4151890159013535,
+                "99.9" : 0.4151890159013535,
+                "99.99" : 0.4151890159013535,
+                "99.999" : 0.4151890159013535,
+                "99.9999" : 0.4151890159013535,
+                "100.0" : 0.4151890159013535
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41174427046277995,
+                    0.41458384196343434,
+                    0.4151890159013535
+                ],
+                [
+                    0.39781974946296444,
+                    0.3980175689552239,
+                    0.3973910268229684
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15848417973032433,
+            "scoreError" : 0.008917106669293663,
+            "scoreConfidence" : [
+                0.14956707306103068,
+                0.167401286399618
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15551664451114255,
+                "50.0" : 0.15798795257461656,
+                "90.0" : 0.16204032154778494,
+                "95.0" : 0.16204032154778494,
+                "99.0" : 0.16204032154778494,
+                "99.9" : 0.16204032154778494,
+                "99.99" : 0.16204032154778494,
+                "99.999" : 0.16204032154778494,
+                "99.9999" : 0.16204032154778494,
+                "100.0" : 0.16204032154778494
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1616899299573147,
+                    0.16027785064029618,
+                    0.16204032154778494
+                ],
+                [
+                    0.15569805450893692,
+                    0.15551664451114255,
+                    0.15568227721647077
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.0464164227544003,
+            "scoreError" : 0.0015755957845160558,
+            "scoreConfidence" : [
+                0.04484082696988424,
+                0.04799201853891635
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04584113358362213,
+                "50.0" : 0.04646669496771423,
+                "90.0" : 0.04695371689697106,
+                "95.0" : 0.04695371689697106,
+                "99.0" : 0.04695371689697106,
+                "99.9" : 0.04695371689697106,
+                "99.99" : 0.04695371689697106,
+                "99.999" : 0.04695371689697106,
+                "99.9999" : 0.04695371689697106,
+                "100.0" : 0.04695371689697106
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.046037892875722214,
+                    0.04584472766823606,
+                    0.04584113358362213
+                ],
+                [
+                    0.04695371689697106,
+                    0.046925568442144086,
+                    0.046895497059706255
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8596135.407448309,
+            "scoreError" : 410340.60026806477,
+            "scoreConfidence" : [
+                8185794.807180244,
+                9006476.007716373
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8455080.286559595,
+                "50.0" : 8597719.26440141,
+                "90.0" : 8739640.92139738,
+                "95.0" : 8739640.92139738,
+                "99.0" : 8739640.92139738,
+                "99.9" : 8739640.92139738,
+                "99.99" : 8739640.92139738,
+                "99.999" : 8739640.92139738,
+                "99.9999" : 8739640.92139738,
+                "100.0" : 8739640.92139738
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8724267.838709677,
+                    8724711.56495205,
+                    8739640.92139738
+                ],
+                [
+                    8455080.286559595,
+                    8461941.142978003,
+                    8471170.690093141
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-08T07-45-30Z-8e1c98a014a76455800b997b9c5aa06bf639dc5c-jdk17.json
+++ b/performance-results/2026-02-08T07-45-30Z-8e1c98a014a76455800b997b9c5aa06bf639dc5c-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.31259690056577,
+            "scoreError" : 0.08094511807961623,
+            "scoreConfidence" : [
+                3.231651782486154,
+                3.393542018645386
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.301249490589653,
+                "50.0" : 3.31129203896516,
+                "90.0" : 3.326554033743108,
+                "95.0" : 3.326554033743108,
+                "99.0" : 3.326554033743108,
+                "99.9" : 3.326554033743108,
+                "99.99" : 3.326554033743108,
+                "99.999" : 3.326554033743108,
+                "99.9999" : 3.326554033743108,
+                "100.0" : 3.326554033743108
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3028139061543813,
+                    3.319770171775939
+                ],
+                [
+                    3.301249490589653,
+                    3.326554033743108
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.668981231704692,
+            "scoreError" : 0.03903002838496581,
+            "scoreConfidence" : [
+                1.629951203319726,
+                1.7080112600896578
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6638589702300217,
+                "50.0" : 1.6675386157326204,
+                "90.0" : 1.6769887251235052,
+                "95.0" : 1.6769887251235052,
+                "99.0" : 1.6769887251235052,
+                "99.9" : 1.6769887251235052,
+                "99.99" : 1.6769887251235052,
+                "99.999" : 1.6769887251235052,
+                "99.9999" : 1.6769887251235052,
+                "100.0" : 1.6769887251235052
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.67027017517215,
+                    1.6769887251235052
+                ],
+                [
+                    1.6648070562930908,
+                    1.6638589702300217
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8447551411288073,
+            "scoreError" : 0.011060154532868918,
+            "scoreConfidence" : [
+                0.8336949865959384,
+                0.8558152956616762
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8421885636642709,
+                "50.0" : 0.8455856207586977,
+                "90.0" : 0.8456607593335629,
+                "95.0" : 0.8456607593335629,
+                "99.0" : 0.8456607593335629,
+                "99.9" : 0.8456607593335629,
+                "99.99" : 0.8456607593335629,
+                "99.999" : 0.8456607593335629,
+                "99.9999" : 0.8456607593335629,
+                "100.0" : 0.8456607593335629
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8456136424365026,
+                    0.8456607593335629
+                ],
+                [
+                    0.8421885636642709,
+                    0.8455575990808928
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.015825890940274,
+            "scoreError" : 0.18815292475121187,
+            "scoreConfidence" : [
+                15.827672966189063,
+                16.203978815691485
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.936041671536552,
+                "50.0" : 16.01707293701655,
+                "90.0" : 16.119550840102665,
+                "95.0" : 16.119550840102665,
+                "99.0" : 16.119550840102665,
+                "99.9" : 16.119550840102665,
+                "99.99" : 16.119550840102665,
+                "99.999" : 16.119550840102665,
+                "99.9999" : 16.119550840102665,
+                "100.0" : 16.119550840102665
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.03210648445868,
+                    16.05046881141645,
+                    15.936041671536552
+                ],
+                [
+                    15.95474814855289,
+                    16.002039389574424,
+                    16.119550840102665
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2722.2416544260805,
+            "scoreError" : 156.68326299117825,
+            "scoreConfidence" : [
+                2565.558391434902,
+                2878.9249174172587
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2661.280714347542,
+                "50.0" : 2717.615606942913,
+                "90.0" : 2801.4471866957606,
+                "95.0" : 2801.4471866957606,
+                "99.0" : 2801.4471866957606,
+                "99.9" : 2801.4471866957606,
+                "99.99" : 2801.4471866957606,
+                "99.999" : 2801.4471866957606,
+                "99.9999" : 2801.4471866957606,
+                "100.0" : 2801.4471866957606
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2685.9948899286014,
+                    2675.6905644605317,
+                    2661.280714347542
+                ],
+                [
+                    2801.4471866957606,
+                    2759.800247166822,
+                    2749.2363239572246
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 72145.76292676096,
+            "scoreError" : 3664.9665161573944,
+            "scoreConfidence" : [
+                68480.79641060357,
+                75810.72944291835
+            ],
+            "scorePercentiles" : {
+                "0.0" : 70891.08039046766,
+                "50.0" : 72088.6748948716,
+                "90.0" : 73582.08472911133,
+                "95.0" : 73582.08472911133,
+                "99.0" : 73582.08472911133,
+                "99.9" : 73582.08472911133,
+                "99.99" : 73582.08472911133,
+                "99.999" : 73582.08472911133,
+                "99.9999" : 73582.08472911133,
+                "100.0" : 73582.08472911133
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73167.89625941256,
+                    73244.5668194649,
+                    73582.08472911133
+                ],
+                [
+                    70979.49583177862,
+                    71009.45353033065,
+                    70891.08039046766
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 337.955649584765,
+            "scoreError" : 8.246248049270227,
+            "scoreConfidence" : [
+                329.7094015354948,
+                346.2018976340352
+            ],
+            "scorePercentiles" : {
+                "0.0" : 334.84369763949167,
+                "50.0" : 337.5287878853322,
+                "90.0" : 341.7711869117332,
+                "95.0" : 341.7711869117332,
+                "99.0" : 341.7711869117332,
+                "99.9" : 341.7711869117332,
+                "99.99" : 341.7711869117332,
+                "99.999" : 341.7711869117332,
+                "99.9999" : 341.7711869117332,
+                "100.0" : 341.7711869117332
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    337.49697057855695,
+                    341.08178766938045,
+                    341.7711869117332
+                ],
+                [
+                    334.84369763949167,
+                    334.9796495173203,
+                    337.5606051921074
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 109.89338413716314,
+            "scoreError" : 6.589699399763981,
+            "scoreConfidence" : [
+                103.30368473739915,
+                116.48308353692713
+            ],
+            "scorePercentiles" : {
+                "0.0" : 106.95767123421489,
+                "50.0" : 110.53352090972572,
+                "90.0" : 112.18258227425616,
+                "95.0" : 112.18258227425616,
+                "99.0" : 112.18258227425616,
+                "99.9" : 112.18258227425616,
+                "99.99" : 112.18258227425616,
+                "99.999" : 112.18258227425616,
+                "99.9999" : 112.18258227425616,
+                "100.0" : 112.18258227425616
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    109.31477192913614,
+                    107.36727185724993,
+                    106.95767123421489
+                ],
+                [
+                    111.7857376378063,
+                    112.18258227425616,
+                    111.75226989031532
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.061689970151332575,
+            "scoreError" : 8.924588106260846E-4,
+            "scoreConfidence" : [
+                0.06079751134070649,
+                0.06258242896195866
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06114479928339519,
+                "50.0" : 0.06173288600548388,
+                "90.0" : 0.06203836751595913,
+                "95.0" : 0.06203836751595913,
+                "99.0" : 0.06203836751595913,
+                "99.9" : 0.06203836751595913,
+                "99.99" : 0.06203836751595913,
+                "99.999" : 0.06203836751595913,
+                "99.9999" : 0.06203836751595913,
+                "100.0" : 0.06203836751595913
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.061844597317220994,
+                    0.06190831652551816,
+                    0.06203836751595913
+                ],
+                [
+                    0.06158256557215523,
+                    0.06162117469374676,
+                    0.06114479928339519
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.763998342876939E-4,
+            "scoreError" : 8.544892945429893E-6,
+            "scoreConfidence" : [
+                3.6785494134226404E-4,
+                3.849447272331238E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.7067193803996394E-4,
+                "50.0" : 3.7704293086073936E-4,
+                "90.0" : 3.796665508593897E-4,
+                "95.0" : 3.796665508593897E-4,
+                "99.0" : 3.796665508593897E-4,
+                "99.9" : 3.796665508593897E-4,
+                "99.99" : 3.796665508593897E-4,
+                "99.999" : 3.796665508593897E-4,
+                "99.9999" : 3.796665508593897E-4,
+                "100.0" : 3.796665508593897E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.770134289407572E-4,
+                    3.778321508388933E-4,
+                    3.796665508593897E-4
+                ],
+                [
+                    3.7067193803996394E-4,
+                    3.761425042664377E-4,
+                    3.770724327807216E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.300433051925048,
+            "scoreError" : 0.09285146343747995,
+            "scoreConfidence" : [
+                2.2075815884875682,
+                2.393284515362528
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.227247558129176,
+                "50.0" : 2.2946943792144685,
+                "90.0" : 2.4084426810549355,
+                "95.0" : 2.4137496492879555,
+                "99.0" : 2.4137496492879555,
+                "99.9" : 2.4137496492879555,
+                "99.99" : 2.4137496492879555,
+                "99.999" : 2.4137496492879555,
+                "99.9999" : 2.4137496492879555,
+                "100.0" : 2.4137496492879555
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3479252267605633,
+                    2.276616633963123,
+                    2.236373162119857,
+                    2.23172923900915,
+                    2.227247558129176
+                ],
+                [
+                    2.4137496492879555,
+                    2.360679966957753,
+                    2.3206203245939676,
+                    2.2943037666896076,
+                    2.29508499173933
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013601332295778359,
+            "scoreError" : 4.248807039553013E-4,
+            "scoreConfidence" : [
+                0.013176451591823058,
+                0.01402621299973366
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013456748641894901,
+                "50.0" : 0.013585145847970097,
+                "90.0" : 0.013774955550198701,
+                "95.0" : 0.013774955550198701,
+                "99.0" : 0.013774955550198701,
+                "99.9" : 0.013774955550198701,
+                "99.99" : 0.013774955550198701,
+                "99.999" : 0.013774955550198701,
+                "99.9999" : 0.013774955550198701,
+                "100.0" : 0.013774955550198701
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013774955550198701,
+                    0.01374068320747043,
+                    0.013697603371759189
+                ],
+                [
+                    0.013465314679165915,
+                    0.013456748641894901,
+                    0.013472688324181007
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0363232649349257,
+            "scoreError" : 0.06936228573526805,
+            "scoreConfidence" : [
+                0.9669609791996576,
+                1.1056855506701937
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.010817052456034,
+                "50.0" : 1.0369653678637922,
+                "90.0" : 1.0607165736105217,
+                "95.0" : 1.0607165736105217,
+                "99.0" : 1.0607165736105217,
+                "99.9" : 1.0607165736105217,
+                "99.99" : 1.0607165736105217,
+                "99.999" : 1.0607165736105217,
+                "99.9999" : 1.0607165736105217,
+                "100.0" : 1.0607165736105217
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.010817052456034,
+                    1.0145234095566602,
+                    1.016112163483032
+                ],
+                [
+                    1.0607165736105217,
+                    1.0579518182587537,
+                    1.0578185722445526
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010485659678930975,
+            "scoreError" : 2.3114683647556535E-4,
+            "scoreConfidence" : [
+                0.01025451284245541,
+                0.010716806515406541
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010410975824267346,
+                "50.0" : 0.010462445818559742,
+                "90.0" : 0.010601493513157086,
+                "95.0" : 0.010601493513157086,
+                "99.0" : 0.010601493513157086,
+                "99.9" : 0.010601493513157086,
+                "99.99" : 0.010601493513157086,
+                "99.999" : 0.010601493513157086,
+                "99.9999" : 0.010601493513157086,
+                "100.0" : 0.010601493513157086
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010410975824267346,
+                    0.01042021271319251,
+                    0.01041646980861254
+                ],
+                [
+                    0.010601493513157086,
+                    0.010560127290429405,
+                    0.010504678923926973
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.2808754191348304,
+            "scoreError" : 0.15416988379517962,
+            "scoreConfidence" : [
+                3.1267055353396507,
+                3.43504530293001
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.2262329322580645,
+                "50.0" : 3.2780548536492766,
+                "90.0" : 3.346245092976589,
+                "95.0" : 3.346245092976589,
+                "99.0" : 3.346245092976589,
+                "99.9" : 3.346245092976589,
+                "99.99" : 3.346245092976589,
+                "99.999" : 3.346245092976589,
+                "99.9999" : 3.346245092976589,
+                "100.0" : 3.346245092976589
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.3281339727212242,
+                    3.346245092976589,
+                    3.315902724137931
+                ],
+                [
+                    3.240206983160622,
+                    3.2262329322580645,
+                    3.2285308095545515
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.934044734258567,
+            "scoreError" : 0.10271265579811605,
+            "scoreConfidence" : [
+                2.8313320784604508,
+                3.036757390056683
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.881309995102276,
+                "50.0" : 2.933126061535585,
+                "90.0" : 2.9771495224769278,
+                "95.0" : 2.9771495224769278,
+                "99.0" : 2.9771495224769278,
+                "99.9" : 2.9771495224769278,
+                "99.99" : 2.9771495224769278,
+                "99.999" : 2.9771495224769278,
+                "99.9999" : 2.9771495224769278,
+                "100.0" : 2.9771495224769278
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9487439413325474,
+                    2.967291296351231,
+                    2.9771495224769278
+                ],
+                [
+                    2.912265468549796,
+                    2.881309995102276,
+                    2.917508181738623
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17838130557583085,
+            "scoreError" : 0.003721684946433467,
+            "scoreConfidence" : [
+                0.17465962062939738,
+                0.1821029905222643
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17702320806854188,
+                "50.0" : 0.17836305629022775,
+                "90.0" : 0.1798440818077186,
+                "95.0" : 0.1798440818077186,
+                "99.0" : 0.1798440818077186,
+                "99.9" : 0.1798440818077186,
+                "99.99" : 0.1798440818077186,
+                "99.999" : 0.1798440818077186,
+                "99.9999" : 0.1798440818077186,
+                "100.0" : 0.1798440818077186
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17702320806854188,
+                    0.17734849473292189,
+                    0.17717219518460775
+                ],
+                [
+                    0.1798440818077186,
+                    0.17937761784753364,
+                    0.17952223581366125
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.33045674097440086,
+            "scoreError" : 0.0021591596007993204,
+            "scoreConfidence" : [
+                0.32829758137360154,
+                0.3326159005752002
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3296318452435889,
+                "50.0" : 0.33030994378731077,
+                "90.0" : 0.33192249014206054,
+                "95.0" : 0.33192249014206054,
+                "99.0" : 0.33192249014206054,
+                "99.9" : 0.33192249014206054,
+                "99.99" : 0.33192249014206054,
+                "99.999" : 0.33192249014206054,
+                "99.9999" : 0.33192249014206054,
+                "100.0" : 0.33192249014206054
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.33040568173258006,
+                    0.3303416453275196,
+                    0.3296318452435889
+                ],
+                [
+                    0.33192249014206054,
+                    0.3301605411535541,
+                    0.33027824224710195
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14728130006152815,
+            "scoreError" : 0.0036396094675559426,
+            "scoreConfidence" : [
+                0.1436416905939722,
+                0.1509209095290841
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14572743769581628,
+                "50.0" : 0.1473110250476018,
+                "90.0" : 0.14855156286580112,
+                "95.0" : 0.14855156286580112,
+                "99.0" : 0.14855156286580112,
+                "99.9" : 0.14855156286580112,
+                "99.99" : 0.14855156286580112,
+                "99.999" : 0.14855156286580112,
+                "99.9999" : 0.14855156286580112,
+                "100.0" : 0.14855156286580112
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14855156286580112,
+                    0.148274227596228,
+                    0.1485142040543551
+                ],
+                [
+                    0.14572743769581628,
+                    0.1463478224989756,
+                    0.1462725456579929
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40908051898480485,
+            "scoreError" : 0.03581435534004053,
+            "scoreConfidence" : [
+                0.37326616364476434,
+                0.44489487432484537
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3965198458366376,
+                "50.0" : 0.40934020640015345,
+                "90.0" : 0.42226529269940466,
+                "95.0" : 0.42226529269940466,
+                "99.0" : 0.42226529269940466,
+                "99.9" : 0.42226529269940466,
+                "99.99" : 0.42226529269940466,
+                "99.999" : 0.42226529269940466,
+                "99.9999" : 0.42226529269940466,
+                "100.0" : 0.42226529269940466
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.42226529269940466,
+                    0.42010980860359604,
+                    0.41968482235185495
+                ],
+                [
+                    0.39899559044845195,
+                    0.39690775396888395,
+                    0.3965198458366376
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15602240439204076,
+            "scoreError" : 0.003196017396855146,
+            "scoreConfidence" : [
+                0.1528263869951856,
+                0.15921842178889592
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15482915575407577,
+                "50.0" : 0.15590787067359613,
+                "90.0" : 0.15751417215851815,
+                "95.0" : 0.15751417215851815,
+                "99.0" : 0.15751417215851815,
+                "99.9" : 0.15751417215851815,
+                "99.99" : 0.15751417215851815,
+                "99.999" : 0.15751417215851815,
+                "99.9999" : 0.15751417215851815,
+                "100.0" : 0.15751417215851815
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15520762721360837,
+                    0.15482915575407577,
+                    0.15502945461592124
+                ],
+                [
+                    0.15751417215851815,
+                    0.15694590247653725,
+                    0.15660811413358391
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04828354637997064,
+            "scoreError" : 0.0027548818255970706,
+            "scoreConfidence" : [
+                0.04552866455437357,
+                0.05103842820556771
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04741386361136398,
+                "50.0" : 0.04800883262018707,
+                "90.0" : 0.04955498499497024,
+                "95.0" : 0.04955498499497024,
+                "99.0" : 0.04955498499497024,
+                "99.9" : 0.04955498499497024,
+                "99.99" : 0.04955498499497024,
+                "99.999" : 0.04955498499497024,
+                "99.9999" : 0.04955498499497024,
+                "100.0" : 0.04955498499497024
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04927822254745432,
+                    0.04955498499497024,
+                    0.04855430619835112
+                ],
+                [
+                    0.04743654188566116,
+                    0.04741386361136398,
+                    0.04746335904202303
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8831450.72428208,
+            "scoreError" : 287158.36254799046,
+            "scoreConfidence" : [
+                8544292.36173409,
+                9118609.08683007
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8691600.271068636,
+                "50.0" : 8845815.304864515,
+                "90.0" : 8956425.952551477,
+                "95.0" : 8956425.952551477,
+                "99.0" : 8956425.952551477,
+                "99.9" : 8956425.952551477,
+                "99.99" : 8956425.952551477,
+                "99.999" : 8956425.952551477,
+                "99.9999" : 8956425.952551477,
+                "100.0" : 8956425.952551477
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8909070.710596615,
+                    8691600.271068636,
+                    8810812.870598592
+                ],
+                [
+                    8956425.952551477,
+                    8880817.739130436,
+                    8739976.801746724
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-14T21-35-47Z-89b444633fccd751832bdbbf89935abc50611bc6-jdk17.json
+++ b/performance-results/2026-02-14T21-35-47Z-89b444633fccd751832bdbbf89935abc50611bc6-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3553755285565,
+            "scoreError" : 0.021029343067912248,
+            "scoreConfidence" : [
+                3.3343461854885876,
+                3.376404871624412
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.352305809948541,
+                "50.0" : 3.3548516012701466,
+                "90.0" : 3.3594931017371645,
+                "95.0" : 3.3594931017371645,
+                "99.0" : 3.3594931017371645,
+                "99.9" : 3.3594931017371645,
+                "99.99" : 3.3594931017371645,
+                "99.999" : 3.3594931017371645,
+                "99.9999" : 3.3594931017371645,
+                "100.0" : 3.3594931017371645
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3532951469181924,
+                    3.3564080556221003
+                ],
+                [
+                    3.352305809948541,
+                    3.3594931017371645
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6904409608735338,
+            "scoreError" : 0.032427310676109156,
+            "scoreConfidence" : [
+                1.6580136501974247,
+                1.7228682715496428
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.683790072487002,
+                "50.0" : 1.691589032460798,
+                "90.0" : 1.6947957060855379,
+                "95.0" : 1.6947957060855379,
+                "99.0" : 1.6947957060855379,
+                "99.9" : 1.6947957060855379,
+                "99.99" : 1.6947957060855379,
+                "99.999" : 1.6947957060855379,
+                "99.9999" : 1.6947957060855379,
+                "100.0" : 1.6947957060855379
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.683790072487002,
+                    1.6893854447807246
+                ],
+                [
+                    1.6937926201408713,
+                    1.6947957060855379
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8487901606151895,
+            "scoreError" : 0.028281913456947656,
+            "scoreConfidence" : [
+                0.8205082471582419,
+                0.8770720740721372
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8450035629176201,
+                "50.0" : 0.8476018736901187,
+                "90.0" : 0.8549533321629004,
+                "95.0" : 0.8549533321629004,
+                "99.0" : 0.8549533321629004,
+                "99.9" : 0.8549533321629004,
+                "99.99" : 0.8549533321629004,
+                "99.999" : 0.8549533321629004,
+                "99.9999" : 0.8549533321629004,
+                "100.0" : 0.8549533321629004
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8465252277254305,
+                    0.848678519654807
+                ],
+                [
+                    0.8450035629176201,
+                    0.8549533321629004
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.32510756897162,
+            "scoreError" : 0.2345252532355873,
+            "scoreConfidence" : [
+                16.090582315736032,
+                16.55963282220721
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.24724847634634,
+                "50.0" : 16.305727535089467,
+                "90.0" : 16.419990167921522,
+                "95.0" : 16.419990167921522,
+                "99.0" : 16.419990167921522,
+                "99.9" : 16.419990167921522,
+                "99.99" : 16.419990167921522,
+                "99.999" : 16.419990167921522,
+                "99.9999" : 16.419990167921522,
+                "100.0" : 16.419990167921522
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.253619524290766,
+                    16.24724847634634,
+                    16.253978549294654
+                ],
+                [
+                    16.419990167921522,
+                    16.41833217509217,
+                    16.357476520884276
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2805.74282549623,
+            "scoreError" : 137.94318480157463,
+            "scoreConfidence" : [
+                2667.7996406946554,
+                2943.686010297805
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2759.918218482052,
+                "50.0" : 2805.762965626249,
+                "90.0" : 2852.7374056933436,
+                "95.0" : 2852.7374056933436,
+                "99.0" : 2852.7374056933436,
+                "99.9" : 2852.7374056933436,
+                "99.99" : 2852.7374056933436,
+                "99.999" : 2852.7374056933436,
+                "99.9999" : 2852.7374056933436,
+                "100.0" : 2852.7374056933436
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2849.350189513118,
+                    2852.7374056933436,
+                    2849.8052995926228
+                ],
+                [
+                    2760.470097956865,
+                    2762.1757417393796,
+                    2759.918218482052
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74869.0623116432,
+            "scoreError" : 981.6503811920433,
+            "scoreConfidence" : [
+                73887.41193045116,
+                75850.71269283524
+            ],
+            "scorePercentiles" : {
+                "0.0" : 74514.3427681505,
+                "50.0" : 74885.04330818268,
+                "90.0" : 75229.65444599623,
+                "95.0" : 75229.65444599623,
+                "99.0" : 75229.65444599623,
+                "99.9" : 75229.65444599623,
+                "99.99" : 75229.65444599623,
+                "99.999" : 75229.65444599623,
+                "99.9999" : 75229.65444599623,
+                "100.0" : 75229.65444599623
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    75150.83704723441,
+                    75177.5279620812,
+                    75229.65444599623
+                ],
+                [
+                    74514.3427681505,
+                    74619.24956913093,
+                    74522.76207726596
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 364.0395696837964,
+            "scoreError" : 6.139748295131432,
+            "scoreConfidence" : [
+                357.899821388665,
+                370.1793179789278
+            ],
+            "scorePercentiles" : {
+                "0.0" : 361.93034639625694,
+                "50.0" : 364.077002284871,
+                "90.0" : 366.0997493680116,
+                "95.0" : 366.0997493680116,
+                "99.0" : 366.0997493680116,
+                "99.9" : 366.0997493680116,
+                "99.99" : 366.0997493680116,
+                "99.999" : 366.0997493680116,
+                "99.9999" : 366.0997493680116,
+                "100.0" : 366.0997493680116
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    361.93034639625694,
+                    362.17402107638117,
+                    362.02285843161565
+                ],
+                [
+                    365.9799834933608,
+                    366.03045933715237,
+                    366.0997493680116
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 115.26977525825454,
+            "scoreError" : 1.1236817803770882,
+            "scoreConfidence" : [
+                114.14609347787746,
+                116.39345703863162
+            ],
+            "scorePercentiles" : {
+                "0.0" : 114.73437902578188,
+                "50.0" : 115.26714717280977,
+                "90.0" : 115.7837791556754,
+                "95.0" : 115.7837791556754,
+                "99.0" : 115.7837791556754,
+                "99.9" : 115.7837791556754,
+                "99.99" : 115.7837791556754,
+                "99.999" : 115.7837791556754,
+                "99.9999" : 115.7837791556754,
+                "100.0" : 115.7837791556754
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    114.99999448679435,
+                    115.05342934018157,
+                    114.73437902578188
+                ],
+                [
+                    115.7837791556754,
+                    115.48086500543798,
+                    115.56620453565606
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.060589396086821894,
+            "scoreError" : 2.3136437740696293E-4,
+            "scoreConfidence" : [
+                0.06035803170941493,
+                0.06082076046422886
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06048425821513896,
+                "50.0" : 0.060607320600641695,
+                "90.0" : 0.060686330371880766,
+                "95.0" : 0.060686330371880766,
+                "99.0" : 0.060686330371880766,
+                "99.9" : 0.060686330371880766,
+                "99.99" : 0.060686330371880766,
+                "99.999" : 0.060686330371880766,
+                "99.9999" : 0.060686330371880766,
+                "100.0" : 0.060686330371880766
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06058548958251292,
+                    0.060499387061841325,
+                    0.060686330371880766
+                ],
+                [
+                    0.060629151618770465,
+                    0.06048425821513896,
+                    0.060651759670786884
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.64397830006088E-4,
+            "scoreError" : 3.918998546027193E-5,
+            "scoreConfidence" : [
+                3.2520784454581603E-4,
+                4.035878154663599E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.511394110318041E-4,
+                "50.0" : 3.6446903238004924E-4,
+                "90.0" : 3.7752747410850154E-4,
+                "95.0" : 3.7752747410850154E-4,
+                "99.0" : 3.7752747410850154E-4,
+                "99.9" : 3.7752747410850154E-4,
+                "99.99" : 3.7752747410850154E-4,
+                "99.999" : 3.7752747410850154E-4,
+                "99.9999" : 3.7752747410850154E-4,
+                "100.0" : 3.7752747410850154E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.767192333700128E-4,
+                    3.7752747410850154E-4,
+                    3.7720230643159075E-4
+                ],
+                [
+                    3.5157972370453296E-4,
+                    3.511394110318041E-4,
+                    3.522188313900857E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.216109300574016,
+            "scoreError" : 0.057009917864503816,
+            "scoreConfidence" : [
+                2.159099382709512,
+                2.2731192184385196
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.166121857916396,
+                "50.0" : 2.2117860485204193,
+                "90.0" : 2.2743638220181657,
+                "95.0" : 2.2760531338188437,
+                "99.0" : 2.2760531338188437,
+                "99.9" : 2.2760531338188437,
+                "99.99" : 2.2760531338188437,
+                "99.999" : 2.2760531338188437,
+                "99.9999" : 2.2760531338188437,
+                "100.0" : 2.2760531338188437
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.245013802244669,
+                    2.202456737502753,
+                    2.2211153595380857,
+                    2.166121857916396,
+                    2.167169563380282
+                ],
+                [
+                    2.2760531338188437,
+                    2.23642628667263,
+                    2.2591600158120624,
+                    2.193172860745614,
+                    2.1944033881088196
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013365353795726403,
+            "scoreError" : 2.111814393273564E-4,
+            "scoreConfidence" : [
+                0.013154172356399046,
+                0.01357653523505376
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01328218739482293,
+                "50.0" : 0.01336859474413676,
+                "90.0" : 0.013434788536513934,
+                "95.0" : 0.013434788536513934,
+                "99.0" : 0.013434788536513934,
+                "99.9" : 0.013434788536513934,
+                "99.99" : 0.013434788536513934,
+                "99.999" : 0.013434788536513934,
+                "99.9999" : 0.013434788536513934,
+                "100.0" : 0.013434788536513934
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013432394816763983,
+                    0.013434788536513934,
+                    0.013433907334792205
+                ],
+                [
+                    0.01328218739482293,
+                    0.013304794671509539,
+                    0.013304050019955832
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0361057036637105,
+            "scoreError" : 0.007972857634595962,
+            "scoreConfidence" : [
+                1.0281328460291146,
+                1.0440785612983063
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.033263950614733,
+                "50.0" : 1.0357468246800112,
+                "90.0" : 1.0391416930590192,
+                "95.0" : 1.0391416930590192,
+                "99.0" : 1.0391416930590192,
+                "99.9" : 1.0391416930590192,
+                "99.99" : 1.0391416930590192,
+                "99.999" : 1.0391416930590192,
+                "99.9999" : 1.0391416930590192,
+                "100.0" : 1.0391416930590192
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0377913732876711,
+                    1.0390480515324676,
+                    1.0391416930590192
+                ],
+                [
+                    1.0337022760723513,
+                    1.0336868774160206,
+                    1.033263950614733
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010239545631329004,
+            "scoreError" : 9.411556027755091E-4,
+            "scoreConfidence" : [
+                0.009298390028553495,
+                0.011180701234104513
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.009927709542085524,
+                "50.0" : 0.010243145229991282,
+                "90.0" : 0.010550615009347609,
+                "95.0" : 0.010550615009347609,
+                "99.0" : 0.010550615009347609,
+                "99.9" : 0.010550615009347609,
+                "99.99" : 0.010550615009347609,
+                "99.999" : 0.010550615009347609,
+                "99.9999" : 0.010550615009347609,
+                "100.0" : 0.010550615009347609
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.009928998957483186,
+                    0.009942924705994647,
+                    0.009927709542085524
+                ],
+                [
+                    0.010550615009347609,
+                    0.010543365753987918,
+                    0.010543659819075133
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.982576612754448,
+            "scoreError" : 0.3779321580128826,
+            "scoreConfidence" : [
+                2.6046444547415653,
+                3.3605087707673307
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.856463439748715,
+                "50.0" : 2.98415002490609,
+                "90.0" : 3.1072794236024843,
+                "95.0" : 3.1072794236024843,
+                "99.0" : 3.1072794236024843,
+                "99.9" : 3.1072794236024843,
+                "99.99" : 3.1072794236024843,
+                "99.999" : 3.1072794236024843,
+                "99.9999" : 3.1072794236024843,
+                "100.0" : 3.1072794236024843
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8584311382857144,
+                    2.8638085315005726,
+                    2.856463439748715
+                ],
+                [
+                    3.1044915183116077,
+                    3.1072794236024843,
+                    3.1049856250775916
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7799856598920463,
+            "scoreError" : 0.054331104289867795,
+            "scoreConfidence" : [
+                2.7256545556021785,
+                2.834316764181914
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7580137352454495,
+                "50.0" : 2.7814425663893134,
+                "90.0" : 2.79867766536094,
+                "95.0" : 2.79867766536094,
+                "99.0" : 2.79867766536094,
+                "99.9" : 2.79867766536094,
+                "99.99" : 2.79867766536094,
+                "99.999" : 2.79867766536094,
+                "99.9999" : 2.79867766536094,
+                "100.0" : 2.79867766536094
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7967476031879195,
+                    2.79867766536094,
+                    2.7970801761744966
+                ],
+                [
+                    2.7580137352454495,
+                    2.766137529590708,
+                    2.7632572497927606
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17317578759237576,
+            "scoreError" : 0.015701520272760415,
+            "scoreConfidence" : [
+                0.15747426731961534,
+                0.18887730786513618
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.167976874540171,
+                "50.0" : 0.17314032638828655,
+                "90.0" : 0.17836787621510747,
+                "95.0" : 0.17836787621510747,
+                "99.0" : 0.17836787621510747,
+                "99.9" : 0.17836787621510747,
+                "99.99" : 0.17836787621510747,
+                "99.999" : 0.17836787621510747,
+                "99.9999" : 0.17836787621510747,
+                "100.0" : 0.17836787621510747
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16808538001512732,
+                    0.167976874540171,
+                    0.16813280772722689
+                ],
+                [
+                    0.17834394200727585,
+                    0.17836787621510747,
+                    0.17814784504934622
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3296474541691063,
+            "scoreError" : 0.0075740462992309856,
+            "scoreConfidence" : [
+                0.3220734078698753,
+                0.33722150046833727
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.32671407494527754,
+                "50.0" : 0.32978216762958,
+                "90.0" : 0.3326600697891025,
+                "95.0" : 0.3326600697891025,
+                "99.0" : 0.3326600697891025,
+                "99.9" : 0.3326600697891025,
+                "99.99" : 0.3326600697891025,
+                "99.999" : 0.3326600697891025,
+                "99.9999" : 0.3326600697891025,
+                "100.0" : 0.3326600697891025
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.32806126024341437,
+                    0.3269457011148527,
+                    0.32671407494527754
+                ],
+                [
+                    0.33200054390624484,
+                    0.33150307501574566,
+                    0.3326600697891025
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1464602328973306,
+            "scoreError" : 0.013147170059682094,
+            "scoreConfidence" : [
+                0.1333130628376485,
+                0.1596074029570127
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14213831171470806,
+                "50.0" : 0.14623632832999023,
+                "90.0" : 0.15155323173448512,
+                "95.0" : 0.15155323173448512,
+                "99.0" : 0.15155323173448512,
+                "99.9" : 0.15155323173448512,
+                "99.99" : 0.15155323173448512,
+                "99.999" : 0.15155323173448512,
+                "99.9999" : 0.15155323173448512,
+                "100.0" : 0.15155323173448512
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14222806417203568,
+                    0.14213831171470806,
+                    0.1422365055399889
+                ],
+                [
+                    0.15155323173448512,
+                    0.15023615111999158,
+                    0.15036913310277422
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3938549893180621,
+            "scoreError" : 0.008953849667448357,
+            "scoreConfidence" : [
+                0.3849011396506138,
+                0.40280883898551045
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3907934391559203,
+                "50.0" : 0.3937318913048047,
+                "90.0" : 0.39700571892492753,
+                "95.0" : 0.39700571892492753,
+                "99.0" : 0.39700571892492753,
+                "99.9" : 0.39700571892492753,
+                "99.99" : 0.39700571892492753,
+                "99.999" : 0.39700571892492753,
+                "99.9999" : 0.39700571892492753,
+                "100.0" : 0.39700571892492753
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.39696645693077165,
+                    0.39700571892492753,
+                    0.39630450360624553
+                ],
+                [
+                    0.39115927900336384,
+                    0.39090053828714383,
+                    0.3907934391559203
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15850729210804268,
+            "scoreError" : 5.424494933515073E-4,
+            "scoreConfidence" : [
+                0.15796484261469118,
+                0.15904974160139418
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15820618517639615,
+                "50.0" : 0.15854531234145752,
+                "90.0" : 0.15875799152259848,
+                "95.0" : 0.15875799152259848,
+                "99.0" : 0.15875799152259848,
+                "99.9" : 0.15875799152259848,
+                "99.99" : 0.15875799152259848,
+                "99.999" : 0.15875799152259848,
+                "99.9999" : 0.15875799152259848,
+                "100.0" : 0.15875799152259848
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15875799152259848,
+                    0.15856860510584317,
+                    0.15820618517639615
+                ],
+                [
+                    0.15852201957707185,
+                    0.1583734794913214,
+                    0.15861547177502497
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04605604594819954,
+            "scoreError" : 0.0016232970302197615,
+            "scoreConfidence" : [
+                0.04443274891797978,
+                0.047679342978419297
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04551478684010505,
+                "50.0" : 0.04605422448489216,
+                "90.0" : 0.046594788592808654,
+                "95.0" : 0.046594788592808654,
+                "99.0" : 0.046594788592808654,
+                "99.9" : 0.046594788592808654,
+                "99.99" : 0.046594788592808654,
+                "99.999" : 0.046594788592808654,
+                "99.9999" : 0.046594788592808654,
+                "100.0" : 0.046594788592808654
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.046594788592808654,
+                    0.04656841003813897,
+                    0.04658993892621202
+                ],
+                [
+                    0.04552831236028719,
+                    0.04551478684010505,
+                    0.04554003893164534
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8510941.786582336,
+            "scoreError" : 79703.92273013837,
+            "scoreConfidence" : [
+                8431237.863852197,
+                8590645.709312474
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8485699.190839695,
+                "50.0" : 8501606.321533794,
+                "90.0" : 8554612.770744225,
+                "95.0" : 8554612.770744225,
+                "99.0" : 8554612.770744225,
+                "99.9" : 8554612.770744225,
+                "99.99" : 8554612.770744225,
+                "99.999" : 8554612.770744225,
+                "99.9999" : 8554612.770744225,
+                "100.0" : 8554612.770744225
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8485699.190839695,
+                    8489195.465195246,
+                    8488561.343511451
+                ],
+                [
+                    8554612.770744225,
+                    8533564.771331059,
+                    8514017.177872341
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-15T12-20-04Z-bd8765243ce5f60bda9e36cd4a17b680fb935153-jdk17.json
+++ b/performance-results/2026-02-15T12-20-04Z-bd8765243ce5f60bda9e36cd4a17b680fb935153-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3500320104196293,
+            "scoreError" : 0.037420106982562935,
+            "scoreConfidence" : [
+                3.3126119034370665,
+                3.387452117402192
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3430854916121278,
+                "50.0" : 3.3503488820677294,
+                "90.0" : 3.356344785930932,
+                "95.0" : 3.356344785930932,
+                "99.0" : 3.356344785930932,
+                "99.9" : 3.356344785930932,
+                "99.99" : 3.356344785930932,
+                "99.999" : 3.356344785930932,
+                "99.9999" : 3.356344785930932,
+                "100.0" : 3.356344785930932
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.35282820898006,
+                    3.356344785930932
+                ],
+                [
+                    3.3430854916121278,
+                    3.347869555155399
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6969367396920392,
+            "scoreError" : 0.027790009476774846,
+            "scoreConfidence" : [
+                1.6691467302152643,
+                1.724726749168814
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.691174857681418,
+                "50.0" : 1.6980346095958951,
+                "90.0" : 1.7005028818949495,
+                "95.0" : 1.7005028818949495,
+                "99.0" : 1.7005028818949495,
+                "99.9" : 1.7005028818949495,
+                "99.99" : 1.7005028818949495,
+                "99.999" : 1.7005028818949495,
+                "99.9999" : 1.7005028818949495,
+                "100.0" : 1.7005028818949495
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6999262366307475,
+                    1.7005028818949495
+                ],
+                [
+                    1.691174857681418,
+                    1.6961429825610428
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8492967927862969,
+            "scoreError" : 0.030626913473022557,
+            "scoreConfidence" : [
+                0.8186698793132743,
+                0.8799237062593195
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8430264703452263,
+                "50.0" : 0.8498074818803378,
+                "90.0" : 0.8545457370392853,
+                "95.0" : 0.8545457370392853,
+                "99.0" : 0.8545457370392853,
+                "99.9" : 0.8545457370392853,
+                "99.99" : 0.8545457370392853,
+                "99.999" : 0.8545457370392853,
+                "99.9999" : 0.8545457370392853,
+                "100.0" : 0.8545457370392853
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8430264703452263,
+                    0.8498066419131809
+                ],
+                [
+                    0.8498083218474948,
+                    0.8545457370392853
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.49248100492034,
+            "scoreError" : 0.32565273110306603,
+            "scoreConfidence" : [
+                16.166828273817273,
+                16.818133736023405
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.362976957897384,
+                "50.0" : 16.506677376731936,
+                "90.0" : 16.600321172705424,
+                "95.0" : 16.600321172705424,
+                "99.0" : 16.600321172705424,
+                "99.9" : 16.600321172705424,
+                "99.99" : 16.600321172705424,
+                "99.999" : 16.600321172705424,
+                "99.9999" : 16.600321172705424,
+                "100.0" : 16.600321172705424
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.59530304694344,
+                    16.596112832480827,
+                    16.600321172705424
+                ],
+                [
+                    16.362976957897384,
+                    16.418051706520433,
+                    16.382120312974532
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2796.2421980055856,
+            "scoreError" : 24.52979481434762,
+            "scoreConfidence" : [
+                2771.712403191238,
+                2820.771992819933
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2787.3833186892484,
+                "50.0" : 2794.9378960769627,
+                "90.0" : 2808.293745694765,
+                "95.0" : 2808.293745694765,
+                "99.0" : 2808.293745694765,
+                "99.9" : 2808.293745694765,
+                "99.99" : 2808.293745694765,
+                "99.999" : 2808.293745694765,
+                "99.9999" : 2808.293745694765,
+                "100.0" : 2808.293745694765
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2799.2785657643667,
+                    2803.619056953136,
+                    2808.293745694765
+                ],
+                [
+                    2788.2812745424394,
+                    2787.3833186892484,
+                    2790.5972263895583
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73890.18986899276,
+            "scoreError" : 2207.087822271499,
+            "scoreConfidence" : [
+                71683.10204672127,
+                76097.27769126426
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73151.53850953949,
+                "50.0" : 73876.70910194656,
+                "90.0" : 74643.08731657846,
+                "95.0" : 74643.08731657846,
+                "99.0" : 74643.08731657846,
+                "99.9" : 74643.08731657846,
+                "99.99" : 74643.08731657846,
+                "99.999" : 74643.08731657846,
+                "99.9999" : 74643.08731657846,
+                "100.0" : 74643.08731657846
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74616.94780566735,
+                    74643.08731657846,
+                    74564.65120478829
+                ],
+                [
+                    73188.76699910482,
+                    73176.1473782782,
+                    73151.53850953949
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 357.7513622010418,
+            "scoreError" : 23.548192077516354,
+            "scoreConfidence" : [
+                334.2031701235254,
+                381.29955427855816
+            ],
+            "scorePercentiles" : {
+                "0.0" : 349.938471683284,
+                "50.0" : 357.4803168450858,
+                "90.0" : 365.8098555989819,
+                "95.0" : 365.8098555989819,
+                "99.0" : 365.8098555989819,
+                "99.9" : 365.8098555989819,
+                "99.99" : 365.8098555989819,
+                "99.999" : 365.8098555989819,
+                "99.9999" : 365.8098555989819,
+                "100.0" : 365.8098555989819
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    365.8098555989819,
+                    364.77987104545787,
+                    365.6408143429717
+                ],
+                [
+                    350.1583978908416,
+                    349.938471683284,
+                    350.18076264471375
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 115.28449428648058,
+            "scoreError" : 8.001784655396062,
+            "scoreConfidence" : [
+                107.28270963108451,
+                123.28627894187665
+            ],
+            "scorePercentiles" : {
+                "0.0" : 112.62356387382988,
+                "50.0" : 115.18300710906311,
+                "90.0" : 118.03785223273071,
+                "95.0" : 118.03785223273071,
+                "99.0" : 118.03785223273071,
+                "99.9" : 118.03785223273071,
+                "99.99" : 118.03785223273071,
+                "99.999" : 118.03785223273071,
+                "99.9999" : 118.03785223273071,
+                "100.0" : 118.03785223273071
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    112.70539786158777,
+                    112.62356387382988,
+                    112.71879860611905
+                ],
+                [
+                    117.97413753260889,
+                    117.64721561200717,
+                    118.03785223273071
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.061469984428942366,
+            "scoreError" : 6.406766863869185E-4,
+            "scoreConfidence" : [
+                0.06082930774255545,
+                0.062110661115329285
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061225112921988074,
+                "50.0" : 0.06148149608740166,
+                "90.0" : 0.06170013703363216,
+                "95.0" : 0.06170013703363216,
+                "99.0" : 0.06170013703363216,
+                "99.9" : 0.06170013703363216,
+                "99.99" : 0.06170013703363216,
+                "99.999" : 0.06170013703363216,
+                "99.9999" : 0.06170013703363216,
+                "100.0" : 0.06170013703363216
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06166053272578169,
+                    0.061670351231846075,
+                    0.06170013703363216
+                ],
+                [
+                    0.0612613132113846,
+                    0.06130245944902163,
+                    0.061225112921988074
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.553512296802093E-4,
+            "scoreError" : 1.8108968563663497E-5,
+            "scoreConfidence" : [
+                3.3724226111654583E-4,
+                3.734601982438728E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.4925036987781566E-4,
+                "50.0" : 3.553740644576768E-4,
+                "90.0" : 3.613462978574255E-4,
+                "95.0" : 3.613462978574255E-4,
+                "99.0" : 3.613462978574255E-4,
+                "99.9" : 3.613462978574255E-4,
+                "99.99" : 3.613462978574255E-4,
+                "99.999" : 3.613462978574255E-4,
+                "99.9999" : 3.613462978574255E-4,
+                "100.0" : 3.613462978574255E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.4953810405481824E-4,
+                    3.495832023435979E-4,
+                    3.4925036987781566E-4
+                ],
+                [
+                    3.613462978574255E-4,
+                    3.6116492657175566E-4,
+                    3.6122447737584247E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2189973945916757,
+            "scoreError" : 0.046931924922831623,
+            "scoreConfidence" : [
+                2.172065469668844,
+                2.265929319514507
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1835576762008735,
+                "50.0" : 2.222201582304179,
+                "90.0" : 2.267534687838492,
+                "95.0" : 2.269187472323049,
+                "99.0" : 2.269187472323049,
+                "99.9" : 2.269187472323049,
+                "99.99" : 2.269187472323049,
+                "99.999" : 2.269187472323049,
+                "99.9999" : 2.269187472323049,
+                "100.0" : 2.269187472323049
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.2526596274774775,
+                    2.223612646287239,
+                    2.2207905183211194,
+                    2.1844863383573614,
+                    2.1835576762008735
+                ],
+                [
+                    2.269187472323049,
+                    2.226361327693678,
+                    2.248412517311151,
+                    2.1903484544459046,
+                    2.1905573674989047
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013731571676756557,
+            "scoreError" : 3.600170078831955E-4,
+            "scoreConfidence" : [
+                0.013371554668873362,
+                0.014091588684639752
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013607228442006061,
+                "50.0" : 0.013733398291744109,
+                "90.0" : 0.013852863834897996,
+                "95.0" : 0.013852863834897996,
+                "99.0" : 0.013852863834897996,
+                "99.9" : 0.013852863834897996,
+                "99.99" : 0.013852863834897996,
+                "99.999" : 0.013852863834897996,
+                "99.9999" : 0.013852863834897996,
+                "100.0" : 0.013852863834897996
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013845311355093282,
+                    0.013852863834897996,
+                    0.013847858069465563
+                ],
+                [
+                    0.013621485228394936,
+                    0.013614683130681501,
+                    0.013607228442006061
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0339545112744595,
+            "scoreError" : 0.0034915396370489814,
+            "scoreConfidence" : [
+                1.0304629716374105,
+                1.0374460509115084
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0324065700423248,
+                "50.0" : 1.033952857736491,
+                "90.0" : 1.0354059994823481,
+                "95.0" : 1.0354059994823481,
+                "99.0" : 1.0354059994823481,
+                "99.9" : 1.0354059994823481,
+                "99.99" : 1.0354059994823481,
+                "99.999" : 1.0354059994823481,
+                "99.9999" : 1.0354059994823481,
+                "100.0" : 1.0354059994823481
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0352605072463767,
+                    1.0341626214064117,
+                    1.0354059994823481
+                ],
+                [
+                    1.0327482754027262,
+                    1.0324065700423248,
+                    1.0337430940665702
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010903668406456242,
+            "scoreError" : 3.778345278461113E-4,
+            "scoreConfidence" : [
+                0.010525833878610131,
+                0.011281502934302353
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010775001573113126,
+                "50.0" : 0.010903394964392906,
+                "90.0" : 0.011031849706008892,
+                "95.0" : 0.011031849706008892,
+                "99.0" : 0.011031849706008892,
+                "99.9" : 0.011031849706008892,
+                "99.99" : 0.011031849706008892,
+                "99.999" : 0.011031849706008892,
+                "99.9999" : 0.011031849706008892,
+                "100.0" : 0.011031849706008892
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010775001573113126,
+                    0.010784806758867022,
+                    0.010782404144653139
+                ],
+                [
+                    0.011021983169918792,
+                    0.011025965086176481,
+                    0.011031849706008892
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.113086699953928,
+            "scoreError" : 0.17061341809278877,
+            "scoreConfidence" : [
+                2.9424732818611394,
+                3.283700118046717
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0518577760829775,
+                "50.0" : 3.113814458493622,
+                "90.0" : 3.1761742146031744,
+                "95.0" : 3.1761742146031744,
+                "99.0" : 3.1761742146031744,
+                "99.9" : 3.1761742146031744,
+                "99.99" : 3.1761742146031744,
+                "99.999" : 3.1761742146031744,
+                "99.9999" : 3.1761742146031744,
+                "100.0" : 3.1761742146031744
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0518577760829775,
+                    3.065707231146536,
+                    3.0560003940134393
+                ],
+                [
+                    3.1761742146031744,
+                    3.166858898036732,
+                    3.1619216858407078
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.741602350187941,
+            "scoreError" : 0.08044454723260439,
+            "scoreConfidence" : [
+                2.6611578029553367,
+                2.8220468974205457
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7115042474925453,
+                "50.0" : 2.7421626069710396,
+                "90.0" : 2.7734551669439824,
+                "95.0" : 2.7734551669439824,
+                "99.0" : 2.7734551669439824,
+                "99.9" : 2.7734551669439824,
+                "99.99" : 2.7734551669439824,
+                "99.999" : 2.7734551669439824,
+                "99.9999" : 2.7734551669439824,
+                "100.0" : 2.7734551669439824
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7734551669439824,
+                    2.762328377796189,
+                    2.7663966868603045
+                ],
+                [
+                    2.72199683614589,
+                    2.7115042474925453,
+                    2.7139327858887383
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18217928975334916,
+            "scoreError" : 0.01844619439155929,
+            "scoreConfidence" : [
+                0.16373309536178987,
+                0.20062548414490844
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17609703803620483,
+                "50.0" : 0.1821992914492117,
+                "90.0" : 0.18830059610604805,
+                "95.0" : 0.18830059610604805,
+                "99.0" : 0.18830059610604805,
+                "99.9" : 0.18830059610604805,
+                "99.99" : 0.18830059610604805,
+                "99.999" : 0.18830059610604805,
+                "99.9999" : 0.18830059610604805,
+                "100.0" : 0.18830059610604805
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18830059610604805,
+                    0.1881822670066427,
+                    0.18806719201113326
+                ],
+                [
+                    0.17633139088729016,
+                    0.17609703803620483,
+                    0.17609725447277594
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.34359185878785814,
+            "scoreError" : 0.05545890057691392,
+            "scoreConfidence" : [
+                0.2881329582109442,
+                0.3990507593647721
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3247093193389181,
+                "50.0" : 0.34429259894631037,
+                "90.0" : 0.3617599868682849,
+                "95.0" : 0.3617599868682849,
+                "99.0" : 0.3617599868682849,
+                "99.9" : 0.3617599868682849,
+                "99.99" : 0.3617599868682849,
+                "99.999" : 0.3617599868682849,
+                "99.9999" : 0.3617599868682849,
+                "100.0" : 0.3617599868682849
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.36151616394331576,
+                    0.3616131306454529,
+                    0.3617599868682849
+                ],
+                [
+                    0.327069033949305,
+                    0.3248835179818719,
+                    0.3247093193389181
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1452005202333793,
+            "scoreError" : 0.002535268800985778,
+            "scoreConfidence" : [
+                0.1426652514323935,
+                0.14773578903436507
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14428615743987072,
+                "50.0" : 0.14518913583730564,
+                "90.0" : 0.14608050199395242,
+                "95.0" : 0.14608050199395242,
+                "99.0" : 0.14608050199395242,
+                "99.9" : 0.14608050199395242,
+                "99.99" : 0.14608050199395242,
+                "99.999" : 0.14608050199395242,
+                "99.9999" : 0.14608050199395242,
+                "100.0" : 0.14608050199395242
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14428615743987072,
+                    0.14447174698064144,
+                    0.14437898263167012
+                ],
+                [
+                    0.14608050199395242,
+                    0.1460792076601712,
+                    0.14590652469396986
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.39650732465957894,
+            "scoreError" : 0.0038186736474942005,
+            "scoreConfidence" : [
+                0.3926886510120847,
+                0.40032599830707316
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39505252259619184,
+                "50.0" : 0.39635166647345454,
+                "90.0" : 0.39800935763750694,
+                "95.0" : 0.39800935763750694,
+                "99.0" : 0.39800935763750694,
+                "99.9" : 0.39800935763750694,
+                "99.99" : 0.39800935763750694,
+                "99.999" : 0.39800935763750694,
+                "99.9999" : 0.39800935763750694,
+                "100.0" : 0.39800935763750694
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.39800935763750694,
+                    0.39798043755969437,
+                    0.39713248230808945
+                ],
+                [
+                    0.3955708506388197,
+                    0.3952982972171713,
+                    0.39505252259619184
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15279116401608742,
+            "scoreError" : 0.009263186601538494,
+            "scoreConfidence" : [
+                0.14352797741454892,
+                0.1620543506176259
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14950754740760674,
+                "50.0" : 0.15289489854483196,
+                "90.0" : 0.15586974037532342,
+                "95.0" : 0.15586974037532342,
+                "99.0" : 0.15586974037532342,
+                "99.9" : 0.15586974037532342,
+                "99.99" : 0.15586974037532342,
+                "99.999" : 0.15586974037532342,
+                "99.9999" : 0.15586974037532342,
+                "100.0" : 0.15586974037532342
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15585126458349569,
+                    0.15568198788822293,
+                    0.15586974037532342
+                ],
+                [
+                    0.150107809201441,
+                    0.14972863464043482,
+                    0.14950754740760674
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04701627584594204,
+            "scoreError" : 0.0021713633158060575,
+            "scoreConfidence" : [
+                0.044844912530135984,
+                0.0491876391617481
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04631662049928211,
+                "50.0" : 0.04689533589013372,
+                "90.0" : 0.048018058230656205,
+                "95.0" : 0.048018058230656205,
+                "99.0" : 0.048018058230656205,
+                "99.9" : 0.048018058230656205,
+                "99.99" : 0.048018058230656205,
+                "99.999" : 0.048018058230656205,
+                "99.9999" : 0.048018058230656205,
+                "100.0" : 0.048018058230656205
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04632719247286423,
+                    0.046345191287220484,
+                    0.04631662049928211
+                ],
+                [
+                    0.048018058230656205,
+                    0.04764511209258227,
+                    0.047445480493046956
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8498651.11339389,
+            "scoreError" : 39324.20176459278,
+            "scoreConfidence" : [
+                8459326.911629297,
+                8537975.315158483
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8479906.06779661,
+                "50.0" : 8503430.876385685,
+                "90.0" : 8511378.514042553,
+                "95.0" : 8511378.514042553,
+                "99.0" : 8511378.514042553,
+                "99.9" : 8511378.514042553,
+                "99.99" : 8511378.514042553,
+                "99.999" : 8511378.514042553,
+                "99.9999" : 8511378.514042553,
+                "100.0" : 8511378.514042553
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8505858.011904761,
+                    8511378.514042553,
+                    8511130.910638297
+                ],
+                [
+                    8479906.06779661,
+                    8501003.74086661,
+                    8482629.435114503
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-19T03-11-51Z-fd7ff0ada03f9a721ebf6d1eb5b6d38e476728b9-jdk17.json
+++ b/performance-results/2026-02-19T03-11-51Z-fd7ff0ada03f9a721ebf6d1eb5b6d38e476728b9-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.340827160897512,
+            "scoreError" : 0.04339751516283107,
+            "scoreConfidence" : [
+                3.297429645734681,
+                3.3842246760603434
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3324141757473313,
+                "50.0" : 3.3412238579524587,
+                "90.0" : 3.3484467519378005,
+                "95.0" : 3.3484467519378005,
+                "99.0" : 3.3484467519378005,
+                "99.9" : 3.3484467519378005,
+                "99.99" : 3.3484467519378005,
+                "99.999" : 3.3484467519378005,
+                "99.9999" : 3.3484467519378005,
+                "100.0" : 3.3484467519378005
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3394695447790648,
+                    3.3484467519378005
+                ],
+                [
+                    3.3324141757473313,
+                    3.342978171125852
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6905205434956054,
+            "scoreError" : 0.029890327306713257,
+            "scoreConfidence" : [
+                1.6606302161888922,
+                1.7204108708023187
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6861626150881515,
+                "50.0" : 1.6900352181948435,
+                "90.0" : 1.6958491225045833,
+                "95.0" : 1.6958491225045833,
+                "99.0" : 1.6958491225045833,
+                "99.9" : 1.6958491225045833,
+                "99.99" : 1.6958491225045833,
+                "99.999" : 1.6958491225045833,
+                "99.9999" : 1.6958491225045833,
+                "100.0" : 1.6958491225045833
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6928927586342064,
+                    1.6958491225045833
+                ],
+                [
+                    1.6871776777554803,
+                    1.6861626150881515
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8479895878008669,
+            "scoreError" : 0.04047885825279181,
+            "scoreConfidence" : [
+                0.807510729548075,
+                0.8884684460536587
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.840221140423438,
+                "50.0" : 0.8491763740253324,
+                "90.0" : 0.8533844627293646,
+                "95.0" : 0.8533844627293646,
+                "99.0" : 0.8533844627293646,
+                "99.9" : 0.8533844627293646,
+                "99.99" : 0.8533844627293646,
+                "99.999" : 0.8533844627293646,
+                "99.9999" : 0.8533844627293646,
+                "100.0" : 0.8533844627293646
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8533844627293646,
+                    0.8527434654067851
+                ],
+                [
+                    0.840221140423438,
+                    0.8456092826438798
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.287254753876965,
+            "scoreError" : 0.2716746094886496,
+            "scoreConfidence" : [
+                16.015580144388316,
+                16.558929363365614
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.171271608279696,
+                "50.0" : 16.283665822470024,
+                "90.0" : 16.389815601448433,
+                "95.0" : 16.389815601448433,
+                "99.0" : 16.389815601448433,
+                "99.9" : 16.389815601448433,
+                "99.99" : 16.389815601448433,
+                "99.999" : 16.389815601448433,
+                "99.9999" : 16.389815601448433,
+                "100.0" : 16.389815601448433
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.218535537315823,
+                    16.213181469351582,
+                    16.171271608279696
+                ],
+                [
+                    16.389815601448433,
+                    16.381928199242022,
+                    16.348796107624224
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2768.1043904833627,
+            "scoreError" : 113.17138007509172,
+            "scoreConfidence" : [
+                2654.933010408271,
+                2881.2757705584545
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2726.828282276871,
+                "50.0" : 2764.895241282397,
+                "90.0" : 2810.346525344426,
+                "95.0" : 2810.346525344426,
+                "99.0" : 2810.346525344426,
+                "99.9" : 2810.346525344426,
+                "99.99" : 2810.346525344426,
+                "99.999" : 2810.346525344426,
+                "99.9999" : 2810.346525344426,
+                "100.0" : 2810.346525344426
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2795.435003642897,
+                    2810.346525344426,
+                    2807.9446235309897
+                ],
+                [
+                    2733.7164291830954,
+                    2734.355478921897,
+                    2726.828282276871
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73293.38924419826,
+            "scoreError" : 933.306487862158,
+            "scoreConfidence" : [
+                72360.08275633611,
+                74226.69573206041
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72968.63768960616,
+                "50.0" : 73293.02844268616,
+                "90.0" : 73633.13547839707,
+                "95.0" : 73633.13547839707,
+                "99.0" : 73633.13547839707,
+                "99.9" : 73633.13547839707,
+                "99.99" : 73633.13547839707,
+                "99.999" : 73633.13547839707,
+                "99.9999" : 73633.13547839707,
+                "100.0" : 73633.13547839707
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73010.74742147731,
+                    72968.63768960616,
+                    72991.7126702994
+                ],
+                [
+                    73633.13547839707,
+                    73580.79274151467,
+                    73575.309463895
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 360.46899136893495,
+            "scoreError" : 4.625338859966472,
+            "scoreConfidence" : [
+                355.8436525089685,
+                365.0943302289014
+            ],
+            "scorePercentiles" : {
+                "0.0" : 358.0835945075427,
+                "50.0" : 360.1565325895176,
+                "90.0" : 362.70072975328844,
+                "95.0" : 362.70072975328844,
+                "99.0" : 362.70072975328844,
+                "99.9" : 362.70072975328844,
+                "99.99" : 362.70072975328844,
+                "99.999" : 362.70072975328844,
+                "99.9999" : 362.70072975328844,
+                "100.0" : 362.70072975328844
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    361.94086910491484,
+                    362.70072975328844,
+                    360.3688311592398
+                ],
+                [
+                    358.0835945075427,
+                    359.94423401979543,
+                    359.77568966882853
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 115.76241383234446,
+            "scoreError" : 3.8151651824972057,
+            "scoreConfidence" : [
+                111.94724864984725,
+                119.57757901484167
+            ],
+            "scorePercentiles" : {
+                "0.0" : 114.42409164116812,
+                "50.0" : 115.68869529187359,
+                "90.0" : 117.16527667599028,
+                "95.0" : 117.16527667599028,
+                "99.0" : 117.16527667599028,
+                "99.9" : 117.16527667599028,
+                "99.99" : 117.16527667599028,
+                "99.999" : 117.16527667599028,
+                "99.9999" : 117.16527667599028,
+                "100.0" : 117.16527667599028
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    114.42409164116812,
+                    114.65101827604252,
+                    114.51387089985644
+                ],
+                [
+                    116.72637230770464,
+                    117.09385319330477,
+                    117.16527667599028
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06133704832637408,
+            "scoreError" : 7.664540016265166E-4,
+            "scoreConfidence" : [
+                0.06057059432474756,
+                0.0621035023280006
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06097465151062468,
+                "50.0" : 0.061397252519941437,
+                "90.0" : 0.06166636390096507,
+                "95.0" : 0.06166636390096507,
+                "99.0" : 0.06166636390096507,
+                "99.9" : 0.06166636390096507,
+                "99.99" : 0.06166636390096507,
+                "99.999" : 0.06166636390096507,
+                "99.9999" : 0.06166636390096507,
+                "100.0" : 0.06166636390096507
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06097465151062468,
+                    0.06129103907844495,
+                    0.061069635389312975
+                ],
+                [
+                    0.06166636390096507,
+                    0.06151713411745889,
+                    0.06150346596143793
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6056755473844654E-4,
+            "scoreError" : 1.5228833827681198E-5,
+            "scoreConfidence" : [
+                3.453387209107653E-4,
+                3.7579638856612775E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.554871585720253E-4,
+                "50.0" : 3.6052552606750406E-4,
+                "90.0" : 3.6573115154777867E-4,
+                "95.0" : 3.6573115154777867E-4,
+                "99.0" : 3.6573115154777867E-4,
+                "99.9" : 3.6573115154777867E-4,
+                "99.99" : 3.6573115154777867E-4,
+                "99.999" : 3.6573115154777867E-4,
+                "99.9999" : 3.6573115154777867E-4,
+                "100.0" : 3.6573115154777867E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.554871585720253E-4,
+                    3.5558781456561796E-4,
+                    3.5576189732524407E-4
+                ],
+                [
+                    3.6528915480976405E-4,
+                    3.6573115154777867E-4,
+                    3.6554815161024925E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.282471150610378,
+            "scoreError" : 0.0731638809631371,
+            "scoreConfidence" : [
+                2.209307269647241,
+                2.3556350315735153
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.215536215551617,
+                "50.0" : 2.273649357101248,
+                "90.0" : 2.36616838911472,
+                "95.0" : 2.3701828469194313,
+                "99.0" : 2.3701828469194313,
+                "99.9" : 2.3701828469194313,
+                "99.99" : 2.3701828469194313,
+                "99.999" : 2.3701828469194313,
+                "99.9999" : 2.3701828469194313,
+                "100.0" : 2.3701828469194313
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3068557663206457,
+                    2.259227710187486,
+                    2.2759774037323623,
+                    2.215536215551617,
+                    2.2187085474711625
+                ],
+                [
+                    2.3701828469194313,
+                    2.3129565191951897,
+                    2.3300382688723205,
+                    2.271321310470134,
+                    2.2639069173834314
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013408065289939484,
+            "scoreError" : 1.2988184231398298E-4,
+            "scoreConfidence" : [
+                0.013278183447625502,
+                0.013537947132253467
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013358218714100228,
+                "50.0" : 0.013410091131735458,
+                "90.0" : 0.013452476067174668,
+                "95.0" : 0.013452476067174668,
+                "99.0" : 0.013452476067174668,
+                "99.9" : 0.013452476067174668,
+                "99.99" : 0.013452476067174668,
+                "99.999" : 0.013452476067174668,
+                "99.9999" : 0.013452476067174668,
+                "100.0" : 0.013452476067174668
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013371627899886879,
+                    0.013368128714618385,
+                    0.013358218714100228
+                ],
+                [
+                    0.013448554363584038,
+                    0.013449385980272696,
+                    0.013452476067174668
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.042617584306856,
+            "scoreError" : 0.02786423236837994,
+            "scoreConfidence" : [
+                1.014753351938476,
+                1.070481816675236
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0330376301001962,
+                "50.0" : 1.0424193868135494,
+                "90.0" : 1.0530774442455513,
+                "95.0" : 1.0530774442455513,
+                "99.0" : 1.0530774442455513,
+                "99.9" : 1.0530774442455513,
+                "99.99" : 1.0530774442455513,
+                "99.999" : 1.0530774442455513,
+                "99.9999" : 1.0530774442455513,
+                "100.0" : 1.0530774442455513
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0530774442455513,
+                    1.0513493466148023,
+                    1.0505205516806724
+                ],
+                [
+                    1.0334023112534876,
+                    1.0330376301001962,
+                    1.0343182219464266
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010660989526823662,
+            "scoreError" : 5.001770755751767E-4,
+            "scoreConfidence" : [
+                0.010160812451248485,
+                0.01116116660239884
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010489809065066661,
+                "50.0" : 0.01066391793523384,
+                "90.0" : 0.010825139448234355,
+                "95.0" : 0.010825139448234355,
+                "99.0" : 0.010825139448234355,
+                "99.9" : 0.010825139448234355,
+                "99.99" : 0.010825139448234355,
+                "99.999" : 0.010825139448234355,
+                "99.9999" : 0.010825139448234355,
+                "100.0" : 0.010825139448234355
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010822114535604754,
+                    0.010825139448234355,
+                    0.010823991806490298
+                ],
+                [
+                    0.010505721334862925,
+                    0.010499160970682972,
+                    0.010489809065066661
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0530370312803985,
+            "scoreError" : 0.09099076330788786,
+            "scoreConfidence" : [
+                2.962046267972511,
+                3.144027794588286
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0078239476849067,
+                "50.0" : 3.05670270874551,
+                "90.0" : 3.094451792079208,
+                "95.0" : 3.094451792079208,
+                "99.0" : 3.094451792079208,
+                "99.9" : 3.094451792079208,
+                "99.99" : 3.094451792079208,
+                "99.999" : 3.094451792079208,
+                "99.9999" : 3.094451792079208,
+                "100.0" : 3.094451792079208
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.040809372036474,
+                    3.0292852289521504,
+                    3.0078239476849067
+                ],
+                [
+                    3.094451792079208,
+                    3.0725960454545453,
+                    3.0732558014751077
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.759417346810057,
+            "scoreError" : 0.02655321451346599,
+            "scoreConfidence" : [
+                2.732864132296591,
+                2.785970561323523
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7494179356789443,
+                "50.0" : 2.7584350088251517,
+                "90.0" : 2.7771358056095528,
+                "95.0" : 2.7771358056095528,
+                "99.0" : 2.7771358056095528,
+                "99.9" : 2.7771358056095528,
+                "99.99" : 2.7771358056095528,
+                "99.999" : 2.7771358056095528,
+                "99.9999" : 2.7771358056095528,
+                "100.0" : 2.7771358056095528
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7593594598620688,
+                    2.7771358056095528,
+                    2.758375671814672
+                ],
+                [
+                    2.7494179356789443,
+                    2.7537208620594713,
+                    2.7584943458356315
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17906658639817272,
+            "scoreError" : 0.009772536710594956,
+            "scoreConfidence" : [
+                0.16929404968757777,
+                0.18883912310876766
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17580755240673676,
+                "50.0" : 0.1791025165040057,
+                "90.0" : 0.18227471428831818,
+                "95.0" : 0.18227471428831818,
+                "99.0" : 0.18227471428831818,
+                "99.9" : 0.18227471428831818,
+                "99.99" : 0.18227471428831818,
+                "99.999" : 0.18227471428831818,
+                "99.9999" : 0.18227471428831818,
+                "100.0" : 0.18227471428831818
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18227471428831818,
+                    0.1822258653558803,
+                    0.18224190977347693
+                ],
+                [
+                    0.17587030891249297,
+                    0.17580755240673676,
+                    0.17597916765213106
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3203622815697967,
+            "scoreError" : 0.008234326523384496,
+            "scoreConfidence" : [
+                0.31212795504641216,
+                0.3285966080931812
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.317170531937837,
+                "50.0" : 0.320726375195348,
+                "90.0" : 0.3231778028697001,
+                "95.0" : 0.3231778028697001,
+                "99.0" : 0.3231778028697001,
+                "99.9" : 0.3231778028697001,
+                "99.99" : 0.3231778028697001,
+                "99.999" : 0.3231778028697001,
+                "99.9999" : 0.3231778028697001,
+                "100.0" : 0.3231778028697001
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3186918351763919,
+                    0.317170531937837,
+                    0.3173233310909437
+                ],
+                [
+                    0.3231778028697001,
+                    0.3230492731296033,
+                    0.32276091521430417
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1499870430819004,
+            "scoreError" : 0.011550239125649724,
+            "scoreConfidence" : [
+                0.13843680395625066,
+                0.16153728220755012
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14615400738066703,
+                "50.0" : 0.1499914947470605,
+                "90.0" : 0.1538344495362038,
+                "95.0" : 0.1538344495362038,
+                "99.0" : 0.1538344495362038,
+                "99.9" : 0.1538344495362038,
+                "99.99" : 0.1538344495362038,
+                "99.999" : 0.1538344495362038,
+                "99.9999" : 0.1538344495362038,
+                "100.0" : 0.1538344495362038
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1537768482723624,
+                    0.1536267968937229,
+                    0.1538344495362038
+                ],
+                [
+                    0.14617396380804817,
+                    0.1463561926003981,
+                    0.14615400738066703
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4038066066567542,
+            "scoreError" : 0.013360249255043536,
+            "scoreConfidence" : [
+                0.3904463574017107,
+                0.41716685591179775
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.398157114225425,
+                "50.0" : 0.40346737768087215,
+                "90.0" : 0.41025195745815557,
+                "95.0" : 0.41025195745815557,
+                "99.0" : 0.41025195745815557,
+                "99.9" : 0.41025195745815557,
+                "99.99" : 0.41025195745815557,
+                "99.999" : 0.41025195745815557,
+                "99.9999" : 0.41025195745815557,
+                "100.0" : 0.41025195745815557
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4024395650126766,
+                    0.3994069343398035,
+                    0.398157114225425
+                ],
+                [
+                    0.41025195745815557,
+                    0.4080888785553969,
+                    0.40449519034906767
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15715230244024533,
+            "scoreError" : 0.00384711063730289,
+            "scoreConfidence" : [
+                0.15330519180294244,
+                0.16099941307754823
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15537508192722413,
+                "50.0" : 0.1579309878673579,
+                "90.0" : 0.15817015808620008,
+                "95.0" : 0.15817015808620008,
+                "99.0" : 0.15817015808620008,
+                "99.9" : 0.15817015808620008,
+                "99.99" : 0.15817015808620008,
+                "99.999" : 0.15817015808620008,
+                "99.9999" : 0.15817015808620008,
+                "100.0" : 0.15817015808620008
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15817015808620008,
+                    0.15787093532141955,
+                    0.15799104041329626
+                ],
+                [
+                    0.15810938076491327,
+                    0.15537508192722413,
+                    0.1553972181284187
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04629729955717379,
+            "scoreError" : 0.00131595484733804,
+            "scoreConfidence" : [
+                0.04498134470983575,
+                0.047613254404511834
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.045594909249659185,
+                "50.0" : 0.04639768607319364,
+                "90.0" : 0.046706169129598143,
+                "95.0" : 0.046706169129598143,
+                "99.0" : 0.046706169129598143,
+                "99.9" : 0.046706169129598143,
+                "99.99" : 0.046706169129598143,
+                "99.999" : 0.046706169129598143,
+                "99.9999" : 0.046706169129598143,
+                "100.0" : 0.046706169129598143
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0461146845282288,
+                    0.04598592586750789,
+                    0.045594909249659185
+                ],
+                [
+                    0.046706169129598143,
+                    0.04670142094989025,
+                    0.04668068761815848
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8707468.003636016,
+            "scoreError" : 524552.9347786128,
+            "scoreConfidence" : [
+                8182915.068857403,
+                9232020.938414628
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8526046.768968457,
+                "50.0" : 8700998.832138265,
+                "90.0" : 8889949.949333332,
+                "95.0" : 8889949.949333332,
+                "99.0" : 8889949.949333332,
+                "99.9" : 8889949.949333332,
+                "99.99" : 8889949.949333332,
+                "99.999" : 8889949.949333332,
+                "99.9999" : 8889949.949333332,
+                "100.0" : 8889949.949333332
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8853204.530088495,
+                    8889949.949333332,
+                    8889840.493333334
+                ],
+                [
+                    8526046.768968457,
+                    8548793.134188034,
+                    8536973.145904437
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-19T21-54-46Z-f8f9892d6ac76044c65ba9ba1676cf246ce744fd-jdk17.json
+++ b/performance-results/2026-02-19T21-54-46Z-f8f9892d6ac76044c65ba9ba1676cf246ce744fd-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.329242635164232,
+            "scoreError" : 0.05708999904682872,
+            "scoreConfidence" : [
+                3.2721526361174034,
+                3.386332634211061
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3195876184442055,
+                "50.0" : 3.3287683266142265,
+                "90.0" : 3.339846268984271,
+                "95.0" : 3.339846268984271,
+                "99.0" : 3.339846268984271,
+                "99.9" : 3.339846268984271,
+                "99.99" : 3.339846268984271,
+                "99.999" : 3.339846268984271,
+                "99.9999" : 3.339846268984271,
+                "100.0" : 3.339846268984271
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3250232240550055,
+                    3.332513429173448
+                ],
+                [
+                    3.3195876184442055,
+                    3.339846268984271
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6808687180239295,
+            "scoreError" : 0.020413885917307223,
+            "scoreConfidence" : [
+                1.6604548321066221,
+                1.7012826039412368
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.676935983584558,
+                "50.0" : 1.681436950921988,
+                "90.0" : 1.6836649866671838,
+                "95.0" : 1.6836649866671838,
+                "99.0" : 1.6836649866671838,
+                "99.9" : 1.6836649866671838,
+                "99.99" : 1.6836649866671838,
+                "99.999" : 1.6836649866671838,
+                "99.9999" : 1.6836649866671838,
+                "100.0" : 1.6836649866671838
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.676935983584558,
+                    1.679703760022568
+                ],
+                [
+                    1.6831701418214082,
+                    1.6836649866671838
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8434827658903749,
+            "scoreError" : 0.02586279748371502,
+            "scoreConfidence" : [
+                0.8176199684066598,
+                0.8693455633740899
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.840445621133267,
+                "50.0" : 0.8421693268691118,
+                "90.0" : 0.8491467886900087,
+                "95.0" : 0.8491467886900087,
+                "99.0" : 0.8491467886900087,
+                "99.9" : 0.8491467886900087,
+                "99.99" : 0.8491467886900087,
+                "99.999" : 0.8491467886900087,
+                "99.9999" : 0.8491467886900087,
+                "100.0" : 0.8491467886900087
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8434537501019574,
+                    0.8491467886900087
+                ],
+                [
+                    0.840445621133267,
+                    0.8408849036362662
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.724436136170736,
+            "scoreError" : 0.9707224567459692,
+            "scoreConfidence" : [
+                14.753713679424767,
+                16.695158592916705
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.378711927506044,
+                "50.0" : 15.71642998622635,
+                "90.0" : 16.105385210951628,
+                "95.0" : 16.105385210951628,
+                "99.0" : 16.105385210951628,
+                "99.9" : 16.105385210951628,
+                "99.99" : 16.105385210951628,
+                "99.999" : 16.105385210951628,
+                "99.9999" : 16.105385210951628,
+                "100.0" : 16.105385210951628
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.434701506651685,
+                    15.378711927506044,
+                    15.418635023688973
+                ],
+                [
+                    15.998158465801016,
+                    16.105385210951628,
+                    16.011024682425074
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2634.642613407419,
+            "scoreError" : 77.58739669651024,
+            "scoreConfidence" : [
+                2557.055216710909,
+                2712.230010103929
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2605.8490197490232,
+                "50.0" : 2626.3545433661184,
+                "90.0" : 2678.9396182556566,
+                "95.0" : 2678.9396182556566,
+                "99.0" : 2678.9396182556566,
+                "99.9" : 2678.9396182556566,
+                "99.99" : 2678.9396182556566,
+                "99.999" : 2678.9396182556566,
+                "99.9999" : 2678.9396182556566,
+                "100.0" : 2678.9396182556566
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2605.8490197490232,
+                    2655.9507509719765,
+                    2678.9396182556566
+                ],
+                [
+                    2614.407204735623,
+                    2622.140457841477,
+                    2630.568628890759
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 72652.26934273423,
+            "scoreError" : 2215.068544872067,
+            "scoreConfidence" : [
+                70437.20079786217,
+                74867.33788760629
+            ],
+            "scorePercentiles" : {
+                "0.0" : 71734.24958103654,
+                "50.0" : 72695.9687644142,
+                "90.0" : 73513.00927480665,
+                "95.0" : 73513.00927480665,
+                "99.0" : 73513.00927480665,
+                "99.9" : 73513.00927480665,
+                "99.99" : 73513.00927480665,
+                "99.999" : 73513.00927480665,
+                "99.9999" : 73513.00927480665,
+                "100.0" : 73513.00927480665
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72150.06194096968,
+                    71734.24958103654,
+                    71953.14407993566
+                ],
+                [
+                    73241.87558785871,
+                    73513.00927480665,
+                    73321.27559179807
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 338.2369067295518,
+            "scoreError" : 9.047445008616359,
+            "scoreConfidence" : [
+                329.1894617209354,
+                347.28435173816814
+            ],
+            "scorePercentiles" : {
+                "0.0" : 334.13185253897365,
+                "50.0" : 338.56651843870884,
+                "90.0" : 342.36328756300276,
+                "95.0" : 342.36328756300276,
+                "99.0" : 342.36328756300276,
+                "99.9" : 342.36328756300276,
+                "99.99" : 342.36328756300276,
+                "99.999" : 342.36328756300276,
+                "99.9999" : 342.36328756300276,
+                "100.0" : 342.36328756300276
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    340.86053162269917,
+                    338.84194871635685,
+                    342.36328756300276
+                ],
+                [
+                    338.2910881610608,
+                    334.9327317752175,
+                    334.13185253897365
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 125.07133543976953,
+            "scoreError" : 3.078566459761309,
+            "scoreConfidence" : [
+                121.99276898000822,
+                128.14990189953085
+            ],
+            "scorePercentiles" : {
+                "0.0" : 123.02662936647576,
+                "50.0" : 125.49560767626896,
+                "90.0" : 125.89425140410296,
+                "95.0" : 125.89425140410296,
+                "99.0" : 125.89425140410296,
+                "99.9" : 125.89425140410296,
+                "99.99" : 125.89425140410296,
+                "99.999" : 125.89425140410296,
+                "99.9999" : 125.89425140410296,
+                "100.0" : 125.89425140410296
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    125.89425140410296,
+                    125.80726699800888,
+                    125.2356361466875
+                ],
+                [
+                    123.02662936647576,
+                    125.75557920585042,
+                    124.70864951749157
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06273138164222312,
+            "scoreError" : 0.0012911880651086897,
+            "scoreConfidence" : [
+                0.06144019357711444,
+                0.06402256970733182
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06223374602799231,
+                "50.0" : 0.06261155939881335,
+                "90.0" : 0.06335769360602143,
+                "95.0" : 0.06335769360602143,
+                "99.0" : 0.06335769360602143,
+                "99.9" : 0.06335769360602143,
+                "99.99" : 0.06335769360602143,
+                "99.999" : 0.06335769360602143,
+                "99.9999" : 0.06335769360602143,
+                "100.0" : 0.06335769360602143
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06242890678278241,
+                    0.06335769360602143,
+                    0.06279421201484431
+                ],
+                [
+                    0.06223374602799231,
+                    0.06318596967112122,
+                    0.06238776175057708
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.889645214549988E-4,
+            "scoreError" : 2.7543029848246928E-5,
+            "scoreConfidence" : [
+                3.614214916067519E-4,
+                4.165075513032457E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.757393035097671E-4,
+                "50.0" : 3.888141158466729E-4,
+                "90.0" : 4.0151869601348444E-4,
+                "95.0" : 4.0151869601348444E-4,
+                "99.0" : 4.0151869601348444E-4,
+                "99.9" : 4.0151869601348444E-4,
+                "99.99" : 4.0151869601348444E-4,
+                "99.999" : 4.0151869601348444E-4,
+                "99.9999" : 4.0151869601348444E-4,
+                "100.0" : 4.0151869601348444E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.9621251177280275E-4,
+                    3.9419403341608647E-4,
+                    4.0151869601348444E-4
+                ],
+                [
+                    3.834341982772593E-4,
+                    3.8268838574059247E-4,
+                    3.757393035097671E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2599582074401665,
+            "scoreError" : 0.05968090652216845,
+            "scoreConfidence" : [
+                2.200277300917998,
+                2.319639113962335
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.190092604116488,
+                "50.0" : 2.2473072672474865,
+                "90.0" : 2.31551318746675,
+                "95.0" : 2.316583796849664,
+                "99.0" : 2.316583796849664,
+                "99.9" : 2.316583796849664,
+                "99.99" : 2.316583796849664,
+                "99.999" : 2.316583796849664,
+                "99.9999" : 2.316583796849664,
+                "100.0" : 2.316583796849664
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.305877703020521,
+                    2.2484502212230217,
+                    2.2461643132719513,
+                    2.230798565023422,
+                    2.190092604116488
+                ],
+                [
+                    2.316583796849664,
+                    2.302773594059406,
+                    2.274070894952251,
+                    2.2440348920798745,
+                    2.240735489805064
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013698457438429124,
+            "scoreError" : 5.180377937134048E-4,
+            "scoreConfidence" : [
+                0.013180419644715719,
+                0.014216495232142528
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013522811645961263,
+                "50.0" : 0.013676907651138132,
+                "90.0" : 0.013921641031637974,
+                "95.0" : 0.013921641031637974,
+                "99.0" : 0.013921641031637974,
+                "99.9" : 0.013921641031637974,
+                "99.99" : 0.013921641031637974,
+                "99.999" : 0.013921641031637974,
+                "99.9999" : 0.013921641031637974,
+                "100.0" : 0.013921641031637974
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013861960441357896,
+                    0.013807503696912544,
+                    0.013921641031637974
+                ],
+                [
+                    0.013522811645961263,
+                    0.013530516209341344,
+                    0.01354631160536372
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0580923441822343,
+            "scoreError" : 0.03748827495043085,
+            "scoreConfidence" : [
+                1.0206040692318035,
+                1.0955806191326651
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0433626304642671,
+                "50.0" : 1.0590172320795785,
+                "90.0" : 1.072133893331904,
+                "95.0" : 1.072133893331904,
+                "99.0" : 1.072133893331904,
+                "99.9" : 1.072133893331904,
+                "99.99" : 1.072133893331904,
+                "99.999" : 1.072133893331904,
+                "99.9999" : 1.072133893331904,
+                "100.0" : 1.072133893331904
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0706562028690718,
+                    1.0671267495731969,
+                    1.072133893331904
+                ],
+                [
+                    1.0443668742690058,
+                    1.0433626304642671,
+                    1.0509077145859604
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010940847337362045,
+            "scoreError" : 3.229013140924922E-4,
+            "scoreConfidence" : [
+                0.010617946023269553,
+                0.011263748651454537
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010779003817838858,
+                "50.0" : 0.01096620972430994,
+                "90.0" : 0.01105351671692207,
+                "95.0" : 0.01105351671692207,
+                "99.0" : 0.01105351671692207,
+                "99.9" : 0.01105351671692207,
+                "99.99" : 0.01105351671692207,
+                "99.999" : 0.01105351671692207,
+                "99.9999" : 0.01105351671692207,
+                "100.0" : 0.01105351671692207
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010918801564840656,
+                    0.010836084510460867,
+                    0.010779003817838858
+                ],
+                [
+                    0.011013617883779223,
+                    0.01105351671692207,
+                    0.011044059530330606
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0556709669331217,
+            "scoreError" : 0.091374655334099,
+            "scoreConfidence" : [
+                2.9642963115990226,
+                3.1470456222672207
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0173946139927623,
+                "50.0" : 3.055440005252723,
+                "90.0" : 3.1057461130434785,
+                "95.0" : 3.1057461130434785,
+                "99.0" : 3.1057461130434785,
+                "99.9" : 3.1057461130434785,
+                "99.99" : 3.1057461130434785,
+                "99.999" : 3.1057461130434785,
+                "99.9999" : 3.1057461130434785,
+                "100.0" : 3.1057461130434785
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.073991803318992,
+                    3.0476618555758686,
+                    3.026013260738052
+                ],
+                [
+                    3.1057461130434785,
+                    3.0632181549295776,
+                    3.0173946139927623
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8945607086777234,
+            "scoreError" : 0.22196774129810593,
+            "scoreConfidence" : [
+                2.6725929673796176,
+                3.1165284499758292
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.809537713764045,
+                "50.0" : 2.889974460383474,
+                "90.0" : 3.023983813426066,
+                "95.0" : 3.023983813426066,
+                "99.0" : 3.023983813426066,
+                "99.9" : 3.023983813426066,
+                "99.99" : 3.023983813426066,
+                "99.999" : 3.023983813426066,
+                "99.9999" : 3.023983813426066,
+                "100.0" : 3.023983813426066
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.023983813426066,
+                    2.9242667263157895,
+                    2.923201632563578
+                ],
+                [
+                    2.809537713764045,
+                    2.8296270777934938,
+                    2.8567472882033704
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.38525928157383355,
+            "scoreError" : 0.014510468420308325,
+            "scoreConfidence" : [
+                0.3707488131535252,
+                0.3997697499941419
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3802369296958175,
+                "50.0" : 0.38446433470537467,
+                "90.0" : 0.39274994607650615,
+                "95.0" : 0.39274994607650615,
+                "99.0" : 0.39274994607650615,
+                "99.9" : 0.39274994607650615,
+                "99.99" : 0.39274994607650615,
+                "99.999" : 0.39274994607650615,
+                "99.9999" : 0.39274994607650615,
+                "100.0" : 0.39274994607650615
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.39274994607650615,
+                    0.387632620644211,
+                    0.38874570480077747
+                ],
+                [
+                    0.3812960487665383,
+                    0.38089443945915064,
+                    0.3802369296958175
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1598096007698745,
+            "scoreError" : 0.003211925374181506,
+            "scoreConfidence" : [
+                0.156597675395693,
+                0.163021526144056
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15799424420570346,
+                "50.0" : 0.16009250112284773,
+                "90.0" : 0.16114386667311226,
+                "95.0" : 0.16114386667311226,
+                "99.0" : 0.16114386667311226,
+                "99.9" : 0.16114386667311226,
+                "99.99" : 0.16114386667311226,
+                "99.999" : 0.16114386667311226,
+                "99.9999" : 0.16114386667311226,
+                "100.0" : 0.16114386667311226
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1600716906232993,
+                    0.15895501363809766,
+                    0.15799424420570346
+                ],
+                [
+                    0.16114386667311226,
+                    0.1605794778566382,
+                    0.1601133116223962
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.406470906812551,
+            "scoreError" : 0.027722364335690905,
+            "scoreConfidence" : [
+                0.3787485424768601,
+                0.4341932711482419
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39581712550959824,
+                "50.0" : 0.40641927873234907,
+                "90.0" : 0.41990254488579104,
+                "95.0" : 0.41990254488579104,
+                "99.0" : 0.41990254488579104,
+                "99.9" : 0.41990254488579104,
+                "99.99" : 0.41990254488579104,
+                "99.999" : 0.41990254488579104,
+                "99.9999" : 0.41990254488579104,
+                "100.0" : 0.41990254488579104
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41990254488579104,
+                    0.41256245523927393,
+                    0.412739520615791
+                ],
+                [
+                    0.40027610222542426,
+                    0.3975276923994276,
+                    0.39581712550959824
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1464533659185502,
+            "scoreError" : 0.005512989426021651,
+            "scoreConfidence" : [
+                0.14094037649252855,
+                0.15196635534457187
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14422958005336411,
+                "50.0" : 0.14671749654411698,
+                "90.0" : 0.14876042786802332,
+                "95.0" : 0.14876042786802332,
+                "99.0" : 0.14876042786802332,
+                "99.9" : 0.14876042786802332,
+                "99.99" : 0.14876042786802332,
+                "99.999" : 0.14876042786802332,
+                "99.9999" : 0.14876042786802332,
+                "100.0" : 0.14876042786802332
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14876042786802332,
+                    0.14793159863905325,
+                    0.14780512895740341
+                ],
+                [
+                    0.1456298641308305,
+                    0.14422958005336411,
+                    0.1443635958626265
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04360998571457054,
+            "scoreError" : 0.0012341441405407053,
+            "scoreConfidence" : [
+                0.042375841574029835,
+                0.04484412985511124
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04317201651311984,
+                "50.0" : 0.04359909842057389,
+                "90.0" : 0.04431270882519763,
+                "95.0" : 0.04431270882519763,
+                "99.0" : 0.04431270882519763,
+                "99.9" : 0.04431270882519763,
+                "99.99" : 0.04431270882519763,
+                "99.999" : 0.04431270882519763,
+                "99.9999" : 0.04431270882519763,
+                "100.0" : 0.04431270882519763
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04380003221002654,
+                    0.04317201651311984,
+                    0.043176959897931425
+                ],
+                [
+                    0.04431270882519763,
+                    0.0437708118502891,
+                    0.04342738499085868
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7974885.294398616,
+            "scoreError" : 205407.60323440738,
+            "scoreConfidence" : [
+                7769477.691164209,
+                8180292.897633024
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7882666.90070922,
+                "50.0" : 7979341.820347883,
+                "90.0" : 8059264.153102336,
+                "95.0" : 8059264.153102336,
+                "99.0" : 8059264.153102336,
+                "99.9" : 8059264.153102336,
+                "99.99" : 8059264.153102336,
+                "99.999" : 8059264.153102336,
+                "99.9999" : 8059264.153102336,
+                "100.0" : 8059264.153102336
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8059264.153102336,
+                    8021095.559743384,
+                    8036304.097991968
+                ],
+                [
+                    7937588.080952381,
+                    7882666.90070922,
+                    7912392.973892405
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-19T23-29-58Z-9ae83abdaaedce0371838b2651d7c69c3253a9a2-jdk17.json
+++ b/performance-results/2026-02-19T23-29-58Z-9ae83abdaaedce0371838b2651d7c69c3253a9a2-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.377265190383788,
+            "scoreError" : 0.01886535498171371,
+            "scoreConfidence" : [
+                3.358399835402074,
+                3.3961305453655015
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3748032689328715,
+                "50.0" : 3.3764890801683034,
+                "90.0" : 3.3812793322656733,
+                "95.0" : 3.3812793322656733,
+                "99.0" : 3.3812793322656733,
+                "99.9" : 3.3812793322656733,
+                "99.99" : 3.3812793322656733,
+                "99.999" : 3.3812793322656733,
+                "99.9999" : 3.3812793322656733,
+                "100.0" : 3.3812793322656733
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.377535552371847,
+                    3.3812793322656733
+                ],
+                [
+                    3.3748032689328715,
+                    3.3754426079647595
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7051942254609906,
+            "scoreError" : 0.019942097851265737,
+            "scoreConfidence" : [
+                1.685252127609725,
+                1.7251363233122563
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.7007069239089014,
+                "50.0" : 1.7061822230804111,
+                "90.0" : 1.7077055317742387,
+                "95.0" : 1.7077055317742387,
+                "99.0" : 1.7077055317742387,
+                "99.9" : 1.7077055317742387,
+                "99.99" : 1.7077055317742387,
+                "99.999" : 1.7077055317742387,
+                "99.9999" : 1.7077055317742387,
+                "100.0" : 1.7077055317742387
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.706479306868113,
+                    1.7058851392927095
+                ],
+                [
+                    1.7007069239089014,
+                    1.7077055317742387
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8544139077484453,
+            "scoreError" : 0.039096296502988924,
+            "scoreConfidence" : [
+                0.8153176112454563,
+                0.8935102042514342
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8485361844440272,
+                "50.0" : 0.8531382327937986,
+                "90.0" : 0.8628429809621562,
+                "95.0" : 0.8628429809621562,
+                "99.0" : 0.8628429809621562,
+                "99.9" : 0.8628429809621562,
+                "99.99" : 0.8628429809621562,
+                "99.999" : 0.8628429809621562,
+                "99.9999" : 0.8628429809621562,
+                "100.0" : 0.8628429809621562
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8538321293228435,
+                    0.8628429809621562
+                ],
+                [
+                    0.8524443362647539,
+                    0.8485361844440272
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.42365944152893,
+            "scoreError" : 0.08197762316092953,
+            "scoreConfidence" : [
+                16.341681818368,
+                16.50563706468986
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.376897747572393,
+                "50.0" : 16.426184578735814,
+                "90.0" : 16.46861633540318,
+                "95.0" : 16.46861633540318,
+                "99.0" : 16.46861633540318,
+                "99.9" : 16.46861633540318,
+                "99.99" : 16.46861633540318,
+                "99.999" : 16.46861633540318,
+                "99.9999" : 16.46861633540318,
+                "100.0" : 16.46861633540318
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.42690166323201,
+                    16.426226838418167,
+                    16.417171745494354
+                ],
+                [
+                    16.42614231905346,
+                    16.376897747572393,
+                    16.46861633540318
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2735.056240100748,
+            "scoreError" : 167.6793225207804,
+            "scoreConfidence" : [
+                2567.3769175799675,
+                2902.735562621528
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2679.478720523268,
+                "50.0" : 2732.560648317509,
+                "90.0" : 2798.800427920552,
+                "95.0" : 2798.800427920552,
+                "99.0" : 2798.800427920552,
+                "99.9" : 2798.800427920552,
+                "99.99" : 2798.800427920552,
+                "99.999" : 2798.800427920552,
+                "99.9999" : 2798.800427920552,
+                "100.0" : 2798.800427920552
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2679.478720523268,
+                    2680.6173706280265,
+                    2681.9558969985123
+                ],
+                [
+                    2798.800427920552,
+                    2786.3196248976215,
+                    2783.1653996365058
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73375.98272612081,
+            "scoreError" : 1089.65264787672,
+            "scoreConfidence" : [
+                72286.3300782441,
+                74465.63537399753
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73017.9558340203,
+                "50.0" : 73335.53068850501,
+                "90.0" : 73825.7157703225,
+                "95.0" : 73825.7157703225,
+                "99.0" : 73825.7157703225,
+                "99.9" : 73825.7157703225,
+                "99.99" : 73825.7157703225,
+                "99.999" : 73825.7157703225,
+                "99.9999" : 73825.7157703225,
+                "100.0" : 73825.7157703225
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73037.06836837072,
+                    73021.98386997404,
+                    73017.9558340203
+                ],
+                [
+                    73633.9930086393,
+                    73719.1795053981,
+                    73825.7157703225
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 363.15699127028296,
+            "scoreError" : 2.1500695865518016,
+            "scoreConfidence" : [
+                361.00692168373115,
+                365.30706085683477
+            ],
+            "scorePercentiles" : {
+                "0.0" : 362.4015864426266,
+                "50.0" : 363.02465025361425,
+                "90.0" : 364.46032663469816,
+                "95.0" : 364.46032663469816,
+                "99.0" : 364.46032663469816,
+                "99.9" : 364.46032663469816,
+                "99.99" : 364.46032663469816,
+                "99.999" : 364.46032663469816,
+                "99.9999" : 364.46032663469816,
+                "100.0" : 364.46032663469816
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    363.22977064985713,
+                    363.5207408458319,
+                    364.46032663469816
+                ],
+                [
+                    362.5099931913125,
+                    362.81952985737144,
+                    362.4015864426266
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 127.6072346741712,
+            "scoreError" : 2.7315334567206833,
+            "scoreConfidence" : [
+                124.87570121745051,
+                130.33876813089188
+            ],
+            "scorePercentiles" : {
+                "0.0" : 126.48988236523634,
+                "50.0" : 127.62518701356342,
+                "90.0" : 129.01000148767417,
+                "95.0" : 129.01000148767417,
+                "99.0" : 129.01000148767417,
+                "99.9" : 129.01000148767417,
+                "99.99" : 129.01000148767417,
+                "99.999" : 129.01000148767417,
+                "99.9999" : 129.01000148767417,
+                "100.0" : 129.01000148767417
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    129.01000148767417,
+                    128.13569216857786,
+                    128.13742175798342
+                ],
+                [
+                    126.75572840700647,
+                    127.11468185854896,
+                    126.48988236523634
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.0608830558855736,
+            "scoreError" : 0.002020307831114334,
+            "scoreConfidence" : [
+                0.05886274805445926,
+                0.06290336371668794
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06012948695809031,
+                "50.0" : 0.06091869490559407,
+                "90.0" : 0.06155671821561796,
+                "95.0" : 0.06155671821561796,
+                "99.0" : 0.06155671821561796,
+                "99.9" : 0.06155671821561796,
+                "99.99" : 0.06155671821561796,
+                "99.999" : 0.06155671821561796,
+                "99.9999" : 0.06155671821561796,
+                "100.0" : 0.06155671821561796
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06155671821561796,
+                    0.06153253858034187,
+                    0.06152638430491894
+                ],
+                [
+                    0.06031100550626919,
+                    0.0602422017482033,
+                    0.06012948695809031
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.600870827163159E-4,
+            "scoreError" : 9.81640059591573E-6,
+            "scoreConfidence" : [
+                3.5027068212040017E-4,
+                3.699034833122316E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5684922029675676E-4,
+                "50.0" : 3.599178297251165E-4,
+                "90.0" : 3.637862554981849E-4,
+                "95.0" : 3.637862554981849E-4,
+                "99.0" : 3.637862554981849E-4,
+                "99.9" : 3.637862554981849E-4,
+                "99.99" : 3.637862554981849E-4,
+                "99.999" : 3.637862554981849E-4,
+                "99.9999" : 3.637862554981849E-4,
+                "100.0" : 3.637862554981849E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.6284410444618296E-4,
+                    3.637862554981849E-4,
+                    3.631810865259105E-4
+                ],
+                [
+                    3.5684922029675676E-4,
+                    3.5699155500405E-4,
+                    3.568702745268103E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.126580812163348,
+            "scoreError" : 0.053852642200734574,
+            "scoreConfidence" : [
+                2.0727281699626134,
+                2.180433454364082
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.0956242114417436,
+                "50.0" : 2.1074695209460144,
+                "90.0" : 2.186228356457833,
+                "95.0" : 2.18691333544719,
+                "99.0" : 2.18691333544719,
+                "99.9" : 2.18691333544719,
+                "99.99" : 2.18691333544719,
+                "99.999" : 2.18691333544719,
+                "99.9999" : 2.18691333544719,
+                "100.0" : 2.18691333544719
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.180063545553618,
+                    2.1359549918838105,
+                    2.095681221081308,
+                    2.0956242114417436,
+                    2.0972648347661984
+                ],
+                [
+                    2.18691333544719,
+                    2.155190176470588,
+                    2.109399109681502,
+                    2.104176763096991,
+                    2.1055399322105264
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013276602387072692,
+            "scoreError" : 2.160023337309603E-5,
+            "scoreConfidence" : [
+                0.013255002153699597,
+                0.013298202620445787
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0132627136690075,
+                "50.0" : 0.01327719043334864,
+                "90.0" : 0.013284668198369461,
+                "95.0" : 0.013284668198369461,
+                "99.0" : 0.013284668198369461,
+                "99.9" : 0.013284668198369461,
+                "99.99" : 0.013284668198369461,
+                "99.999" : 0.013284668198369461,
+                "99.9999" : 0.013284668198369461,
+                "100.0" : 0.013284668198369461
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013276420449189683,
+                    0.013277960417507595,
+                    0.013275317331906697
+                ],
+                [
+                    0.013282534256455212,
+                    0.013284668198369461,
+                    0.0132627136690075
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0249114845395122,
+            "scoreError" : 0.03600729664496091,
+            "scoreConfidence" : [
+                0.9889041878945513,
+                1.0609187811844731
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0125838514580803,
+                "50.0" : 1.0248407134223547,
+                "90.0" : 1.0371865172163452,
+                "95.0" : 1.0371865172163452,
+                "99.0" : 1.0371865172163452,
+                "99.9" : 1.0371865172163452,
+                "99.99" : 1.0371865172163452,
+                "99.999" : 1.0371865172163452,
+                "99.9999" : 1.0371865172163452,
+                "100.0" : 1.0371865172163452
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0371865172163452,
+                    1.0361713240779113,
+                    1.0365184900497513
+                ],
+                [
+                    1.0135101027667983,
+                    1.0125838514580803,
+                    1.013498621668187
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010355786559804061,
+            "scoreError" : 8.499290499928437E-4,
+            "scoreConfidence" : [
+                0.009505857509811217,
+                0.011205715609796905
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010073115146509262,
+                "50.0" : 0.010357146107699673,
+                "90.0" : 0.01063571819682383,
+                "95.0" : 0.01063571819682383,
+                "99.0" : 0.01063571819682383,
+                "99.9" : 0.01063571819682383,
+                "99.99" : 0.01063571819682383,
+                "99.999" : 0.01063571819682383,
+                "99.9999" : 0.01063571819682383,
+                "100.0" : 0.01063571819682383
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010073115146509262,
+                    0.010086641846203502,
+                    0.01007766668547784
+                ],
+                [
+                    0.01063571819682383,
+                    0.010627650369195846,
+                    0.010633927114614082
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0762214830409467,
+            "scoreError" : 0.40706814132763525,
+            "scoreConfidence" : [
+                2.6691533417133115,
+                3.483289624368582
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9418293229411763,
+                "50.0" : 3.074867385779253,
+                "90.0" : 3.21182251701991,
+                "95.0" : 3.21182251701991,
+                "99.0" : 3.21182251701991,
+                "99.9" : 3.21182251701991,
+                "99.99" : 3.21182251701991,
+                "99.999" : 3.21182251701991,
+                "99.9999" : 3.21182251701991,
+                "100.0" : 3.21182251701991
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9449147561837457,
+                    2.9444296615656267,
+                    2.9418293229411763
+                ],
+                [
+                    3.209512625160462,
+                    3.20482001537476,
+                    3.21182251701991
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.6737095662978327,
+            "scoreError" : 0.218434924964034,
+            "scoreConfidence" : [
+                2.4552746413337987,
+                2.892144491261867
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.5987136232787735,
+                "50.0" : 2.673808418919359,
+                "90.0" : 2.746328756727073,
+                "95.0" : 2.746328756727073,
+                "99.0" : 2.746328756727073,
+                "99.9" : 2.746328756727073,
+                "99.99" : 2.746328756727073,
+                "99.999" : 2.746328756727073,
+                "99.9999" : 2.746328756727073,
+                "100.0" : 2.746328756727073
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.6058117292860863,
+                    2.5987136232787735,
+                    2.6034145632483083
+                ],
+                [
+                    2.746328756727073,
+                    2.746183616694124,
+                    2.7418051085526316
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3804502847915197,
+            "scoreError" : 0.008055052910257827,
+            "scoreConfidence" : [
+                0.3723952318812619,
+                0.38850533770177753
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.37751487010192525,
+                "50.0" : 0.38050821919346245,
+                "90.0" : 0.38319903413923906,
+                "95.0" : 0.38319903413923906,
+                "99.0" : 0.38319903413923906,
+                "99.9" : 0.38319903413923906,
+                "99.99" : 0.38319903413923906,
+                "99.999" : 0.38319903413923906,
+                "99.9999" : 0.38319903413923906,
+                "100.0" : 0.38319903413923906
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.37751487010192525,
+                    0.37784202331204897,
+                    0.37815267487237664
+                ],
+                [
+                    0.38319903413923906,
+                    0.38286376351454826,
+                    0.38312934280898014
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15468713415444238,
+            "scoreError" : 0.003257250674658155,
+            "scoreConfidence" : [
+                0.15142988347978423,
+                0.15794438482910053
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15357776563003916,
+                "50.0" : 0.1545467408712981,
+                "90.0" : 0.1560239483571005,
+                "95.0" : 0.1560239483571005,
+                "99.0" : 0.1560239483571005,
+                "99.9" : 0.1560239483571005,
+                "99.99" : 0.1560239483571005,
+                "99.999" : 0.1560239483571005,
+                "99.9999" : 0.1560239483571005,
+                "100.0" : 0.1560239483571005
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15362626412166833,
+                    0.15357776563003916,
+                    0.1537336951716293
+                ],
+                [
+                    0.15580134507525006,
+                    0.1560239483571005,
+                    0.15535978657096694
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40707533728281886,
+            "scoreError" : 0.002085385127215878,
+            "scoreConfidence" : [
+                0.40498995215560296,
+                0.40916072241003476
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40560224537637896,
+                "50.0" : 0.40726087102638553,
+                "90.0" : 0.40769494850992705,
+                "95.0" : 0.40769494850992705,
+                "99.0" : 0.40769494850992705,
+                "99.9" : 0.40769494850992705,
+                "99.99" : 0.40769494850992705,
+                "99.999" : 0.40769494850992705,
+                "99.9999" : 0.40769494850992705,
+                "100.0" : 0.40769494850992705
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40769494850992705,
+                    0.40728242392278247,
+                    0.40720438337812526
+                ],
+                [
+                    0.4072393181299886,
+                    0.40560224537637896,
+                    0.40742870437971074
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14824805101601213,
+            "scoreError" : 0.00437338182501179,
+            "scoreConfidence" : [
+                0.14387466919100034,
+                0.15262143284102392
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14670650388029047,
+                "50.0" : 0.14830771083933025,
+                "90.0" : 0.14979891392662942,
+                "95.0" : 0.14979891392662942,
+                "99.0" : 0.14979891392662942,
+                "99.9" : 0.14979891392662942,
+                "99.99" : 0.14979891392662942,
+                "99.999" : 0.14979891392662942,
+                "99.9999" : 0.14979891392662942,
+                "100.0" : 0.14979891392662942
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14703711943656173,
+                    0.14670650388029047,
+                    0.1467457024080297
+                ],
+                [
+                    0.14979891392662942,
+                    0.1495783022420988,
+                    0.1496217642024627
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.043674366878643574,
+            "scoreError" : 0.0028695264961058832,
+            "scoreConfidence" : [
+                0.04080484038253769,
+                0.04654389337474946
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.042609024141560044,
+                "50.0" : 0.043766539234639384,
+                "90.0" : 0.04470447356656861,
+                "95.0" : 0.04470447356656861,
+                "99.0" : 0.04470447356656861,
+                "99.9" : 0.04470447356656861,
+                "99.99" : 0.04470447356656861,
+                "99.999" : 0.04470447356656861,
+                "99.9999" : 0.04470447356656861,
+                "100.0" : 0.04470447356656861
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04300512978261337,
+                    0.042637510433277334,
+                    0.042609024141560044
+                ],
+                [
+                    0.04470447356656861,
+                    0.04456211466117669,
+                    0.04452794868666539
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7784353.299395355,
+            "scoreError" : 295528.1845082568,
+            "scoreConfidence" : [
+                7488825.114887099,
+                8079881.483903612
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7673037.493098159,
+                "50.0" : 7790008.744738622,
+                "90.0" : 7890073.550473186,
+                "95.0" : 7890073.550473186,
+                "99.0" : 7890073.550473186,
+                "99.9" : 7890073.550473186,
+                "99.99" : 7890073.550473186,
+                "99.999" : 7890073.550473186,
+                "99.9999" : 7890073.550473186,
+                "100.0" : 7890073.550473186
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7673037.493098159,
+                    7686168.1743471585,
+                    7707212.513867488
+                ],
+                [
+                    7890073.550473186,
+                    7876823.088976378,
+                    7872804.975609756
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-21T06-47-31Z-50c22c1e9465736e56729bb89a5cbe9b12794575-jdk17.json
+++ b/performance-results/2026-02-21T06-47-31Z-50c22c1e9465736e56729bb89a5cbe9b12794575-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3373013685661994,
+            "scoreError" : 0.06653578940298976,
+            "scoreConfidence" : [
+                3.2707655791632098,
+                3.403837157969189
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3265319654325762,
+                "50.0" : 3.3358508392726995,
+                "90.0" : 3.3509718302868214,
+                "95.0" : 3.3509718302868214,
+                "99.0" : 3.3509718302868214,
+                "99.9" : 3.3509718302868214,
+                "99.99" : 3.3509718302868214,
+                "99.999" : 3.3509718302868214,
+                "99.9999" : 3.3509718302868214,
+                "100.0" : 3.3509718302868214
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3265319654325762,
+                    3.3335074123585513
+                ],
+                [
+                    3.338194266186848,
+                    3.3509718302868214
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6786879990778378,
+            "scoreError" : 0.03696830586605793,
+            "scoreConfidence" : [
+                1.64171969321178,
+                1.7156563049438958
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6724673512598984,
+                "50.0" : 1.6793271889572372,
+                "90.0" : 1.6836302671369785,
+                "95.0" : 1.6836302671369785,
+                "99.0" : 1.6836302671369785,
+                "99.9" : 1.6836302671369785,
+                "99.99" : 1.6836302671369785,
+                "99.999" : 1.6836302671369785,
+                "99.9999" : 1.6836302671369785,
+                "100.0" : 1.6836302671369785
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6724673512598984,
+                    1.6751891931650018
+                ],
+                [
+                    1.6834651847494724,
+                    1.6836302671369785
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8417858135165552,
+            "scoreError" : 0.007718442925661634,
+            "scoreConfidence" : [
+                0.8340673705908936,
+                0.8495042564422168
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8406490708191585,
+                "50.0" : 0.8415356293518277,
+                "90.0" : 0.8434229245434071,
+                "95.0" : 0.8434229245434071,
+                "99.0" : 0.8434229245434071,
+                "99.9" : 0.8434229245434071,
+                "99.99" : 0.8434229245434071,
+                "99.999" : 0.8434229245434071,
+                "99.9999" : 0.8434229245434071,
+                "100.0" : 0.8434229245434071
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8412335178347154,
+                    0.8406490708191585
+                ],
+                [
+                    0.8434229245434071,
+                    0.84183774086894
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.048118139516216,
+            "scoreError" : 0.20172850465073444,
+            "scoreConfidence" : [
+                15.846389634865481,
+                16.24984664416695
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.987585190805376,
+                "50.0" : 16.021274584151655,
+                "90.0" : 16.176110515561437,
+                "95.0" : 16.176110515561437,
+                "99.0" : 16.176110515561437,
+                "99.9" : 16.176110515561437,
+                "99.99" : 16.176110515561437,
+                "99.999" : 16.176110515561437,
+                "99.9999" : 16.176110515561437,
+                "100.0" : 16.176110515561437
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.987585190805376,
+                    16.176110515561437,
+                    16.04065335089375
+                ],
+                [
+                    16.083316803349394,
+                    15.999147159077786,
+                    16.001895817409558
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2666.0001142349906,
+            "scoreError" : 52.371744323470864,
+            "scoreConfidence" : [
+                2613.6283699115197,
+                2718.3718585584616
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2642.6489751124645,
+                "50.0" : 2671.815877784082,
+                "90.0" : 2689.222242202293,
+                "95.0" : 2689.222242202293,
+                "99.0" : 2689.222242202293,
+                "99.9" : 2689.222242202293,
+                "99.99" : 2689.222242202293,
+                "99.999" : 2689.222242202293,
+                "99.9999" : 2689.222242202293,
+                "100.0" : 2689.222242202293
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2689.222242202293,
+                    2673.692421274505,
+                    2676.3521032356334
+                ],
+                [
+                    2644.1456092913863,
+                    2669.9393342936596,
+                    2642.6489751124645
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 72530.11303745623,
+            "scoreError" : 1017.9325800195945,
+            "scoreConfidence" : [
+                71512.18045743664,
+                73548.04561747583
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72135.0978172142,
+                "50.0" : 72500.24895532992,
+                "90.0" : 73009.9619335705,
+                "95.0" : 73009.9619335705,
+                "99.0" : 73009.9619335705,
+                "99.9" : 73009.9619335705,
+                "99.99" : 73009.9619335705,
+                "99.999" : 73009.9619335705,
+                "99.9999" : 73009.9619335705,
+                "100.0" : 73009.9619335705
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72135.0978172142,
+                    72255.27531831828,
+                    72243.29166897385
+                ],
+                [
+                    73009.9619335705,
+                    72791.82889431897,
+                    72745.22259234157
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 342.30382986176045,
+            "scoreError" : 8.892639332360158,
+            "scoreConfidence" : [
+                333.4111905294003,
+                351.1964691941206
+            ],
+            "scorePercentiles" : {
+                "0.0" : 339.21591637982505,
+                "50.0" : 341.0913036289578,
+                "90.0" : 347.7341928340366,
+                "95.0" : 347.7341928340366,
+                "99.0" : 347.7341928340366,
+                "99.9" : 347.7341928340366,
+                "99.99" : 347.7341928340366,
+                "99.999" : 347.7341928340366,
+                "99.9999" : 347.7341928340366,
+                "100.0" : 347.7341928340366
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    340.4134350080821,
+                    341.7439021233274,
+                    339.21591637982505
+                ],
+                [
+                    340.43870513458825,
+                    344.27682769070327,
+                    347.7341928340366
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 119.13204221877852,
+            "scoreError" : 4.666403091297501,
+            "scoreConfidence" : [
+                114.46563912748103,
+                123.79844531007602
+            ],
+            "scorePercentiles" : {
+                "0.0" : 117.08968101521077,
+                "50.0" : 119.10381572236892,
+                "90.0" : 121.3252204724105,
+                "95.0" : 121.3252204724105,
+                "99.0" : 121.3252204724105,
+                "99.9" : 121.3252204724105,
+                "99.99" : 121.3252204724105,
+                "99.999" : 121.3252204724105,
+                "99.9999" : 121.3252204724105,
+                "100.0" : 121.3252204724105
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    121.3252204724105,
+                    119.9453965854182,
+                    120.39673863294554
+                ],
+                [
+                    117.08968101521077,
+                    117.77298174736653,
+                    118.26223485931966
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06238598351878183,
+            "scoreError" : 0.0017911425575313448,
+            "scoreConfidence" : [
+                0.060594840961250486,
+                0.06417712607631318
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06151520483624911,
+                "50.0" : 0.06225854750921515,
+                "90.0" : 0.0631290992557241,
+                "95.0" : 0.0631290992557241,
+                "99.0" : 0.0631290992557241,
+                "99.9" : 0.0631290992557241,
+                "99.99" : 0.0631290992557241,
+                "99.999" : 0.0631290992557241,
+                "99.9999" : 0.0631290992557241,
+                "100.0" : 0.0631290992557241
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06312452049312267,
+                    0.06236991378159751,
+                    0.0631290992557241
+                ],
+                [
+                    0.06202998150916478,
+                    0.062147181236832785,
+                    0.06151520483624911
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6729176597903324E-4,
+            "scoreError" : 1.6794543733621654E-5,
+            "scoreConfidence" : [
+                3.504972222454116E-4,
+                3.840863097126549E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6098391519992094E-4,
+                "50.0" : 3.665328246782461E-4,
+                "90.0" : 3.751053666085799E-4,
+                "95.0" : 3.751053666085799E-4,
+                "99.0" : 3.751053666085799E-4,
+                "99.9" : 3.751053666085799E-4,
+                "99.99" : 3.751053666085799E-4,
+                "99.999" : 3.751053666085799E-4,
+                "99.9999" : 3.751053666085799E-4,
+                "100.0" : 3.751053666085799E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.6231634667923356E-4,
+                    3.6098391519992094E-4,
+                    3.6280975024416314E-4
+                ],
+                [
+                    3.70255899112329E-4,
+                    3.7227931802997274E-4,
+                    3.751053666085799E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.2006263607617558,
+            "scoreError" : 0.08249401386368123,
+            "scoreConfidence" : [
+                2.1181323468980744,
+                2.283120374625437
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.124500559898046,
+                "50.0" : 2.184024186618422,
+                "90.0" : 2.2915381442921787,
+                "95.0" : 2.2937630676605503,
+                "99.0" : 2.2937630676605503,
+                "99.9" : 2.2937630676605503,
+                "99.99" : 2.2937630676605503,
+                "99.999" : 2.2937630676605503,
+                "99.9999" : 2.2937630676605503,
+                "100.0" : 2.2937630676605503
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.271513833976834,
+                    2.224383384564057,
+                    2.124500559898046,
+                    2.152629712656048,
+                    2.1619047349762215
+                ],
+                [
+                    2.2937630676605503,
+                    2.2388293254980973,
+                    2.1706906151508574,
+                    2.180363237410072,
+                    2.1876851358267717
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013647046945413221,
+            "scoreError" : 7.304297432208339E-5,
+            "scoreConfidence" : [
+                0.013574003971091137,
+                0.013720089919735305
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01360223532100171,
+                "50.0" : 0.01365169281190138,
+                "90.0" : 0.013674801281858434,
+                "95.0" : 0.013674801281858434,
+                "99.0" : 0.013674801281858434,
+                "99.9" : 0.013674801281858434,
+                "99.99" : 0.013674801281858434,
+                "99.999" : 0.013674801281858434,
+                "99.9999" : 0.013674801281858434,
+                "100.0" : 0.013674801281858434
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013664832071197057,
+                    0.013660473223786933,
+                    0.01360223532100171
+                ],
+                [
+                    0.013637027374619361,
+                    0.013642912400015826,
+                    0.013674801281858434
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0190576706068748,
+            "scoreError" : 0.08641901250083196,
+            "scoreConfidence" : [
+                0.9326386581060429,
+                1.1054766831077067
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9878143834452785,
+                "50.0" : 1.0195021993471856,
+                "90.0" : 1.0494409759706191,
+                "95.0" : 1.0494409759706191,
+                "99.0" : 1.0494409759706191,
+                "99.9" : 1.0494409759706191,
+                "99.99" : 1.0494409759706191,
+                "99.999" : 1.0494409759706191,
+                "99.9999" : 1.0494409759706191,
+                "100.0" : 1.0494409759706191
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.9878143834452785,
+                    0.9914063418261129,
+                    0.9937978046308258
+                ],
+                [
+                    1.0494409759706191,
+                    1.0466799237048665,
+                    1.045206594063545
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010560912869980581,
+            "scoreError" : 8.450987929350199E-4,
+            "scoreConfidence" : [
+                0.00971581407704556,
+                0.011406011662915602
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010271364538162098,
+                "50.0" : 0.01054027626495649,
+                "90.0" : 0.010868142115650457,
+                "95.0" : 0.010868142115650457,
+                "99.0" : 0.010868142115650457,
+                "99.9" : 0.010868142115650457,
+                "99.99" : 0.010868142115650457,
+                "99.999" : 0.010868142115650457,
+                "99.9999" : 0.010868142115650457,
+                "100.0" : 0.010868142115650457
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010271364538162098,
+                    0.010296970088180661,
+                    0.010293096226290805
+                ],
+                [
+                    0.010852321809867149,
+                    0.010868142115650457,
+                    0.010783582441732319
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1975890469448625,
+            "scoreError" : 0.08409951572399091,
+            "scoreConfidence" : [
+                3.1134895312208717,
+                3.2816885626688532
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.159318375236892,
+                "50.0" : 3.1932104777371624,
+                "90.0" : 3.234413015523933,
+                "95.0" : 3.234413015523933,
+                "99.0" : 3.234413015523933,
+                "99.9" : 3.234413015523933,
+                "99.99" : 3.234413015523933,
+                "99.999" : 3.234413015523933,
+                "99.9999" : 3.234413015523933,
+                "100.0" : 3.234413015523933
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.229825319561007,
+                    3.234413015523933,
+                    3.2007474420985287
+                ],
+                [
+                    3.185673513375796,
+                    3.175556615873016,
+                    3.159318375236892
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.9255795570190983,
+            "scoreError" : 0.15708788130645956,
+            "scoreConfidence" : [
+                2.7684916757126388,
+                3.082667438325558
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.864871131767402,
+                "50.0" : 2.9232098999309684,
+                "90.0" : 2.983129692812407,
+                "95.0" : 2.983129692812407,
+                "99.0" : 2.983129692812407,
+                "99.9" : 2.983129692812407,
+                "99.99" : 2.983129692812407,
+                "99.999" : 2.983129692812407,
+                "99.9999" : 2.983129692812407,
+                "100.0" : 2.983129692812407
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9652017583753336,
+                    2.9801450101311087,
+                    2.983129692812407
+                ],
+                [
+                    2.8789117075417385,
+                    2.864871131767402,
+                    2.881218041486603
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3815497603565193,
+            "scoreError" : 0.007017238548267891,
+            "scoreConfidence" : [
+                0.37453252180825136,
+                0.3885669989047872
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.37859187442740866,
+                "50.0" : 0.38098011020327555,
+                "90.0" : 0.3847754097345133,
+                "95.0" : 0.3847754097345133,
+                "99.0" : 0.3847754097345133,
+                "99.9" : 0.3847754097345133,
+                "99.99" : 0.3847754097345133,
+                "99.999" : 0.3847754097345133,
+                "99.9999" : 0.3847754097345133,
+                "100.0" : 0.3847754097345133
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3847754097345133,
+                    0.384096413658012,
+                    0.382032734767162
+                ],
+                [
+                    0.3798746439126306,
+                    0.3799274856393891,
+                    0.37859187442740866
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16415641224725638,
+            "scoreError" : 0.019411527788902268,
+            "scoreConfidence" : [
+                0.14474488445835412,
+                0.18356794003615864
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15777807213518247,
+                "50.0" : 0.16367760158875888,
+                "90.0" : 0.17155180656339525,
+                "95.0" : 0.17155180656339525,
+                "99.0" : 0.17155180656339525,
+                "99.9" : 0.17155180656339525,
+                "99.99" : 0.17155180656339525,
+                "99.999" : 0.17155180656339525,
+                "99.9999" : 0.17155180656339525,
+                "100.0" : 0.17155180656339525
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15793248299115603,
+                    0.15789188775735757,
+                    0.15777807213518247
+                ],
+                [
+                    0.1694227201863617,
+                    0.17036150385008517,
+                    0.17155180656339525
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4071444935834048,
+            "scoreError" : 0.026459864829061364,
+            "scoreConfidence" : [
+                0.38068462875434345,
+                0.4336043584124662
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3982076073746665,
+                "50.0" : 0.40574161064739855,
+                "90.0" : 0.4188483840258,
+                "95.0" : 0.4188483840258,
+                "99.0" : 0.4188483840258,
+                "99.9" : 0.4188483840258,
+                "99.99" : 0.4188483840258,
+                "99.999" : 0.4188483840258,
+                "99.9999" : 0.4188483840258,
+                "100.0" : 0.4188483840258
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4188483840258,
+                    0.4156981653157085,
+                    0.41201542505767963
+                ],
+                [
+                    0.39946779623711753,
+                    0.3986295834894567,
+                    0.3982076073746665
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1469773949593213,
+            "scoreError" : 0.00690663349923455,
+            "scoreConfidence" : [
+                0.14007076146008676,
+                0.15388402845855584
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14448165450631376,
+                "50.0" : 0.14711081696384903,
+                "90.0" : 0.14926946074275307,
+                "95.0" : 0.14926946074275307,
+                "99.0" : 0.14926946074275307,
+                "99.9" : 0.14926946074275307,
+                "99.99" : 0.14926946074275307,
+                "99.999" : 0.14926946074275307,
+                "99.9999" : 0.14926946074275307,
+                "100.0" : 0.14926946074275307
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14921347331353796,
+                    0.14926946074275307,
+                    0.14917560280143802
+                ],
+                [
+                    0.14504603112626005,
+                    0.144678147265625,
+                    0.14448165450631376
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.043162265459596755,
+            "scoreError" : 0.0012420040643327268,
+            "scoreConfidence" : [
+                0.04192026139526403,
+                0.04440426952392948
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.042757610954335556,
+                "50.0" : 0.04311535393130621,
+                "90.0" : 0.04373291049273385,
+                "95.0" : 0.04373291049273385,
+                "99.0" : 0.04373291049273385,
+                "99.9" : 0.04373291049273385,
+                "99.99" : 0.04373291049273385,
+                "99.999" : 0.04373291049273385,
+                "99.9999" : 0.04373291049273385,
+                "100.0" : 0.04373291049273385
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04276650036992529,
+                    0.042757610954335556,
+                    0.042779406592983564
+                ],
+                [
+                    0.04373291049273385,
+                    0.043451301269628845,
+                    0.04348586307797341
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8131279.823263358,
+            "scoreError" : 468182.4814423486,
+            "scoreConfidence" : [
+                7663097.341821009,
+                8599462.304705707
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7857953.462686568,
+                "50.0" : 8170976.320975484,
+                "90.0" : 8302917.609958506,
+                "95.0" : 8302917.609958506,
+                "99.0" : 8302917.609958506,
+                "99.9" : 8302917.609958506,
+                "99.99" : 8302917.609958506,
+                "99.999" : 8302917.609958506,
+                "99.9999" : 8302917.609958506,
+                "100.0" : 8302917.609958506
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8302917.609958506,
+                    8182292.010629599,
+                    8268030.994214876
+                ],
+                [
+                    8159660.631321371,
+                    8016824.230769231,
+                    7857953.462686568
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-22T23-40-24Z-f7a2377750d8fcf2e1a9345f58e284d8942444f0-jdk17.json
+++ b/performance-results/2026-02-22T23-40-24Z-f7a2377750d8fcf2e1a9345f58e284d8942444f0-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3488728596173596,
+            "scoreError" : 0.04305349212288041,
+            "scoreConfidence" : [
+                3.3058193674944794,
+                3.39192635174024
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.340994493452765,
+                "50.0" : 3.348632467548331,
+                "90.0" : 3.357232009920012,
+                "95.0" : 3.357232009920012,
+                "99.0" : 3.357232009920012,
+                "99.9" : 3.357232009920012,
+                "99.99" : 3.357232009920012,
+                "99.999" : 3.357232009920012,
+                "99.9999" : 3.357232009920012,
+                "100.0" : 3.357232009920012
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.340994493452765,
+                    3.3493774895317654
+                ],
+                [
+                    3.347887445564896,
+                    3.357232009920012
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.682570036596773,
+            "scoreError" : 0.024933264609537924,
+            "scoreConfidence" : [
+                1.6576367719872351,
+                1.707503301206311
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6791808365913736,
+                "50.0" : 1.6815804385574653,
+                "90.0" : 1.6879384326807878,
+                "95.0" : 1.6879384326807878,
+                "99.0" : 1.6879384326807878,
+                "99.9" : 1.6879384326807878,
+                "99.99" : 1.6879384326807878,
+                "99.999" : 1.6879384326807878,
+                "99.9999" : 1.6879384326807878,
+                "100.0" : 1.6879384326807878
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6791808365913736,
+                    1.680485460395412
+                ],
+                [
+                    1.6826754167195184,
+                    1.6879384326807878
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8482093823433154,
+            "scoreError" : 0.010436481265026384,
+            "scoreConfidence" : [
+                0.8377729010782891,
+                0.8586458636083418
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8464153755337513,
+                "50.0" : 0.8483668374098708,
+                "90.0" : 0.849688479019769,
+                "95.0" : 0.849688479019769,
+                "99.0" : 0.849688479019769,
+                "99.9" : 0.849688479019769,
+                "99.99" : 0.849688479019769,
+                "99.999" : 0.849688479019769,
+                "99.9999" : 0.849688479019769,
+                "100.0" : 0.849688479019769
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8464153755337513,
+                    0.849688479019769
+                ],
+                [
+                    0.8472783852964532,
+                    0.8494552895232885
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.103449916400308,
+            "scoreError" : 0.13214927940605492,
+            "scoreConfidence" : [
+                15.971300636994252,
+                16.235599195806362
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.05101912161129,
+                "50.0" : 16.09789407441106,
+                "90.0" : 16.16031831115726,
+                "95.0" : 16.16031831115726,
+                "99.0" : 16.16031831115726,
+                "99.9" : 16.16031831115726,
+                "99.99" : 16.16031831115726,
+                "99.999" : 16.16031831115726,
+                "99.9999" : 16.16031831115726,
+                "100.0" : 16.16031831115726
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.148630558484268,
+                    16.125601276461474,
+                    16.16031831115726
+                ],
+                [
+                    16.06494335832692,
+                    16.05101912161129,
+                    16.070186872360644
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2654.5827466439528,
+            "scoreError" : 69.21453043695593,
+            "scoreConfidence" : [
+                2585.3682162069967,
+                2723.7972770809088
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2614.7558353068343,
+                "50.0" : 2661.4541800182483,
+                "90.0" : 2675.7232738770913,
+                "95.0" : 2675.7232738770913,
+                "99.0" : 2675.7232738770913,
+                "99.9" : 2675.7232738770913,
+                "99.99" : 2675.7232738770913,
+                "99.999" : 2675.7232738770913,
+                "99.9999" : 2675.7232738770913,
+                "100.0" : 2675.7232738770913
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2614.7558353068343,
+                    2639.314319494599,
+                    2649.6864196030797
+                ],
+                [
+                    2673.221940433417,
+                    2674.794691148696,
+                    2675.7232738770913
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73743.64247495569,
+            "scoreError" : 1118.3347729713403,
+            "scoreConfidence" : [
+                72625.30770198435,
+                74861.97724792703
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73352.50607922683,
+                "50.0" : 73725.63199300959,
+                "90.0" : 74181.17483464182,
+                "95.0" : 74181.17483464182,
+                "99.0" : 74181.17483464182,
+                "99.9" : 74181.17483464182,
+                "99.99" : 74181.17483464182,
+                "99.999" : 74181.17483464182,
+                "99.9999" : 74181.17483464182,
+                "100.0" : 74181.17483464182
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74054.2156297461,
+                    74080.64181822503,
+                    74181.17483464182
+                ],
+                [
+                    73397.04835627307,
+                    73352.50607922683,
+                    73396.2681316213
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 362.18362931562,
+            "scoreError" : 1.4622963677644545,
+            "scoreConfidence" : [
+                360.72133294785556,
+                363.64592568338446
+            ],
+            "scorePercentiles" : {
+                "0.0" : 361.3112779201013,
+                "50.0" : 362.2747133869182,
+                "90.0" : 362.7914319910298,
+                "95.0" : 362.7914319910298,
+                "99.0" : 362.7914319910298,
+                "99.9" : 362.7914319910298,
+                "99.99" : 362.7914319910298,
+                "99.999" : 362.7914319910298,
+                "99.9999" : 362.7914319910298,
+                "100.0" : 362.7914319910298
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    361.3112779201013,
+                    361.9094702279517,
+                    362.5401689808006
+                ],
+                [
+                    362.3466579339149,
+                    362.7914319910298,
+                    362.20276883992153
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 126.77437717878071,
+            "scoreError" : 3.8657757195286253,
+            "scoreConfidence" : [
+                122.90860145925208,
+                130.64015289830934
+            ],
+            "scorePercentiles" : {
+                "0.0" : 125.34709616754276,
+                "50.0" : 126.77712611158145,
+                "90.0" : 128.1483760674431,
+                "95.0" : 128.1483760674431,
+                "99.0" : 128.1483760674431,
+                "99.9" : 128.1483760674431,
+                "99.99" : 128.1483760674431,
+                "99.999" : 128.1483760674431,
+                "99.9999" : 128.1483760674431,
+                "100.0" : 128.1483760674431
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    125.62396688547356,
+                    125.59066787239215,
+                    125.34709616754276
+                ],
+                [
+                    128.00587074214332,
+                    127.93028533768934,
+                    128.1483760674431
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06176178849755137,
+            "scoreError" : 0.0010230722245855432,
+            "scoreConfidence" : [
+                0.06073871627296583,
+                0.06278486072213692
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0612072919783085,
+                "50.0" : 0.061854705179934105,
+                "90.0" : 0.06209091462028971,
+                "95.0" : 0.06209091462028971,
+                "99.0" : 0.06209091462028971,
+                "99.9" : 0.06209091462028971,
+                "99.99" : 0.06209091462028971,
+                "99.999" : 0.06209091462028971,
+                "99.9999" : 0.06209091462028971,
+                "100.0" : 0.06209091462028971
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.062062368451756646,
+                    0.06209091462028971,
+                    0.06204703634028454
+                ],
+                [
+                    0.06166237401958366,
+                    0.061500745575085176,
+                    0.0612072919783085
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7244403634680034E-4,
+            "scoreError" : 4.595751141311252E-5,
+            "scoreConfidence" : [
+                3.2648652493368784E-4,
+                4.1840154775991283E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5705692350225537E-4,
+                "50.0" : 3.725810207023296E-4,
+                "90.0" : 3.874999255621972E-4,
+                "95.0" : 3.874999255621972E-4,
+                "99.0" : 3.874999255621972E-4,
+                "99.9" : 3.874999255621972E-4,
+                "99.99" : 3.874999255621972E-4,
+                "99.999" : 3.874999255621972E-4,
+                "99.9999" : 3.874999255621972E-4,
+                "100.0" : 3.874999255621972E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.872184523016888E-4,
+                    3.874999255621972E-4,
+                    3.874891176059078E-4
+                ],
+                [
+                    3.574562100057825E-4,
+                    3.5794358910297034E-4,
+                    3.5705692350225537E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1880243740391543,
+            "scoreError" : 0.06598022530041216,
+            "scoreConfidence" : [
+                2.122044148738742,
+                2.2540045993395665
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.149034795015041,
+                "50.0" : 2.1700669976438722,
+                "90.0" : 2.272092075347427,
+                "95.0" : 2.2751533045950865,
+                "99.0" : 2.2751533045950865,
+                "99.9" : 2.2751533045950865,
+                "99.99" : 2.2751533045950865,
+                "99.999" : 2.2751533045950865,
+                "99.9999" : 2.2751533045950865,
+                "100.0" : 2.2751533045950865
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.2152792429678847,
+                    2.2751533045950865,
+                    2.1537197678725235,
+                    2.153443234496124,
+                    2.149034795015041
+                ],
+                [
+                    2.244541012118492,
+                    2.190736973493976,
+                    2.179514954674221,
+                    2.1582014145446697,
+                    2.1606190406135233
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013574474364557339,
+            "scoreError" : 4.1642046453400943E-4,
+            "scoreConfidence" : [
+                0.01315805390002333,
+                0.013990894829091348
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013435789296122082,
+                "50.0" : 0.01357540376021525,
+                "90.0" : 0.013714986294775475,
+                "95.0" : 0.013714986294775475,
+                "99.0" : 0.013714986294775475,
+                "99.9" : 0.013714986294775475,
+                "99.99" : 0.013714986294775475,
+                "99.999" : 0.013714986294775475,
+                "99.9999" : 0.013714986294775475,
+                "100.0" : 0.013714986294775475
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013444044575925747,
+                    0.013437050493133752,
+                    0.013435789296122082
+                ],
+                [
+                    0.013708212582882224,
+                    0.013706762944504753,
+                    0.013714986294775475
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1176353948341051,
+            "scoreError" : 0.19725140038684444,
+            "scoreConfidence" : [
+                0.9203839944472607,
+                1.3148867952209495
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0530843014636202,
+                "50.0" : 1.1175679981509279,
+                "90.0" : 1.1828038928444706,
+                "95.0" : 1.1828038928444706,
+                "99.0" : 1.1828038928444706,
+                "99.9" : 1.1828038928444706,
+                "99.99" : 1.1828038928444706,
+                "99.999" : 1.1828038928444706,
+                "99.9999" : 1.1828038928444706,
+                "100.0" : 1.1828038928444706
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0540091511382799,
+                    1.0530843014636202,
+                    1.0531817374684078
+                ],
+                [
+                    1.1828038928444706,
+                    1.181606440926276,
+                    1.1811268451635761
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010511533023171168,
+            "scoreError" : 8.565299792904648E-4,
+            "scoreConfidence" : [
+                0.009655003043880703,
+                0.011368063002461633
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010229101670782078,
+                "50.0" : 0.010510659199562242,
+                "90.0" : 0.010792988192809053,
+                "95.0" : 0.010792988192809053,
+                "99.0" : 0.010792988192809053,
+                "99.9" : 0.010792988192809053,
+                "99.99" : 0.010792988192809053,
+                "99.999" : 0.010792988192809053,
+                "99.9999" : 0.010792988192809053,
+                "100.0" : 0.010792988192809053
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01023282555690853,
+                    0.010229101670782078,
+                    0.010236231221185893
+                ],
+                [
+                    0.010785087177938591,
+                    0.010792964319402862,
+                    0.010792988192809053
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.9797793578843916,
+            "scoreError" : 0.03351458528893954,
+            "scoreConfidence" : [
+                2.9462647725954523,
+                3.013293943173331
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9656838196915776,
+                "50.0" : 2.9801547096917944,
+                "90.0" : 2.9927427169359664,
+                "95.0" : 2.9927427169359664,
+                "99.0" : 2.9927427169359664,
+                "99.9" : 2.9927427169359664,
+                "99.99" : 2.9927427169359664,
+                "99.999" : 2.9927427169359664,
+                "99.9999" : 2.9927427169359664,
+                "100.0" : 2.9927427169359664
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.969399096199525,
+                    2.972292550207962,
+                    2.9656838196915776
+                ],
+                [
+                    2.990541095095694,
+                    2.9927427169359664,
+                    2.988016869175627
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.729930388755662,
+            "scoreError" : 0.10206316860110236,
+            "scoreConfidence" : [
+                2.6278672201545596,
+                2.831993557356764
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6947823729452978,
+                "50.0" : 2.7291095530180263,
+                "90.0" : 2.7702013814404434,
+                "95.0" : 2.7702013814404434,
+                "99.0" : 2.7702013814404434,
+                "99.9" : 2.7702013814404434,
+                "99.99" : 2.7702013814404434,
+                "99.999" : 2.7702013814404434,
+                "99.9999" : 2.7702013814404434,
+                "100.0" : 2.7702013814404434
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7574596796250344,
+                    2.76098912368857,
+                    2.7702013814404434
+                ],
+                [
+                    2.700759426411018,
+                    2.6953903484236057,
+                    2.6947823729452978
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.378546037989762,
+            "scoreError" : 0.014057819303915212,
+            "scoreConfidence" : [
+                0.3644882186858468,
+                0.3926038572936772
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.37374767182419555,
+                "50.0" : 0.3784804827949456,
+                "90.0" : 0.38351759984659634,
+                "95.0" : 0.38351759984659634,
+                "99.0" : 0.38351759984659634,
+                "99.9" : 0.38351759984659634,
+                "99.99" : 0.38351759984659634,
+                "99.999" : 0.38351759984659634,
+                "99.9999" : 0.38351759984659634,
+                "100.0" : 0.38351759984659634
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.38286766419081897,
+                    0.38296422992379275,
+                    0.38351759984659634
+                ],
+                [
+                    0.3740857607540959,
+                    0.37409330139907226,
+                    0.37374767182419555
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1561388666115206,
+            "scoreError" : 0.0018878682059964818,
+            "scoreConfidence" : [
+                0.15425099840552411,
+                0.15802673481751708
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15546181887572677,
+                "50.0" : 0.15609649877609527,
+                "90.0" : 0.15696093748332313,
+                "95.0" : 0.15696093748332313,
+                "99.0" : 0.15696093748332313,
+                "99.9" : 0.15696093748332313,
+                "99.99" : 0.15696093748332313,
+                "99.999" : 0.15696093748332313,
+                "99.9999" : 0.15696093748332313,
+                "100.0" : 0.15696093748332313
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15655447798111996,
+                    0.15670332994860223,
+                    0.15696093748332313
+                ],
+                [
+                    0.15551411580928093,
+                    0.1556385195710706,
+                    0.15546181887572677
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40246980481369815,
+            "scoreError" : 0.008404405061423394,
+            "scoreConfidence" : [
+                0.3940653997522748,
+                0.4108742098751215
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3992779478958716,
+                "50.0" : 0.40233203513371596,
+                "90.0" : 0.40587917999918827,
+                "95.0" : 0.40587917999918827,
+                "99.0" : 0.40587917999918827,
+                "99.9" : 0.40587917999918827,
+                "99.99" : 0.40587917999918827,
+                "99.999" : 0.40587917999918827,
+                "99.9999" : 0.40587917999918827,
+                "100.0" : 0.40587917999918827
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40514239969210825,
+                    0.400200804706259,
+                    0.39985523102758896
+                ],
+                [
+                    0.4044632655611729,
+                    0.40587917999918827,
+                    0.3992779478958716
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14521405392784978,
+            "scoreError" : 0.0019524170781657704,
+            "scoreConfidence" : [
+                0.14326163684968402,
+                0.14716647100601554
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14489957388973412,
+                "50.0" : 0.1449355791670377,
+                "90.0" : 0.1466345051467785,
+                "95.0" : 0.1466345051467785,
+                "99.0" : 0.1466345051467785,
+                "99.9" : 0.1466345051467785,
+                "99.99" : 0.1466345051467785,
+                "99.999" : 0.1466345051467785,
+                "99.9999" : 0.1466345051467785,
+                "100.0" : 0.1466345051467785
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14492003547569016,
+                    0.14495112285838527,
+                    0.1449613845908531
+                ],
+                [
+                    0.1466345051467785,
+                    0.14489957388973412,
+                    0.14491770160565748
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.042477169984365515,
+            "scoreError" : 0.001053564484371751,
+            "scoreConfidence" : [
+                0.041423605499993764,
+                0.043530734468737266
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04214093825589334,
+                "50.0" : 0.042428036295367455,
+                "90.0" : 0.04300543172366933,
+                "95.0" : 0.04300543172366933,
+                "99.0" : 0.04300543172366933,
+                "99.9" : 0.04300543172366933,
+                "99.99" : 0.04300543172366933,
+                "99.999" : 0.04300543172366933,
+                "99.9999" : 0.04300543172366933,
+                "100.0" : 0.04300543172366933
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04215486887920278,
+                    0.04214093825589334,
+                    0.042151705084702895
+                ],
+                [
+                    0.04300543172366933,
+                    0.042708872251192624,
+                    0.04270120371153214
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7936520.80257992,
+            "scoreError" : 97646.49903490771,
+            "scoreConfidence" : [
+                7838874.303545012,
+                8034167.3016148275
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7885849.184397163,
+                "50.0" : 7939376.432053543,
+                "90.0" : 7981381.025538707,
+                "95.0" : 7981381.025538707,
+                "99.0" : 7981381.025538707,
+                "99.9" : 7981381.025538707,
+                "99.99" : 7981381.025538707,
+                "99.999" : 7981381.025538707,
+                "99.9999" : 7981381.025538707,
+                "100.0" : 7981381.025538707
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7923705.590657165,
+                    7914488.859177215,
+                    7885849.184397163
+                ],
+                [
+                    7981381.025538707,
+                    7958652.8822593475,
+                    7955047.27344992
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-22T23-40-38Z-f7a2377750d8fcf2e1a9345f58e284d8942444f0-jdk17.json
+++ b/performance-results/2026-02-22T23-40-38Z-f7a2377750d8fcf2e1a9345f58e284d8942444f0-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.377517278601202,
+            "scoreError" : 0.03809468862370832,
+            "scoreConfidence" : [
+                3.339422589977494,
+                3.4156119672249106
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.37041029174212,
+                "50.0" : 3.3776171457983057,
+                "90.0" : 3.384424531066077,
+                "95.0" : 3.384424531066077,
+                "99.0" : 3.384424531066077,
+                "99.9" : 3.384424531066077,
+                "99.99" : 3.384424531066077,
+                "99.999" : 3.384424531066077,
+                "99.9999" : 3.384424531066077,
+                "100.0" : 3.384424531066077
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.37041029174212,
+                    3.3758821191768176
+                ],
+                [
+                    3.3793521724197944,
+                    3.384424531066077
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.705872686985312,
+            "scoreError" : 0.025417241503682998,
+            "scoreConfidence" : [
+                1.680455445481629,
+                1.731289928488995
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.7003795728980922,
+                "50.0" : 1.7071369986431146,
+                "90.0" : 1.7088371777569265,
+                "95.0" : 1.7088371777569265,
+                "99.0" : 1.7088371777569265,
+                "99.9" : 1.7088371777569265,
+                "99.99" : 1.7088371777569265,
+                "99.999" : 1.7088371777569265,
+                "99.9999" : 1.7088371777569265,
+                "100.0" : 1.7088371777569265
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7056785469801365,
+                    1.7085954503060927
+                ],
+                [
+                    1.7003795728980922,
+                    1.7088371777569265
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.854115923464665,
+            "scoreError" : 0.04395153028018789,
+            "scoreConfidence" : [
+                0.8101643931844771,
+                0.898067453744853
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.84756194419677,
+                "50.0" : 0.85390776774498,
+                "90.0" : 0.8610862141719302,
+                "95.0" : 0.8610862141719302,
+                "99.0" : 0.8610862141719302,
+                "99.9" : 0.8610862141719302,
+                "99.99" : 0.8610862141719302,
+                "99.999" : 0.8610862141719302,
+                "99.9999" : 0.8610862141719302,
+                "100.0" : 0.8610862141719302
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.84756194419677,
+                    0.8587635328573362
+                ],
+                [
+                    0.8490520026326238,
+                    0.8610862141719302
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.04352554078351,
+            "scoreError" : 0.15201166829205442,
+            "scoreConfidence" : [
+                15.891513872491455,
+                16.195537209075564
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.9859342754061,
+                "50.0" : 16.03769318533702,
+                "90.0" : 16.118748207422378,
+                "95.0" : 16.118748207422378,
+                "99.0" : 16.118748207422378,
+                "99.9" : 16.118748207422378,
+                "99.99" : 16.118748207422378,
+                "99.999" : 16.118748207422378,
+                "99.9999" : 16.118748207422378,
+                "100.0" : 16.118748207422378
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.118748207422378,
+                    16.080500148328056,
+                    16.07261216902515
+                ],
+                [
+                    15.9859342754061,
+                    16.00277420164889,
+                    16.00058424287049
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2757.875857030213,
+            "scoreError" : 10.771862008353995,
+            "scoreConfidence" : [
+                2747.1039950218587,
+                2768.647719038567
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2754.5205110412776,
+                "50.0" : 2756.4624600258485,
+                "90.0" : 2762.9333831504678,
+                "95.0" : 2762.9333831504678,
+                "99.0" : 2762.9333831504678,
+                "99.9" : 2762.9333831504678,
+                "99.99" : 2762.9333831504678,
+                "99.999" : 2762.9333831504678,
+                "99.9999" : 2762.9333831504678,
+                "100.0" : 2762.9333831504678
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2762.2147046240243,
+                    2757.839166904831,
+                    2762.9333831504678
+                ],
+                [
+                    2755.0857531468664,
+                    2754.5205110412776,
+                    2754.661623313812
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74890.14776621696,
+            "scoreError" : 156.9830155655928,
+            "scoreConfidence" : [
+                74733.16475065137,
+                75047.13078178256
+            ],
+            "scorePercentiles" : {
+                "0.0" : 74847.94113129462,
+                "50.0" : 74861.26109124918,
+                "90.0" : 74976.45479822953,
+                "95.0" : 74976.45479822953,
+                "99.0" : 74976.45479822953,
+                "99.9" : 74976.45479822953,
+                "99.99" : 74976.45479822953,
+                "99.999" : 74976.45479822953,
+                "99.9999" : 74976.45479822953,
+                "100.0" : 74976.45479822953
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74976.45479822953,
+                    74945.3412105545,
+                    74860.88859361468
+                ],
+                [
+                    74848.6272747248,
+                    74847.94113129462,
+                    74861.63358888366
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 363.4085382705876,
+            "scoreError" : 3.889986346286091,
+            "scoreConfidence" : [
+                359.5185519243015,
+                367.2985246168737
+            ],
+            "scorePercentiles" : {
+                "0.0" : 361.9107446311911,
+                "50.0" : 363.39662869068013,
+                "90.0" : 365.0795334588145,
+                "95.0" : 365.0795334588145,
+                "99.0" : 365.0795334588145,
+                "99.9" : 365.0795334588145,
+                "99.99" : 365.0795334588145,
+                "99.999" : 365.0795334588145,
+                "99.9999" : 365.0795334588145,
+                "100.0" : 365.0795334588145
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    364.36144349066666,
+                    365.0795334588145,
+                    364.49851949333976
+                ],
+                [
+                    362.43181389069366,
+                    362.16917465882034,
+                    361.9107446311911
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 126.32901396913742,
+            "scoreError" : 4.357521391408077,
+            "scoreConfidence" : [
+                121.97149257772935,
+                130.6865353605455
+            ],
+            "scorePercentiles" : {
+                "0.0" : 124.17626050405713,
+                "50.0" : 126.66537083509513,
+                "90.0" : 127.79701522403123,
+                "95.0" : 127.79701522403123,
+                "99.0" : 127.79701522403123,
+                "99.9" : 127.79701522403123,
+                "99.99" : 127.79701522403123,
+                "99.999" : 127.79701522403123,
+                "99.9999" : 127.79701522403123,
+                "100.0" : 127.79701522403123
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    127.52155725641587,
+                    127.67513136130836,
+                    127.79701522403123
+                ],
+                [
+                    124.17626050405713,
+                    124.99493505523763,
+                    125.80918441377439
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06078591338880606,
+            "scoreError" : 6.696672040590495E-4,
+            "scoreConfidence" : [
+                0.060116246184747014,
+                0.06145558059286511
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06051882955095619,
+                "50.0" : 0.06078464536696401,
+                "90.0" : 0.06105336238201643,
+                "95.0" : 0.06105336238201643,
+                "99.0" : 0.06105336238201643,
+                "99.9" : 0.06105336238201643,
+                "99.99" : 0.06105336238201643,
+                "99.999" : 0.06105336238201643,
+                "99.9999" : 0.06105336238201643,
+                "100.0" : 0.06105336238201643
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06065100413634158,
+                    0.06051882955095619,
+                    0.060556171759377005
+                ],
+                [
+                    0.06105336238201643,
+                    0.060918286597586455,
+                    0.06101782590655871
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7366554594457565E-4,
+            "scoreError" : 2.4531487633144702E-5,
+            "scoreConfidence" : [
+                3.4913405831143096E-4,
+                3.9819703357772034E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6553807220545374E-4,
+                "50.0" : 3.737514807271949E-4,
+                "90.0" : 3.8173588824527726E-4,
+                "95.0" : 3.8173588824527726E-4,
+                "99.0" : 3.8173588824527726E-4,
+                "99.9" : 3.8173588824527726E-4,
+                "99.99" : 3.8173588824527726E-4,
+                "99.999" : 3.8173588824527726E-4,
+                "99.9999" : 3.8173588824527726E-4,
+                "100.0" : 3.8173588824527726E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.8155980699092066E-4,
+                    3.8173588824527726E-4,
+                    3.816550524511093E-4
+                ],
+                [
+                    3.6553807220545374E-4,
+                    3.6556130131122367E-4,
+                    3.6594315446346906E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.187619992345375,
+            "scoreError" : 0.04494818102390934,
+            "scoreConfidence" : [
+                2.1426718113214656,
+                2.2325681733692844
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1556097700431036,
+                "50.0" : 2.1767044328912766,
+                "90.0" : 2.232130585472476,
+                "95.0" : 2.2324684785714286,
+                "99.0" : 2.2324684785714286,
+                "99.9" : 2.2324684785714286,
+                "99.99" : 2.2324684785714286,
+                "99.999" : 2.2324684785714286,
+                "99.9999" : 2.2324684785714286,
+                "100.0" : 2.2324684785714286
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.223287104935527,
+                    2.1878919105228616,
+                    2.178021400479094,
+                    2.1556097700431036,
+                    2.155750365164906
+                ],
+                [
+                    2.2324684785714286,
+                    2.2290895475819035,
+                    2.1753874653034586,
+                    2.1703111217447915,
+                    2.168382759106678
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013856486748668793,
+            "scoreError" : 2.5621223849713916E-4,
+            "scoreConfidence" : [
+                0.013600274510171654,
+                0.014112698987165932
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013760768904013078,
+                "50.0" : 0.013857892703214872,
+                "90.0" : 0.013943597360242168,
+                "95.0" : 0.013943597360242168,
+                "99.0" : 0.013943597360242168,
+                "99.9" : 0.013943597360242168,
+                "99.99" : 0.013943597360242168,
+                "99.999" : 0.013943597360242168,
+                "99.9999" : 0.013943597360242168,
+                "100.0" : 0.013943597360242168
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013778753327188076,
+                    0.013780540660988244,
+                    0.013760768904013078
+                ],
+                [
+                    0.013935244745441498,
+                    0.013943597360242168,
+                    0.01394001549413969
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0264298727292982,
+            "scoreError" : 0.0012136661537017208,
+            "scoreConfidence" : [
+                1.0252162065755965,
+                1.0276435388829999
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0258396154477383,
+                "50.0" : 1.026436497006087,
+                "90.0" : 1.0271389562448645,
+                "95.0" : 1.0271389562448645,
+                "99.0" : 1.0271389562448645,
+                "99.9" : 1.0271389562448645,
+                "99.99" : 1.0271389562448645,
+                "99.999" : 1.0271389562448645,
+                "99.9999" : 1.0271389562448645,
+                "100.0" : 1.0271389562448645
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0265515899199342,
+                    1.0271389562448645,
+                    1.0263813393883416
+                ],
+                [
+                    1.0264916546238325,
+                    1.0258396154477383,
+                    1.0261760807510774
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010246173875227568,
+            "scoreError" : 9.288437694144223E-4,
+            "scoreConfidence" : [
+                0.009317330105813145,
+                0.011175017644641991
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.009942666286866469,
+                "50.0" : 0.010238839482604466,
+                "90.0" : 0.010564618364255244,
+                "95.0" : 0.010564618364255244,
+                "99.0" : 0.010564618364255244,
+                "99.9" : 0.010564618364255244,
+                "99.99" : 0.010564618364255244,
+                "99.999" : 0.010564618364255244,
+                "99.9999" : 0.010564618364255244,
+                "100.0" : 0.010564618364255244
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010564618364255244,
+                    0.010548797978924274,
+                    0.010531777649995262
+                ],
+                [
+                    0.009942666286866469,
+                    0.009945901315213673,
+                    0.009943281656110487
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.971125386376592,
+            "scoreError" : 0.2675473524135524,
+            "scoreConfidence" : [
+                2.7035780339630393,
+                3.2386727387901444
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8801957990788716,
+                "50.0" : 2.9718769566484573,
+                "90.0" : 3.0629340642988363,
+                "95.0" : 3.0629340642988363,
+                "99.0" : 3.0629340642988363,
+                "99.9" : 3.0629340642988363,
+                "99.99" : 3.0629340642988363,
+                "99.999" : 3.0629340642988363,
+                "99.9999" : 3.0629340642988363,
+                "100.0" : 3.0629340642988363
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0629340642988363,
+                    3.058555417737003,
+                    3.052830336996337
+                ],
+                [
+                    2.890923576300578,
+                    2.8801957990788716,
+                    2.881313123847926
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.763245665907945,
+            "scoreError" : 0.03205593653914852,
+            "scoreConfidence" : [
+                2.7311897293687966,
+                2.795301602447094
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7499455914215014,
+                "50.0" : 2.7647119128701343,
+                "90.0" : 2.774483585298197,
+                "95.0" : 2.774483585298197,
+                "99.0" : 2.774483585298197,
+                "99.9" : 2.774483585298197,
+                "99.99" : 2.774483585298197,
+                "99.999" : 2.774483585298197,
+                "99.9999" : 2.774483585298197,
+                "100.0" : 2.774483585298197
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.756492597850055,
+                    2.7499455914215014,
+                    2.752553418271877
+                ],
+                [
+                    2.7729312278902136,
+                    2.77306757471583,
+                    2.774483585298197
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.38010461660977074,
+            "scoreError" : 0.014696481898523123,
+            "scoreConfidence" : [
+                0.3654081347112476,
+                0.39480109850829387
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.37433609339322477,
+                "50.0" : 0.3803681374308794,
+                "90.0" : 0.38515368796456767,
+                "95.0" : 0.38515368796456767,
+                "99.0" : 0.38515368796456767,
+                "99.9" : 0.38515368796456767,
+                "99.99" : 0.38515368796456767,
+                "99.999" : 0.38515368796456767,
+                "99.9999" : 0.38515368796456767,
+                "100.0" : 0.38515368796456767
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.38515368796456767,
+                    0.38487843397606125,
+                    0.38453041085092476
+                ],
+                [
+                    0.376205864010834,
+                    0.37552320946301165,
+                    0.37433609339322477
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15705603298987117,
+            "scoreError" : 0.0011984854766081891,
+            "scoreConfidence" : [
+                0.15585754751326297,
+                0.15825451846647937
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15644164960500587,
+                "50.0" : 0.15705638185854576,
+                "90.0" : 0.15767612391403749,
+                "95.0" : 0.15767612391403749,
+                "99.0" : 0.15767612391403749,
+                "99.9" : 0.15767612391403749,
+                "99.99" : 0.15767612391403749,
+                "99.999" : 0.15767612391403749,
+                "99.9999" : 0.15767612391403749,
+                "100.0" : 0.15767612391403749
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15767612391403749,
+                    0.15677872429254527,
+                    0.15644164960500587
+                ],
+                [
+                    0.15732693641054685,
+                    0.15707927954574014,
+                    0.1570334841713514
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4115056332424815,
+            "scoreError" : 0.009942715313209914,
+            "scoreConfidence" : [
+                0.4015629179292716,
+                0.4214483485556914
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4071970345698115,
+                "50.0" : 0.41260623339151964,
+                "90.0" : 0.4146864849678623,
+                "95.0" : 0.4146864849678623,
+                "99.0" : 0.4146864849678623,
+                "99.9" : 0.4146864849678623,
+                "99.99" : 0.4146864849678623,
+                "99.999" : 0.4146864849678623,
+                "99.9999" : 0.4146864849678623,
+                "100.0" : 0.4146864849678623
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41101167909251574,
+                    0.4071970345698115,
+                    0.4073569147012098
+                ],
+                [
+                    0.41458089843296575,
+                    0.41420078769052354,
+                    0.4146864849678623
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14613902092588169,
+            "scoreError" : 0.003776951772283178,
+            "scoreConfidence" : [
+                0.1423620691535985,
+                0.14991597269816487
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1449561086855685,
+                "50.0" : 0.14575253139873054,
+                "90.0" : 0.1482779688621334,
+                "95.0" : 0.1482779688621334,
+                "99.0" : 0.1482779688621334,
+                "99.9" : 0.1482779688621334,
+                "99.99" : 0.1482779688621334,
+                "99.999" : 0.1482779688621334,
+                "99.9999" : 0.1482779688621334,
+                "100.0" : 0.1482779688621334
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14514721620680146,
+                    0.1449561086855685,
+                    0.14503557189267585
+                ],
+                [
+                    0.1482779688621334,
+                    0.1470594133174512,
+                    0.14635784659065962
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04358649724720634,
+            "scoreError" : 0.0012081091514977546,
+            "scoreConfidence" : [
+                0.04237838809570858,
+                0.0447946063987041
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04327384907611753,
+                "50.0" : 0.04335198864578296,
+                "90.0" : 0.04423354448504043,
+                "95.0" : 0.04423354448504043,
+                "99.0" : 0.04423354448504043,
+                "99.9" : 0.04423354448504043,
+                "99.99" : 0.04423354448504043,
+                "99.999" : 0.04423354448504043,
+                "99.9999" : 0.04423354448504043,
+                "100.0" : 0.04423354448504043
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04403126614710609,
+                    0.04423354448504043,
+                    0.04341372760108706
+                ],
+                [
+                    0.04329024969047887,
+                    0.04327634648340806,
+                    0.04327384907611753
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7879637.579976768,
+            "scoreError" : 116858.33871749269,
+            "scoreConfidence" : [
+                7762779.241259276,
+                7996495.9186942605
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7823017.760750586,
+                "50.0" : 7884611.852150537,
+                "90.0" : 7926941.100633915,
+                "95.0" : 7926941.100633915,
+                "99.0" : 7926941.100633915,
+                "99.9" : 7926941.100633915,
+                "99.99" : 7926941.100633915,
+                "99.999" : 7926941.100633915,
+                "99.9999" : 7926941.100633915,
+                "100.0" : 7926941.100633915
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7842213.956896552,
+                    7869845.870967742,
+                    7823017.760750586
+                ],
+                [
+                    7926941.100633915,
+                    7916428.957278481,
+                    7899377.833333333
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-23T05-22-11Z-30e0cb42962b2fe2f48fd8093d2f571a76a049fc-jdk17.json
+++ b/performance-results/2026-02-23T05-22-11Z-30e0cb42962b2fe2f48fd8093d2f571a76a049fc-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.344378707224687,
+            "scoreError" : 0.05366457720306554,
+            "scoreConfidence" : [
+                3.2907141300216214,
+                3.398043284427753
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3366559399890763,
+                "50.0" : 3.3444674561939176,
+                "90.0" : 3.3519239765218374,
+                "95.0" : 3.3519239765218374,
+                "99.0" : 3.3519239765218374,
+                "99.9" : 3.3519239765218374,
+                "99.99" : 3.3519239765218374,
+                "99.999" : 3.3519239765218374,
+                "99.9999" : 3.3519239765218374,
+                "100.0" : 3.3519239765218374
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.33774756797463,
+                    3.3511873444132054
+                ],
+                [
+                    3.3366559399890763,
+                    3.3519239765218374
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6795139002953448,
+            "scoreError" : 0.03533966287327492,
+            "scoreConfidence" : [
+                1.6441742374220698,
+                1.7148535631686197
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6742545801424358,
+                "50.0" : 1.6790876319808192,
+                "90.0" : 1.6856257570773048,
+                "95.0" : 1.6856257570773048,
+                "99.0" : 1.6856257570773048,
+                "99.9" : 1.6856257570773048,
+                "99.99" : 1.6856257570773048,
+                "99.999" : 1.6856257570773048,
+                "99.9999" : 1.6856257570773048,
+                "100.0" : 1.6856257570773048
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6825766414211953,
+                    1.6856257570773048
+                ],
+                [
+                    1.6755986225404433,
+                    1.6742545801424358
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.846045972370879,
+            "scoreError" : 0.04401641084698775,
+            "scoreConfidence" : [
+                0.8020295615238913,
+                0.8900623832178667
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8394922387607734,
+                "50.0" : 0.8447771982899936,
+                "90.0" : 0.8551372541427554,
+                "95.0" : 0.8551372541427554,
+                "99.0" : 0.8551372541427554,
+                "99.9" : 0.8551372541427554,
+                "99.99" : 0.8551372541427554,
+                "99.999" : 0.8551372541427554,
+                "99.9999" : 0.8551372541427554,
+                "100.0" : 0.8551372541427554
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8394922387607734,
+                    0.8425000507592239
+                ],
+                [
+                    0.8470543458207636,
+                    0.8551372541427554
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.473514937842856,
+            "scoreError" : 0.22622427600741918,
+            "scoreConfidence" : [
+                15.247290661835436,
+                15.699739213850275
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.364643195353633,
+                "50.0" : 15.459552374786295,
+                "90.0" : 15.58021016290836,
+                "95.0" : 15.58021016290836,
+                "99.0" : 15.58021016290836,
+                "99.9" : 15.58021016290836,
+                "99.99" : 15.58021016290836,
+                "99.999" : 15.58021016290836,
+                "99.9999" : 15.58021016290836,
+                "100.0" : 15.58021016290836
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.549766073984113,
+                    15.58021016290836,
+                    15.481579964948432
+                ],
+                [
+                    15.437524784624157,
+                    15.427365445238427,
+                    15.364643195353633
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2602.1463065068933,
+            "scoreError" : 277.88625737903754,
+            "scoreConfidence" : [
+                2324.260049127856,
+                2880.032563885931
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2498.9302922852676,
+                "50.0" : 2596.052549100139,
+                "90.0" : 2709.7681908502204,
+                "95.0" : 2709.7681908502204,
+                "99.0" : 2709.7681908502204,
+                "99.9" : 2709.7681908502204,
+                "99.99" : 2709.7681908502204,
+                "99.999" : 2709.7681908502204,
+                "99.9999" : 2709.7681908502204,
+                "100.0" : 2709.7681908502204
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2537.5944043277827,
+                    2498.9302922852676,
+                    2506.2229906585944
+                ],
+                [
+                    2654.5106938724953,
+                    2709.7681908502204,
+                    2705.851267047001
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 71413.82025784043,
+            "scoreError" : 5313.607314298629,
+            "scoreConfidence" : [
+                66100.2129435418,
+                76727.42757213906
+            ],
+            "scorePercentiles" : {
+                "0.0" : 69530.31698852086,
+                "50.0" : 71348.22620423045,
+                "90.0" : 73468.4637501327,
+                "95.0" : 73468.4637501327,
+                "99.0" : 73468.4637501327,
+                "99.9" : 73468.4637501327,
+                "99.99" : 73468.4637501327,
+                "99.999" : 73468.4637501327,
+                "99.9999" : 73468.4637501327,
+                "100.0" : 73468.4637501327
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72818.76186660332,
+                    73468.4637501327,
+                    73104.0226218726
+                ],
+                [
+                    69877.69054185759,
+                    69683.66577805553,
+                    69530.31698852086
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 344.11644928398624,
+            "scoreError" : 6.368375713584647,
+            "scoreConfidence" : [
+                337.7480735704016,
+                350.4848249975709
+            ],
+            "scorePercentiles" : {
+                "0.0" : 340.6721648016322,
+                "50.0" : 344.36833243993397,
+                "90.0" : 346.8459904950595,
+                "95.0" : 346.8459904950595,
+                "99.0" : 346.8459904950595,
+                "99.9" : 346.8459904950595,
+                "99.99" : 346.8459904950595,
+                "99.999" : 346.8459904950595,
+                "99.9999" : 346.8459904950595,
+                "100.0" : 346.8459904950595
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    346.8459904950595,
+                    345.16695261142274,
+                    345.8108883379951
+                ],
+                [
+                    340.6721648016322,
+                    342.63298718936284,
+                    343.56971226844524
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 122.01510569150746,
+            "scoreError" : 6.425731306227055,
+            "scoreConfidence" : [
+                115.58937438528041,
+                128.44083699773452
+            ],
+            "scorePercentiles" : {
+                "0.0" : 119.21050757522661,
+                "50.0" : 122.15862530809187,
+                "90.0" : 124.44119574849323,
+                "95.0" : 124.44119574849323,
+                "99.0" : 124.44119574849323,
+                "99.9" : 124.44119574849323,
+                "99.99" : 124.44119574849323,
+                "99.999" : 124.44119574849323,
+                "99.9999" : 124.44119574849323,
+                "100.0" : 124.44119574849323
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    124.12667110155738,
+                    124.44119574849323,
+                    123.5589773816139
+                ],
+                [
+                    120.75827323456984,
+                    119.9950091075837,
+                    119.21050757522661
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06416337915311855,
+            "scoreError" : 0.0033823156896567357,
+            "scoreConfidence" : [
+                0.060781063463461814,
+                0.06754569484277528
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06289310924390888,
+                "50.0" : 0.06414305468829472,
+                "90.0" : 0.06587633932135728,
+                "95.0" : 0.06587633932135728,
+                "99.0" : 0.06587633932135728,
+                "99.9" : 0.06587633932135728,
+                "99.99" : 0.06587633932135728,
+                "99.999" : 0.06587633932135728,
+                "99.9999" : 0.06587633932135728,
+                "100.0" : 0.06587633932135728
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0647120404441741,
+                    0.06587633932135728,
+                    0.06496166671430427
+                ],
+                [
+                    0.06289310924390888,
+                    0.06357406893241534,
+                    0.06296305026255147
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.9292397147954475E-4,
+            "scoreError" : 1.0635601324814912E-5,
+            "scoreConfidence" : [
+                3.8228837015472983E-4,
+                4.0355957280435967E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.8832097828959104E-4,
+                "50.0" : 3.9278522983237035E-4,
+                "90.0" : 3.9956561104685293E-4,
+                "95.0" : 3.9956561104685293E-4,
+                "99.0" : 3.9956561104685293E-4,
+                "99.9" : 3.9956561104685293E-4,
+                "99.99" : 3.9956561104685293E-4,
+                "99.999" : 3.9956561104685293E-4,
+                "99.9999" : 3.9956561104685293E-4,
+                "100.0" : 3.9956561104685293E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.9045965729579067E-4,
+                    3.936271225802937E-4,
+                    3.8832097828959104E-4
+                ],
+                [
+                    3.9956561104685293E-4,
+                    3.9268429641979547E-4,
+                    3.928861632449453E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.263352323769743,
+            "scoreError" : 0.052059214130279675,
+            "scoreConfidence" : [
+                2.2112931096394632,
+                2.3154115379000224
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2049288386243386,
+                "50.0" : 2.257466282668683,
+                "90.0" : 2.3295245171891112,
+                "95.0" : 2.3341357911318554,
+                "99.0" : 2.3341357911318554,
+                "99.9" : 2.3341357911318554,
+                "99.99" : 2.3341357911318554,
+                "99.999" : 2.3341357911318554,
+                "99.9999" : 2.3341357911318554,
+                "100.0" : 2.3341357911318554
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.264899307744565,
+                    2.2880230517044153,
+                    2.247800752079119,
+                    2.2472485829213484,
+                    2.2049288386243386
+                ],
+                [
+                    2.3341357911318554,
+                    2.2696900898570456,
+                    2.250033257592801,
+                    2.2419588861241873,
+                    2.2848046799177517
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013627077706070466,
+            "scoreError" : 2.767449464078205E-4,
+            "scoreConfidence" : [
+                0.013350332759662645,
+                0.013903822652478286
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01352128097311929,
+                "50.0" : 0.013637527738755406,
+                "90.0" : 0.01378304315910181,
+                "95.0" : 0.01378304315910181,
+                "99.0" : 0.01378304315910181,
+                "99.9" : 0.01378304315910181,
+                "99.99" : 0.01378304315910181,
+                "99.999" : 0.01378304315910181,
+                "99.9999" : 0.01378304315910181,
+                "100.0" : 0.01378304315910181
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01352128097311929,
+                    0.013521942939548292,
+                    0.013656868209527556
+                ],
+                [
+                    0.013661143687142595,
+                    0.013618187267983256,
+                    0.01378304315910181
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0439548469673774,
+            "scoreError" : 0.06901600593103022,
+            "scoreConfidence" : [
+                0.9749388410363472,
+                1.1129708528984077
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.018734604461648,
+                "50.0" : 1.0442114364544963,
+                "90.0" : 1.0713745301049924,
+                "95.0" : 1.0713745301049924,
+                "99.0" : 1.0713745301049924,
+                "99.9" : 1.0713745301049924,
+                "99.99" : 1.0713745301049924,
+                "99.999" : 1.0713745301049924,
+                "99.9999" : 1.0713745301049924,
+                "100.0" : 1.0713745301049924
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0713745301049924,
+                    1.066212471108742,
+                    1.0603630695578412
+                ],
+                [
+                    1.01898460321989,
+                    1.018734604461648,
+                    1.0280598033511512
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01060814994474555,
+            "scoreError" : 3.678389664866102E-4,
+            "scoreConfidence" : [
+                0.01024031097825894,
+                0.01097598891123216
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010443945563539142,
+                "50.0" : 0.010654409839482244,
+                "90.0" : 0.01072987096704971,
+                "95.0" : 0.01072987096704971,
+                "99.0" : 0.01072987096704971,
+                "99.9" : 0.01072987096704971,
+                "99.99" : 0.01072987096704971,
+                "99.999" : 0.01072987096704971,
+                "99.9999" : 0.01072987096704971,
+                "100.0" : 0.01072987096704971
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010443945563539142,
+                    0.01045050801009073,
+                    0.010612306806122709
+                ],
+                [
+                    0.01069651287284178,
+                    0.010715755448829224,
+                    0.01072987096704971
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.322924732610339,
+            "scoreError" : 0.09526383806984873,
+            "scoreConfidence" : [
+                3.2276608945404903,
+                3.4181885706801878
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.26606731809275,
+                "50.0" : 3.3297994255678613,
+                "90.0" : 3.366575767833109,
+                "95.0" : 3.366575767833109,
+                "99.0" : 3.366575767833109,
+                "99.9" : 3.366575767833109,
+                "99.99" : 3.366575767833109,
+                "99.999" : 3.366575767833109,
+                "99.9999" : 3.366575767833109,
+                "100.0" : 3.366575767833109
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.366575767833109,
+                    3.331126256990679,
+                    3.338995124165554
+                ],
+                [
+                    3.328472594145043,
+                    3.3063113344348976,
+                    3.26606731809275
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.895233507971516,
+            "scoreError" : 0.06712536395902872,
+            "scoreConfidence" : [
+                2.8281081440124876,
+                2.9623588719305447
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8720014758759334,
+                "50.0" : 2.8862541960545385,
+                "90.0" : 2.9304618570172867,
+                "95.0" : 2.9304618570172867,
+                "99.0" : 2.9304618570172867,
+                "99.9" : 2.9304618570172867,
+                "99.99" : 2.9304618570172867,
+                "99.999" : 2.9304618570172867,
+                "99.9999" : 2.9304618570172867,
+                "100.0" : 2.9304618570172867
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.919064502918856,
+                    2.8720014758759334,
+                    2.882023030259366
+                ],
+                [
+                    2.8773648199079402,
+                    2.890485361849711,
+                    2.9304618570172867
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4098140200033591,
+            "scoreError" : 0.011332272851316582,
+            "scoreConfidence" : [
+                0.3984817471520425,
+                0.4211462928546757
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40509968476059305,
+                "50.0" : 0.41040478640014555,
+                "90.0" : 0.4143728490925665,
+                "95.0" : 0.4143728490925665,
+                "99.0" : 0.4143728490925665,
+                "99.9" : 0.4143728490925665,
+                "99.99" : 0.4143728490925665,
+                "99.999" : 0.4143728490925665,
+                "99.9999" : 0.4143728490925665,
+                "100.0" : 0.4143728490925665
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40509968476059305,
+                    0.4052930556050904,
+                    0.408777396705363
+                ],
+                [
+                    0.41330895776161347,
+                    0.4120321760949281,
+                    0.4143728490925665
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16412185499160017,
+            "scoreError" : 0.003772174399138426,
+            "scoreConfidence" : [
+                0.16034968059246174,
+                0.1678940293907386
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.16243146377870904,
+                "50.0" : 0.1641169543719191,
+                "90.0" : 0.16570262450704226,
+                "95.0" : 0.16570262450704226,
+                "99.0" : 0.16570262450704226,
+                "99.9" : 0.16570262450704226,
+                "99.99" : 0.16570262450704226,
+                "99.999" : 0.16570262450704226,
+                "99.9999" : 0.16570262450704226,
+                "100.0" : 0.16570262450704226
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16494130667986145,
+                    0.16525980198968798,
+                    0.16570262450704226
+                ],
+                [
+                    0.16329260206397675,
+                    0.1631033309303236,
+                    0.16243146377870904
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.41722596664609685,
+            "scoreError" : 0.0177977310092622,
+            "scoreConfidence" : [
+                0.39942823563683466,
+                0.43502369765535903
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4110335009864365,
+                "50.0" : 0.416271584889903,
+                "90.0" : 0.42713244381326615,
+                "95.0" : 0.42713244381326615,
+                "99.0" : 0.42713244381326615,
+                "99.9" : 0.42713244381326615,
+                "99.99" : 0.42713244381326615,
+                "99.999" : 0.42713244381326615,
+                "99.9999" : 0.42713244381326615,
+                "100.0" : 0.42713244381326615
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4123166329265276,
+                    0.41243958007176146,
+                    0.4110335009864365
+                ],
+                [
+                    0.42713244381326615,
+                    0.4201035897080445,
+                    0.4203300523705447
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14735980503518378,
+            "scoreError" : 0.002474102301434107,
+            "scoreConfidence" : [
+                0.14488570273374968,
+                0.1498339073366179
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14636155086717892,
+                "50.0" : 0.14736326305897296,
+                "90.0" : 0.14839878870125245,
+                "95.0" : 0.14839878870125245,
+                "99.0" : 0.14839878870125245,
+                "99.9" : 0.14839878870125245,
+                "99.99" : 0.14839878870125245,
+                "99.999" : 0.14839878870125245,
+                "99.9999" : 0.14839878870125245,
+                "100.0" : 0.14839878870125245
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14839878870125245,
+                    0.14786256613733145,
+                    0.1481472782436076
+                ],
+                [
+                    0.14686395998061447,
+                    0.14652468628111767,
+                    0.14636155086717892
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.043476726973663615,
+            "scoreError" : 0.0018101821346939522,
+            "scoreConfidence" : [
+                0.041666544838969664,
+                0.045286909108357566
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04281863086659216,
+                "50.0" : 0.043503281602255764,
+                "90.0" : 0.04412065531937422,
+                "95.0" : 0.04412065531937422,
+                "99.0" : 0.04412065531937422,
+                "99.9" : 0.04412065531937422,
+                "99.99" : 0.04412065531937422,
+                "99.999" : 0.04412065531937422,
+                "99.9999" : 0.04412065531937422,
+                "100.0" : 0.04412065531937422
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.044042294942768685,
+                    0.04402725258106412,
+                    0.04412065531937422
+                ],
+                [
+                    0.04281863086659216,
+                    0.0429793106234474,
+                    0.04287221750873507
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8223401.410217701,
+            "scoreError" : 310403.0645324089,
+            "scoreConfidence" : [
+                7912998.345685293,
+                8533804.47475011
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8050567.135961384,
+                "50.0" : 8248898.170472385,
+                "90.0" : 8355613.007518797,
+                "95.0" : 8355613.007518797,
+                "99.0" : 8355613.007518797,
+                "99.9" : 8355613.007518797,
+                "99.99" : 8355613.007518797,
+                "99.999" : 8355613.007518797,
+                "99.9999" : 8355613.007518797,
+                "100.0" : 8355613.007518797
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8245938.77493817,
+                    8139028.429617575,
+                    8050567.135961384
+                ],
+                [
+                    8251857.566006601,
+                    8355613.007518797,
+                    8297403.547263682
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-24T20-17-52Z-bdd53e6e1911eae2d74f29c3abeb8c9371aa42b3-jdk17.json
+++ b/performance-results/2026-02-24T20-17-52Z-bdd53e6e1911eae2d74f29c3abeb8c9371aa42b3-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3427487882170173,
+            "scoreError" : 0.036761026319910205,
+            "scoreConfidence" : [
+                3.305987761897107,
+                3.3795098145369273
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.334935579264715,
+                "50.0" : 3.3442251077136023,
+                "90.0" : 3.347609358176151,
+                "95.0" : 3.347609358176151,
+                "99.0" : 3.347609358176151,
+                "99.9" : 3.347609358176151,
+                "99.99" : 3.347609358176151,
+                "99.999" : 3.347609358176151,
+                "99.9999" : 3.347609358176151,
+                "100.0" : 3.347609358176151
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.342217964454981,
+                    3.346232250972223
+                ],
+                [
+                    3.334935579264715,
+                    3.347609358176151
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6876057979259624,
+            "scoreError" : 0.01972439763461753,
+            "scoreConfidence" : [
+                1.667881400291345,
+                1.70733019556058
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6847012670474812,
+                "50.0" : 1.6871706225413936,
+                "90.0" : 1.691380679573581,
+                "95.0" : 1.691380679573581,
+                "99.0" : 1.691380679573581,
+                "99.9" : 1.691380679573581,
+                "99.99" : 1.691380679573581,
+                "99.999" : 1.691380679573581,
+                "99.9999" : 1.691380679573581,
+                "100.0" : 1.691380679573581
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.691380679573581,
+                    1.6847012670474812
+                ],
+                [
+                    1.685607589448013,
+                    1.688733655634774
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8470953715402356,
+            "scoreError" : 0.037954859106842716,
+            "scoreConfidence" : [
+                0.8091405124333929,
+                0.8850502306470783
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8408257869563069,
+                "50.0" : 0.8475044724585434,
+                "90.0" : 0.8525467542875483,
+                "95.0" : 0.8525467542875483,
+                "99.0" : 0.8525467542875483,
+                "99.9" : 0.8525467542875483,
+                "99.99" : 0.8525467542875483,
+                "99.999" : 0.8525467542875483,
+                "99.9999" : 0.8525467542875483,
+                "100.0" : 0.8525467542875483
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8516358163464217,
+                    0.8525467542875483
+                ],
+                [
+                    0.8408257869563069,
+                    0.8433731285706653
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.081769200879236,
+            "scoreError" : 0.3528440710502168,
+            "scoreConfidence" : [
+                15.728925129829019,
+                16.434613271929454
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.977925959396286,
+                "50.0" : 16.035916100449832,
+                "90.0" : 16.29987282928393,
+                "95.0" : 16.29987282928393,
+                "99.0" : 16.29987282928393,
+                "99.9" : 16.29987282928393,
+                "99.99" : 16.29987282928393,
+                "99.999" : 16.29987282928393,
+                "99.9999" : 16.29987282928393,
+                "100.0" : 16.29987282928393
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.98385380549499,
+                    16.010045690030243,
+                    15.977925959396286
+                ],
+                [
+                    16.15713041020054,
+                    16.29987282928393,
+                    16.061786510869418
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2666.1269459497803,
+            "scoreError" : 145.44985973493374,
+            "scoreConfidence" : [
+                2520.6770862148464,
+                2811.576805684714
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2611.935853084249,
+                "50.0" : 2670.842696941382,
+                "90.0" : 2715.0789167633993,
+                "95.0" : 2715.0789167633993,
+                "99.0" : 2715.0789167633993,
+                "99.9" : 2715.0789167633993,
+                "99.99" : 2715.0789167633993,
+                "99.999" : 2715.0789167633993,
+                "99.9999" : 2715.0789167633993,
+                "100.0" : 2715.0789167633993
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2615.3352139283356,
+                    2611.935853084249,
+                    2630.080418093891
+                ],
+                [
+                    2711.6049757888736,
+                    2715.0789167633993,
+                    2712.7262980399337
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74191.96936283483,
+            "scoreError" : 462.55176760187493,
+            "scoreConfidence" : [
+                73729.41759523295,
+                74654.52113043671
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73995.95688639536,
+                "50.0" : 74204.04015011284,
+                "90.0" : 74389.91567027221,
+                "95.0" : 74389.91567027221,
+                "99.0" : 74389.91567027221,
+                "99.9" : 74389.91567027221,
+                "99.99" : 74389.91567027221,
+                "99.999" : 74389.91567027221,
+                "99.9999" : 74389.91567027221,
+                "100.0" : 74389.91567027221
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74348.76361449665,
+                    74389.91567027221,
+                    74196.21676657465
+                ],
+                [
+                    73995.95688639536,
+                    74009.09970561916,
+                    74211.86353365102
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 345.46689831751115,
+            "scoreError" : 19.16736192599213,
+            "scoreConfidence" : [
+                326.29953639151904,
+                364.63426024350326
+            ],
+            "scorePercentiles" : {
+                "0.0" : 338.53806963979184,
+                "50.0" : 345.0220223805475,
+                "90.0" : 354.01935842597123,
+                "95.0" : 354.01935842597123,
+                "99.0" : 354.01935842597123,
+                "99.9" : 354.01935842597123,
+                "99.99" : 354.01935842597123,
+                "99.999" : 354.01935842597123,
+                "99.9999" : 354.01935842597123,
+                "100.0" : 354.01935842597123
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    339.6300175706925,
+                    339.9256789894714,
+                    338.53806963979184
+                ],
+                [
+                    354.01935842597123,
+                    350.5698995075164,
+                    350.11836577162364
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 124.75453875916044,
+            "scoreError" : 2.1557605808307447,
+            "scoreConfidence" : [
+                122.5987781783297,
+                126.91029933999118
+            ],
+            "scorePercentiles" : {
+                "0.0" : 123.55019284010979,
+                "50.0" : 124.72070616896582,
+                "90.0" : 125.91111924019945,
+                "95.0" : 125.91111924019945,
+                "99.0" : 125.91111924019945,
+                "99.9" : 125.91111924019945,
+                "99.99" : 125.91111924019945,
+                "99.999" : 125.91111924019945,
+                "99.9999" : 125.91111924019945,
+                "100.0" : 125.91111924019945
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    125.09303939797157,
+                    124.70978965219565,
+                    125.91111924019945
+                ],
+                [
+                    124.53146873875026,
+                    124.73162268573599,
+                    123.55019284010979
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.062161344913961636,
+            "scoreError" : 8.350500082871119E-4,
+            "scoreConfidence" : [
+                0.061326294905674525,
+                0.06299639492224875
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06182238755903954,
+                "50.0" : 0.06217541105078965,
+                "90.0" : 0.06248762114300711,
+                "95.0" : 0.06248762114300711,
+                "99.0" : 0.06248762114300711,
+                "99.9" : 0.06248762114300711,
+                "99.99" : 0.06248762114300711,
+                "99.999" : 0.06248762114300711,
+                "99.9999" : 0.06248762114300711,
+                "100.0" : 0.06248762114300711
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.061835186485533905,
+                    0.06207865670316846,
+                    0.06227216539841084
+                ],
+                [
+                    0.062472052194609995,
+                    0.06248762114300711,
+                    0.06182238755903954
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.729520019047395E-4,
+            "scoreError" : 2.830968069941606E-5,
+            "scoreConfidence" : [
+                3.4464232120532345E-4,
+                4.012616826041556E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.639145648374142E-4,
+                "50.0" : 3.7011821529051747E-4,
+                "90.0" : 3.847059404202201E-4,
+                "95.0" : 3.847059404202201E-4,
+                "99.0" : 3.847059404202201E-4,
+                "99.9" : 3.847059404202201E-4,
+                "99.99" : 3.847059404202201E-4,
+                "99.999" : 3.847059404202201E-4,
+                "99.9999" : 3.847059404202201E-4,
+                "100.0" : 3.847059404202201E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.641946159890868E-4,
+                    3.639145648374142E-4,
+                    3.6464440179518725E-4
+                ],
+                [
+                    3.755920287858477E-4,
+                    3.8466045960068097E-4,
+                    3.847059404202201E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.207414091518584,
+            "scoreError" : 0.08716402688607945,
+            "scoreConfidence" : [
+                2.120250064632504,
+                2.2945781184046634
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.137666011113486,
+                "50.0" : 2.178005675229536,
+                "90.0" : 2.3017807587718213,
+                "95.0" : 2.3044207801843317,
+                "99.0" : 2.3044207801843317,
+                "99.9" : 2.3044207801843317,
+                "99.99" : 2.3044207801843317,
+                "99.999" : 2.3044207801843317,
+                "99.9999" : 2.3044207801843317,
+                "100.0" : 2.3044207801843317
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3044207801843317,
+                    2.270732166628831,
+                    2.1723073301476976,
+                    2.180936034234627,
+                    2.171655770684039
+                ],
+                [
+                    2.2780205660592254,
+                    2.2224182257777776,
+                    2.137666011113486,
+                    2.160908714131374,
+                    2.1750753162244454
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013805358755430588,
+            "scoreError" : 4.988117929782927E-4,
+            "scoreConfidence" : [
+                0.013306546962452296,
+                0.01430417054840888
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01362073584586991,
+                "50.0" : 0.013806098123362098,
+                "90.0" : 0.013973970849298377,
+                "95.0" : 0.013973970849298377,
+                "99.0" : 0.013973970849298377,
+                "99.9" : 0.013973970849298377,
+                "99.99" : 0.013973970849298377,
+                "99.999" : 0.013973970849298377,
+                "99.9999" : 0.013973970849298377,
+                "100.0" : 0.013973970849298377
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013655382894409837,
+                    0.013654264588336977,
+                    0.01362073584586991
+                ],
+                [
+                    0.013956813352314358,
+                    0.013970985002354079,
+                    0.013973970849298377
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0748760154115253,
+            "scoreError" : 0.08461266799472592,
+            "scoreConfidence" : [
+                0.9902633474167994,
+                1.1594886834062512
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0463074849879694,
+                "50.0" : 1.0744333591102648,
+                "90.0" : 1.103875638410596,
+                "95.0" : 1.103875638410596,
+                "99.0" : 1.103875638410596,
+                "99.9" : 1.103875638410596,
+                "99.99" : 1.103875638410596,
+                "99.999" : 1.103875638410596,
+                "99.9999" : 1.103875638410596,
+                "100.0" : 1.103875638410596
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0996068288070369,
+                    1.103875638410596,
+                    1.1036269516662989
+                ],
+                [
+                    1.0492598894134928,
+                    1.0465792991837588,
+                    1.0463074849879694
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010526998638310222,
+            "scoreError" : 1.583964676845863E-4,
+            "scoreConfidence" : [
+                0.010368602170625634,
+                0.010685395105994809
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010472858515957013,
+                "50.0" : 0.010514510550623135,
+                "90.0" : 0.010594986178122741,
+                "95.0" : 0.010594986178122741,
+                "99.0" : 0.010594986178122741,
+                "99.9" : 0.010594986178122741,
+                "99.99" : 0.010594986178122741,
+                "99.999" : 0.010594986178122741,
+                "99.9999" : 0.010594986178122741,
+                "100.0" : 0.010594986178122741
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01047387400108506,
+                    0.010490666410001952,
+                    0.010472858515957013
+                ],
+                [
+                    0.010594986178122741,
+                    0.010591252033450257,
+                    0.010538354691244317
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.4184177771248767,
+            "scoreError" : 0.33788155088778876,
+            "scoreConfidence" : [
+                3.080536226237088,
+                3.7562993280126653
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.306390982815598,
+                "50.0" : 3.413934630912455,
+                "90.0" : 3.5367461315417255,
+                "95.0" : 3.5367461315417255,
+                "99.0" : 3.5367461315417255,
+                "99.9" : 3.5367461315417255,
+                "99.99" : 3.5367461315417255,
+                "99.999" : 3.5367461315417255,
+                "99.9999" : 3.5367461315417255,
+                "100.0" : 3.5367461315417255
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.306390982815598,
+                    3.3103773223031103,
+                    3.308962494047619
+                ],
+                [
+                    3.5174919395218,
+                    3.5305377925194072,
+                    3.5367461315417255
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.9353236127942623,
+            "scoreError" : 0.029931706238554873,
+            "scoreConfidence" : [
+                2.9053919065557077,
+                2.965255319032817
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.921134886390187,
+                "50.0" : 2.9376987377566453,
+                "90.0" : 2.9477320949012675,
+                "95.0" : 2.9477320949012675,
+                "99.0" : 2.9477320949012675,
+                "99.9" : 2.9477320949012675,
+                "99.99" : 2.9477320949012675,
+                "99.999" : 2.9477320949012675,
+                "99.9999" : 2.9477320949012675,
+                "100.0" : 2.9477320949012675
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9477320949012675,
+                    2.943629603001766,
+                    2.9395634147560257
+                ],
+                [
+                    2.9358340607572644,
+                    2.921134886390187,
+                    2.924047616959064
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.38533635477390354,
+            "scoreError" : 0.010914978717345706,
+            "scoreConfidence" : [
+                0.37442137605655784,
+                0.39625133349124925
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.38023594326996196,
+                "50.0" : 0.38513627561604785,
+                "90.0" : 0.38961468928974946,
+                "95.0" : 0.38961468928974946,
+                "99.0" : 0.38961468928974946,
+                "99.9" : 0.38961468928974946,
+                "99.99" : 0.38961468928974946,
+                "99.999" : 0.38961468928974946,
+                "99.9999" : 0.38961468928974946,
+                "100.0" : 0.38961468928974946
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3873020541807056,
+                    0.38961468928974946,
+                    0.3892052964894528
+                ],
+                [
+                    0.3829704970513901,
+                    0.38023594326996196,
+                    0.38268964836216135
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16125003266876434,
+            "scoreError" : 0.005292857466024851,
+            "scoreConfidence" : [
+                0.1559571752027395,
+                0.16654289013478918
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1584108591750095,
+                "50.0" : 0.16142466037491843,
+                "90.0" : 0.1630182755118675,
+                "95.0" : 0.1630182755118675,
+                "99.0" : 0.1630182755118675,
+                "99.9" : 0.1630182755118675,
+                "99.99" : 0.1630182755118675,
+                "99.999" : 0.1630182755118675,
+                "99.9999" : 0.1630182755118675,
+                "100.0" : 0.1630182755118675
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1603178963576902,
+                    0.16022268096901338,
+                    0.1584108591750095
+                ],
+                [
+                    0.1629990596068588,
+                    0.1630182755118675,
+                    0.16253142439214666
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4117571047874942,
+            "scoreError" : 0.018172152694659743,
+            "scoreConfidence" : [
+                0.3935849520928345,
+                0.42992925748215394
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4044626827906977,
+                "50.0" : 0.41317927493395595,
+                "90.0" : 0.41755458526096034,
+                "95.0" : 0.41755458526096034,
+                "99.0" : 0.41755458526096034,
+                "99.9" : 0.41755458526096034,
+                "99.99" : 0.41755458526096034,
+                "99.999" : 0.41755458526096034,
+                "99.9999" : 0.41755458526096034,
+                "100.0" : 0.41755458526096034
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4089292847679411,
+                    0.4046772149967627,
+                    0.4044626827906977
+                ],
+                [
+                    0.4174895958086332,
+                    0.41755458526096034,
+                    0.4174292650999708
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14493691339081963,
+            "scoreError" : 0.002165301389845214,
+            "scoreConfidence" : [
+                0.1427716120009744,
+                0.14710221478066485
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14415738242756235,
+                "50.0" : 0.1449021948984014,
+                "90.0" : 0.14591317700445028,
+                "95.0" : 0.14591317700445028,
+                "99.0" : 0.14591317700445028,
+                "99.9" : 0.14591317700445028,
+                "99.99" : 0.14591317700445028,
+                "99.999" : 0.14591317700445028,
+                "99.9999" : 0.14591317700445028,
+                "100.0" : 0.14591317700445028
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14591317700445028,
+                    0.14534934146306014,
+                    0.14415738242756235
+                ],
+                [
+                    0.14558392013393506,
+                    0.14445504833374262,
+                    0.14416261098216732
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04396021509462405,
+            "scoreError" : 9.23212237929953E-4,
+            "scoreConfidence" : [
+                0.043037002856694095,
+                0.044883427332554
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04364848220972965,
+                "50.0" : 0.04385670439116466,
+                "90.0" : 0.04452113725647327,
+                "95.0" : 0.04452113725647327,
+                "99.0" : 0.04452113725647327,
+                "99.9" : 0.04452113725647327,
+                "99.99" : 0.04452113725647327,
+                "99.999" : 0.04452113725647327,
+                "99.9999" : 0.04452113725647327,
+                "100.0" : 0.04452113725647327
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.044162105624815075,
+                    0.04371615669439696,
+                    0.04364848220972965
+                ],
+                [
+                    0.04452113725647327,
+                    0.0439214568213561,
+                    0.04379195196097322
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8039039.863168295,
+            "scoreError" : 194763.23609478967,
+            "scoreConfidence" : [
+                7844276.627073505,
+                8233803.099263084
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7899039.571090047,
+                "50.0" : 8061243.925595365,
+                "90.0" : 8086484.478577203,
+                "95.0" : 8086484.478577203,
+                "99.0" : 8086484.478577203,
+                "99.9" : 8086484.478577203,
+                "99.99" : 8086484.478577203,
+                "99.999" : 8086484.478577203,
+                "99.9999" : 8086484.478577203,
+                "100.0" : 8086484.478577203
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8086484.478577203,
+                    8070222.732258065,
+                    8064584.178887993
+                ],
+                [
+                    7899039.571090047,
+                    8057903.672302738,
+                    8056004.545893719
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-27T23-32-54Z-1e867c2e8cf4007d5e43270e4c10f28e478db26e-jdk17.json
+++ b/performance-results/2026-02-27T23-32-54Z-1e867c2e8cf4007d5e43270e4c10f28e478db26e-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.376251084661484,
+            "scoreError" : 0.014909005956124313,
+            "scoreConfidence" : [
+                3.3613420787053596,
+                3.3911600906176083
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3739096273662876,
+                "50.0" : 3.376360706944386,
+                "90.0" : 3.3783732973908753,
+                "95.0" : 3.3783732973908753,
+                "99.0" : 3.3783732973908753,
+                "99.9" : 3.3783732973908753,
+                "99.99" : 3.3783732973908753,
+                "99.999" : 3.3783732973908753,
+                "99.9999" : 3.3783732973908753,
+                "100.0" : 3.3783732973908753
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.374634574407323,
+                    3.3783732973908753
+                ],
+                [
+                    3.3739096273662876,
+                    3.3780868394814494
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.703683576004115,
+            "scoreError" : 0.028551748995901242,
+            "scoreConfidence" : [
+                1.6751318270082136,
+                1.7322353250000162
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6972767010328766,
+                "50.0" : 1.705020772988059,
+                "90.0" : 1.7074160570074646,
+                "95.0" : 1.7074160570074646,
+                "99.0" : 1.7074160570074646,
+                "99.9" : 1.7074160570074646,
+                "99.99" : 1.7074160570074646,
+                "99.999" : 1.7074160570074646,
+                "99.9999" : 1.7074160570074646,
+                "100.0" : 1.7074160570074646
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6972767010328766,
+                    1.7074160570074646
+                ],
+                [
+                    1.704944897625376,
+                    1.705096648350742
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8603282760509439,
+            "scoreError" : 0.018308350472582124,
+            "scoreConfidence" : [
+                0.8420199255783617,
+                0.878636626523526
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8574947475073903,
+                "50.0" : 0.8598202249212601,
+                "90.0" : 0.8641779068538651,
+                "95.0" : 0.8641779068538651,
+                "99.0" : 0.8641779068538651,
+                "99.9" : 0.8641779068538651,
+                "99.99" : 0.8641779068538651,
+                "99.999" : 0.8641779068538651,
+                "99.9999" : 0.8641779068538651,
+                "100.0" : 0.8641779068538651
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8592215050380407,
+                    0.8641779068538651
+                ],
+                [
+                    0.8574947475073903,
+                    0.8604189448044794
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.402956886695183,
+            "scoreError" : 0.11465753119131519,
+            "scoreConfidence" : [
+                16.288299355503867,
+                16.5176144178865
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.34633616884575,
+                "50.0" : 16.407627990256056,
+                "90.0" : 16.447882027733005,
+                "95.0" : 16.447882027733005,
+                "99.0" : 16.447882027733005,
+                "99.9" : 16.447882027733005,
+                "99.99" : 16.447882027733005,
+                "99.999" : 16.447882027733005,
+                "99.9999" : 16.447882027733005,
+                "100.0" : 16.447882027733005
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.431295459947854,
+                    16.435504376226334,
+                    16.447882027733005
+                ],
+                [
+                    16.38396052056426,
+                    16.34633616884575,
+                    16.37276276685389
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2857.711545407818,
+            "scoreError" : 69.85820245962961,
+            "scoreConfidence" : [
+                2787.8533429481886,
+                2927.5697478674474
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2830.69704553314,
+                "50.0" : 2857.3481848744295,
+                "90.0" : 2882.9790432084556,
+                "95.0" : 2882.9790432084556,
+                "99.0" : 2882.9790432084556,
+                "99.9" : 2882.9790432084556,
+                "99.99" : 2882.9790432084556,
+                "99.999" : 2882.9790432084556,
+                "99.9999" : 2882.9790432084556,
+                "100.0" : 2882.9790432084556
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2837.2579580480747,
+                    2830.69704553314,
+                    2837.466521226202
+                ],
+                [
+                    2877.2298485226565,
+                    2882.9790432084556,
+                    2880.638855908378
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 75110.20806196773,
+            "scoreError" : 2507.2318433075407,
+            "scoreConfidence" : [
+                72602.97621866019,
+                77617.43990527527
+            ],
+            "scorePercentiles" : {
+                "0.0" : 74274.05050766632,
+                "50.0" : 75125.77327634994,
+                "90.0" : 75930.76390276337,
+                "95.0" : 75930.76390276337,
+                "99.0" : 75930.76390276337,
+                "99.9" : 75930.76390276337,
+                "99.99" : 75930.76390276337,
+                "99.999" : 75930.76390276337,
+                "99.9999" : 75930.76390276337,
+                "100.0" : 75930.76390276337
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74274.33138548462,
+                    74334.41854246492,
+                    74274.05050766632
+                ],
+                [
+                    75930.76390276337,
+                    75917.12801023494,
+                    75930.55602319218
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 356.7215424543677,
+            "scoreError" : 1.896074966646615,
+            "scoreConfidence" : [
+                354.8254674877211,
+                358.6176174210143
+            ],
+            "scorePercentiles" : {
+                "0.0" : 355.43560882303933,
+                "50.0" : 356.93539801129907,
+                "90.0" : 357.276280927896,
+                "95.0" : 357.276280927896,
+                "99.0" : 357.276280927896,
+                "99.9" : 357.276280927896,
+                "99.99" : 357.276280927896,
+                "99.999" : 357.276280927896,
+                "99.9999" : 357.276280927896,
+                "100.0" : 357.276280927896
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    357.1037282273553,
+                    357.12862970042323,
+                    357.276280927896
+                ],
+                [
+                    355.43560882303933,
+                    356.6179392522492,
+                    356.7670677952429
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 126.2146334188432,
+            "scoreError" : 0.492151918840692,
+            "scoreConfidence" : [
+                125.72248150000252,
+                126.7067853376839
+            ],
+            "scorePercentiles" : {
+                "0.0" : 125.99769061352828,
+                "50.0" : 126.26748508000036,
+                "90.0" : 126.43693410439619,
+                "95.0" : 126.43693410439619,
+                "99.0" : 126.43693410439619,
+                "99.9" : 126.43693410439619,
+                "99.99" : 126.43693410439619,
+                "99.999" : 126.43693410439619,
+                "99.9999" : 126.43693410439619,
+                "100.0" : 126.43693410439619
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    126.27785229164778,
+                    125.99769061352828,
+                    126.31003551300282
+                ],
+                [
+                    126.00817012213118,
+                    126.25711786835294,
+                    126.43693410439619
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06068622011897249,
+            "scoreError" : 6.735065733302237E-4,
+            "scoreConfidence" : [
+                0.06001271354564227,
+                0.06135972669230271
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06045014865681747,
+                "50.0" : 0.0606894715440303,
+                "90.0" : 0.060916028489976425,
+                "95.0" : 0.060916028489976425,
+                "99.0" : 0.060916028489976425,
+                "99.9" : 0.060916028489976425,
+                "99.99" : 0.060916028489976425,
+                "99.999" : 0.060916028489976425,
+                "99.9999" : 0.060916028489976425,
+                "100.0" : 0.060916028489976425
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.060907445567831606,
+                    0.060916028489976425,
+                    0.06089180702438074
+                ],
+                [
+                    0.06046475491114887,
+                    0.06048713606367986,
+                    0.06045014865681747
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6027249815165753E-4,
+            "scoreError" : 1.9768064866982026E-5,
+            "scoreConfidence" : [
+                3.405044332846755E-4,
+                3.800405630186396E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.538063677277176E-4,
+                "50.0" : 3.601636677335129E-4,
+                "90.0" : 3.670721791573924E-4,
+                "95.0" : 3.670721791573924E-4,
+                "99.0" : 3.670721791573924E-4,
+                "99.9" : 3.670721791573924E-4,
+                "99.99" : 3.670721791573924E-4,
+                "99.999" : 3.670721791573924E-4,
+                "99.9999" : 3.670721791573924E-4,
+                "100.0" : 3.670721791573924E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.538654008739526E-4,
+                    3.5384812692626277E-4,
+                    3.538063677277176E-4
+                ],
+                [
+                    3.670721791573924E-4,
+                    3.665809796315467E-4,
+                    3.664619345930732E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1602508577376107,
+            "scoreError" : 0.06115809700939772,
+            "scoreConfidence" : [
+                2.099092760728213,
+                2.2214089547470084
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.112896644200296,
+                "50.0" : 2.159281868739206,
+                "90.0" : 2.234889463468825,
+                "95.0" : 2.2388106832325945,
+                "99.0" : 2.2388106832325945,
+                "99.9" : 2.2388106832325945,
+                "99.99" : 2.2388106832325945,
+                "99.999" : 2.2388106832325945,
+                "99.9999" : 2.2388106832325945,
+                "100.0" : 2.2388106832325945
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.1798154328683523,
+                    2.167216173347779,
+                    2.1144074467230443,
+                    2.112896644200296,
+                    2.1130714020705685
+                ],
+                [
+                    2.2388106832325945,
+                    2.1995984855948976,
+                    2.1592875906735753,
+                    2.159276146804836,
+                    2.158128571860164
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.01350628915922799,
+            "scoreError" : 9.558323491485535E-4,
+            "scoreConfidence" : [
+                0.012550456810079436,
+                0.014462121508376544
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013191204038829112,
+                "50.0" : 0.013506928862520234,
+                "90.0" : 0.013824881697092022,
+                "95.0" : 0.013824881697092022,
+                "99.0" : 0.013824881697092022,
+                "99.9" : 0.013824881697092022,
+                "99.99" : 0.013824881697092022,
+                "99.999" : 0.013824881697092022,
+                "99.9999" : 0.013824881697092022,
+                "100.0" : 0.013824881697092022
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013824881697092022,
+                    0.013811080511441557,
+                    0.013816238350967264
+                ],
+                [
+                    0.013191204038829112,
+                    0.013191553143439071,
+                    0.013202777213598912
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0226723378763538,
+            "scoreError" : 0.07089774669507129,
+            "scoreConfidence" : [
+                0.9517745911812825,
+                1.0935700845714251
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9986941573796685,
+                "50.0" : 1.0228295993924914,
+                "90.0" : 1.0465413115320217,
+                "95.0" : 1.0465413115320217,
+                "99.0" : 1.0465413115320217,
+                "99.9" : 1.0465413115320217,
+                "99.99" : 1.0465413115320217,
+                "99.999" : 1.0465413115320217,
+                "99.9999" : 1.0465413115320217,
+                "100.0" : 1.0465413115320217
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.9997542710186944,
+                    1.0003544191257376,
+                    0.9986941573796685
+                ],
+                [
+                    1.0453850885427556,
+                    1.0453047796592454,
+                    1.0465413115320217
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010868622916059507,
+            "scoreError" : 1.6852940561532312E-4,
+            "scoreConfidence" : [
+                0.010700093510444184,
+                0.01103715232167483
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010808165081869764,
+                "50.0" : 0.010868129214310952,
+                "90.0" : 0.0109300825748037,
+                "95.0" : 0.0109300825748037,
+                "99.0" : 0.0109300825748037,
+                "99.9" : 0.0109300825748037,
+                "99.99" : 0.0109300825748037,
+                "99.999" : 0.0109300825748037,
+                "99.9999" : 0.0109300825748037,
+                "100.0" : 0.0109300825748037
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010914559377012321,
+                    0.010924807911135193,
+                    0.0109300825748037
+                ],
+                [
+                    0.010812423499926477,
+                    0.01082169905160958,
+                    0.010808165081869764
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.9906332691687822,
+            "scoreError" : 0.06437515993263081,
+            "scoreConfidence" : [
+                2.9262581092361515,
+                3.055008429101413
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9660130735468564,
+                "50.0" : 2.9918090597090545,
+                "90.0" : 3.0184834858177427,
+                "95.0" : 3.0184834858177427,
+                "99.0" : 3.0184834858177427,
+                "99.9" : 3.0184834858177427,
+                "99.99" : 3.0184834858177427,
+                "99.999" : 3.0184834858177427,
+                "99.9999" : 3.0184834858177427,
+                "100.0" : 3.0184834858177427
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0086356034897714,
+                    3.0184834858177427,
+                    3.0054148335336537
+                ],
+                [
+                    2.9670493327402134,
+                    2.978203285884455,
+                    2.9660130735468564
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7912296738818614,
+            "scoreError" : 0.015282283430982584,
+            "scoreConfidence" : [
+                2.7759473904508787,
+                2.806511957312844
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.785364863547758,
+                "50.0" : 2.7914367832020925,
+                "90.0" : 2.7973913314685315,
+                "95.0" : 2.7973913314685315,
+                "99.0" : 2.7973913314685315,
+                "99.9" : 2.7973913314685315,
+                "99.99" : 2.7973913314685315,
+                "99.999" : 2.7973913314685315,
+                "99.9999" : 2.7973913314685315,
+                "100.0" : 2.7973913314685315
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7944125864766693,
+                    2.7973913314685315,
+                    2.796263514117976
+                ],
+                [
+                    2.788460979927516,
+                    2.785484767752715,
+                    2.785364863547758
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3837903416988486,
+            "scoreError" : 0.012497279172778819,
+            "scoreConfidence" : [
+                0.3712930625260698,
+                0.39628762087162744
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.38091534308459984,
+                "50.0" : 0.3825829711935731,
+                "90.0" : 0.3927160274112472,
+                "95.0" : 0.3927160274112472,
+                "99.0" : 0.3927160274112472,
+                "99.9" : 0.3927160274112472,
+                "99.99" : 0.3927160274112472,
+                "99.999" : 0.3927160274112472,
+                "99.9999" : 0.3927160274112472,
+                "100.0" : 0.3927160274112472
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3927160274112472,
+                    0.3822947447532398,
+                    0.38288983306531893
+                ],
+                [
+                    0.38091534308459984,
+                    0.38287119763390637,
+                    0.3810549042447798
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15705074715828207,
+            "scoreError" : 0.002767294508887428,
+            "scoreConfidence" : [
+                0.15428345264939464,
+                0.1598180416671695
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15597504649530525,
+                "50.0" : 0.15680127496408972,
+                "90.0" : 0.15889230204807983,
+                "95.0" : 0.15889230204807983,
+                "99.0" : 0.15889230204807983,
+                "99.9" : 0.15889230204807983,
+                "99.99" : 0.15889230204807983,
+                "99.999" : 0.15889230204807983,
+                "99.9999" : 0.15889230204807983,
+                "100.0" : 0.15889230204807983
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15889230204807983,
+                    0.15692653741016227,
+                    0.15666295649585638
+                ],
+                [
+                    0.15667601251801716,
+                    0.1571716279822714,
+                    0.15597504649530525
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4112452906146042,
+            "scoreError" : 0.007607631758718146,
+            "scoreConfidence" : [
+                0.40363765885588604,
+                0.41885292237332233
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4084364006289822,
+                "50.0" : 0.4112248490980748,
+                "90.0" : 0.4148510746702066,
+                "95.0" : 0.4148510746702066,
+                "99.0" : 0.4148510746702066,
+                "99.9" : 0.4148510746702066,
+                "99.99" : 0.4148510746702066,
+                "99.999" : 0.4148510746702066,
+                "99.9999" : 0.4148510746702066,
+                "100.0" : 0.4148510746702066
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4148510746702066,
+                    0.4086976867873636,
+                    0.4084364006289822
+                ],
+                [
+                    0.4129866877142267,
+                    0.41303688340492317,
+                    0.4094630104819228
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14841995755785645,
+            "scoreError" : 0.007337997161460048,
+            "scoreConfidence" : [
+                0.1410819603963964,
+                0.1557579547193165
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14563379544759492,
+                "50.0" : 0.14871056006235672,
+                "90.0" : 0.15114689840089476,
+                "95.0" : 0.15114689840089476,
+                "99.0" : 0.15114689840089476,
+                "99.9" : 0.15114689840089476,
+                "99.99" : 0.15114689840089476,
+                "99.999" : 0.15114689840089476,
+                "99.9999" : 0.15114689840089476,
+                "100.0" : 0.15114689840089476
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14692257951339915,
+                    0.14563379544759492,
+                    0.14567497334187948
+                ],
+                [
+                    0.15114689840089476,
+                    0.1506429580320559,
+                    0.1504985406113143
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04325466600372524,
+            "scoreError" : 5.491894162948212E-4,
+            "scoreConfidence" : [
+                0.042705476587430416,
+                0.04380385542002006
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.043133176222702435,
+                "50.0" : 0.04318782525547109,
+                "90.0" : 0.04364997078555559,
+                "95.0" : 0.04364997078555559,
+                "99.0" : 0.04364997078555559,
+                "99.9" : 0.04364997078555559,
+                "99.99" : 0.04364997078555559,
+                "99.999" : 0.04364997078555559,
+                "99.9999" : 0.04364997078555559,
+                "100.0" : 0.04364997078555559
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.043216208009576575,
+                    0.04318719047906959,
+                    0.04318846003187258
+                ],
+                [
+                    0.04364997078555559,
+                    0.04315299049357464,
+                    0.043133176222702435
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7831485.224605992,
+            "scoreError" : 45017.453442525926,
+            "scoreConfidence" : [
+                7786467.771163466,
+                7876502.6780485185
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7803628.278471139,
+                "50.0" : 7831034.788960947,
+                "90.0" : 7851069.449764521,
+                "95.0" : 7851069.449764521,
+                "99.0" : 7851069.449764521,
+                "99.9" : 7851069.449764521,
+                "99.99" : 7851069.449764521,
+                "99.999" : 7851069.449764521,
+                "99.9999" : 7851069.449764521,
+                "100.0" : 7851069.449764521
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7830008.993740219,
+                    7829573.536776213,
+                    7803628.278471139
+                ],
+                [
+                    7851069.449764521,
+                    7842570.504702195,
+                    7832060.584181676
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-02-28T22-35-21Z-739403fe73dd226c415aa51567d415583d035fe7-jdk17.json
+++ b/performance-results/2026-02-28T22-35-21Z-739403fe73dd226c415aa51567d415583d035fe7-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.343776598310114,
+            "scoreError" : 0.08848300795957961,
+            "scoreConfidence" : [
+                3.2552935903505342,
+                3.4322596062696937
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3320472493363122,
+                "50.0" : 3.341524137478398,
+                "90.0" : 3.360010868947347,
+                "95.0" : 3.360010868947347,
+                "99.0" : 3.360010868947347,
+                "99.9" : 3.360010868947347,
+                "99.99" : 3.360010868947347,
+                "99.999" : 3.360010868947347,
+                "99.9999" : 3.360010868947347,
+                "100.0" : 3.360010868947347
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.33282915176145,
+                    3.350219123195347
+                ],
+                [
+                    3.3320472493363122,
+                    3.360010868947347
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6822295362463877,
+            "scoreError" : 0.050889609346916845,
+            "scoreConfidence" : [
+                1.6313399268994708,
+                1.7331191455933046
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6748690131939634,
+                "50.0" : 1.681479133450003,
+                "90.0" : 1.6910908648915817,
+                "95.0" : 1.6910908648915817,
+                "99.0" : 1.6910908648915817,
+                "99.9" : 1.6910908648915817,
+                "99.99" : 1.6910908648915817,
+                "99.999" : 1.6910908648915817,
+                "99.9999" : 1.6910908648915817,
+                "100.0" : 1.6910908648915817
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6748690131939634,
+                    1.6763688117344158
+                ],
+                [
+                    1.68658945516559,
+                    1.6910908648915817
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8458130065451183,
+            "scoreError" : 0.013150883178766675,
+            "scoreConfidence" : [
+                0.8326621233663516,
+                0.8589638897238849
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8435756691829337,
+                "50.0" : 0.8457915658009503,
+                "90.0" : 0.8480932253956391,
+                "95.0" : 0.8480932253956391,
+                "99.0" : 0.8480932253956391,
+                "99.9" : 0.8480932253956391,
+                "99.99" : 0.8480932253956391,
+                "99.999" : 0.8480932253956391,
+                "99.9999" : 0.8480932253956391,
+                "100.0" : 0.8480932253956391
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8468449099472377,
+                    0.844738221654663
+                ],
+                [
+                    0.8435756691829337,
+                    0.8480932253956391
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.893424128896251,
+            "scoreError" : 0.114495868304763,
+            "scoreConfidence" : [
+                15.778928260591488,
+                16.007919997201014
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.835391207199855,
+                "50.0" : 15.901329660336955,
+                "90.0" : 15.942653595959902,
+                "95.0" : 15.942653595959902,
+                "99.0" : 15.942653595959902,
+                "99.9" : 15.942653595959902,
+                "99.99" : 15.942653595959902,
+                "99.999" : 15.942653595959902,
+                "99.9999" : 15.942653595959902,
+                "100.0" : 15.942653595959902
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.859669900002636,
+                    15.835391207199855,
+                    15.884529450462338
+                ],
+                [
+                    15.918129870211573,
+                    15.942653595959902,
+                    15.920170749541207
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2684.781821195166,
+            "scoreError" : 44.31928776774078,
+            "scoreConfidence" : [
+                2640.462533427425,
+                2729.1011089629064
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2670.9008783674662,
+                "50.0" : 2678.9648642314296,
+                "90.0" : 2706.8275898314323,
+                "95.0" : 2706.8275898314323,
+                "99.0" : 2706.8275898314323,
+                "99.9" : 2706.8275898314323,
+                "99.99" : 2706.8275898314323,
+                "99.999" : 2706.8275898314323,
+                "99.9999" : 2706.8275898314323,
+                "100.0" : 2706.8275898314323
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2684.379013744986,
+                    2706.8275898314323,
+                    2671.7189575344128
+                ],
+                [
+                    2670.9008783674662,
+                    2673.550714717873,
+                    2701.3137729748264
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 71509.05478692416,
+            "scoreError" : 3681.8768795395713,
+            "scoreConfidence" : [
+                67827.17790738458,
+                75190.93166646373
+            ],
+            "scorePercentiles" : {
+                "0.0" : 70236.66848618421,
+                "50.0" : 71538.682442588,
+                "90.0" : 72722.21625781136,
+                "95.0" : 72722.21625781136,
+                "99.0" : 72722.21625781136,
+                "99.9" : 72722.21625781136,
+                "99.99" : 72722.21625781136,
+                "99.999" : 72722.21625781136,
+                "99.9999" : 72722.21625781136,
+                "100.0" : 72722.21625781136
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72722.21625781136,
+                    72706.34213817208,
+                    72691.98199967649
+                ],
+                [
+                    70311.73695420129,
+                    70385.38288549954,
+                    70236.66848618421
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 342.3781541735804,
+            "scoreError" : 25.775066090924195,
+            "scoreConfidence" : [
+                316.6030880826562,
+                368.1532202645046
+            ],
+            "scorePercentiles" : {
+                "0.0" : 331.9165226294505,
+                "50.0" : 342.6929488567657,
+                "90.0" : 351.6287173692976,
+                "95.0" : 351.6287173692976,
+                "99.0" : 351.6287173692976,
+                "99.9" : 351.6287173692976,
+                "99.99" : 351.6287173692976,
+                "99.999" : 351.6287173692976,
+                "99.9999" : 351.6287173692976,
+                "100.0" : 351.6287173692976
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    331.9165226294505,
+                    333.8432171413456,
+                    336.7238658247826
+                ],
+                [
+                    351.49457018785694,
+                    351.6287173692976,
+                    348.6620318887488
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 120.26692486019287,
+            "scoreError" : 2.170205232141496,
+            "scoreConfidence" : [
+                118.09671962805137,
+                122.43713009233437
+            ],
+            "scorePercentiles" : {
+                "0.0" : 119.17293030981996,
+                "50.0" : 120.10831456843641,
+                "90.0" : 121.36386955126105,
+                "95.0" : 121.36386955126105,
+                "99.0" : 121.36386955126105,
+                "99.9" : 121.36386955126105,
+                "99.99" : 121.36386955126105,
+                "99.999" : 121.36386955126105,
+                "99.9999" : 121.36386955126105,
+                "100.0" : 121.36386955126105
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    121.36386955126105,
+                    120.91784407578432,
+                    120.16863115648918
+                ],
+                [
+                    119.93027608741895,
+                    120.04799798038366,
+                    119.17293030981996
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.0627250304541457,
+            "scoreError" : 8.152455033974673E-4,
+            "scoreConfidence" : [
+                0.061909784950748226,
+                0.06354027595754316
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06236685330289877,
+                "50.0" : 0.06268738893218301,
+                "90.0" : 0.06309128314921485,
+                "95.0" : 0.06309128314921485,
+                "99.0" : 0.06309128314921485,
+                "99.9" : 0.06309128314921485,
+                "99.99" : 0.06309128314921485,
+                "99.999" : 0.06309128314921485,
+                "99.9999" : 0.06309128314921485,
+                "100.0" : 0.06309128314921485
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06303555298374337,
+                    0.06236685330289877,
+                    0.06309128314921485
+                ],
+                [
+                    0.06265813776402107,
+                    0.06271664010034493,
+                    0.0624817154246512
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8018366105017454E-4,
+            "scoreError" : 2.3883898022057752E-5,
+            "scoreConfidence" : [
+                3.562997630281168E-4,
+                4.040675590722323E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.696284983424053E-4,
+                "50.0" : 3.808816321608811E-4,
+                "90.0" : 3.885870806028935E-4,
+                "95.0" : 3.885870806028935E-4,
+                "99.0" : 3.885870806028935E-4,
+                "99.9" : 3.885870806028935E-4,
+                "99.99" : 3.885870806028935E-4,
+                "99.999" : 3.885870806028935E-4,
+                "99.9999" : 3.885870806028935E-4,
+                "100.0" : 3.885870806028935E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.870527065543606E-4,
+                    3.8774705698494506E-4,
+                    3.885870806028935E-4
+                ],
+                [
+                    3.7337606604904126E-4,
+                    3.696284983424053E-4,
+                    3.747105577674016E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.247493998725016,
+            "scoreError" : 0.08393069829225511,
+            "scoreConfidence" : [
+                2.163563300432761,
+                2.331424697017271
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1837638351528383,
+                "50.0" : 2.2248358023974806,
+                "90.0" : 2.336791184810371,
+                "95.0" : 2.3401767817033226,
+                "99.0" : 2.3401767817033226,
+                "99.9" : 2.3401767817033226,
+                "99.99" : 2.3401767817033226,
+                "99.999" : 2.3401767817033226,
+                "99.9999" : 2.3401767817033226,
+                "100.0" : 2.3401767817033226
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.306320812773807,
+                    2.3051028847660753,
+                    2.2095286911179848,
+                    2.1837638351528383,
+                    2.2211986453475463
+                ],
+                [
+                    2.3401767817033226,
+                    2.278500610617453,
+                    2.2169862225177304,
+                    2.1848885438059864,
+                    2.2284729594474153
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013710439505680946,
+            "scoreError" : 5.552079261216926E-4,
+            "scoreConfidence" : [
+                0.013155231579559255,
+                0.014265647431802638
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013505108005580232,
+                "50.0" : 0.01370592255713748,
+                "90.0" : 0.0139214692138817,
+                "95.0" : 0.0139214692138817,
+                "99.0" : 0.0139214692138817,
+                "99.9" : 0.0139214692138817,
+                "99.99" : 0.0139214692138817,
+                "99.999" : 0.0139214692138817,
+                "99.9999" : 0.0139214692138817,
+                "100.0" : 0.0139214692138817
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0138855995798366,
+                    0.0139214692138817,
+                    0.013862551259462778
+                ],
+                [
+                    0.013538615120512186,
+                    0.013505108005580232,
+                    0.013549293854812182
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0307178596279376,
+            "scoreError" : 0.06158868118350605,
+            "scoreConfidence" : [
+                0.9691291784444316,
+                1.0923065408114436
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.005991881299668,
+                "50.0" : 1.0315907538313236,
+                "90.0" : 1.0516203184016824,
+                "95.0" : 1.0516203184016824,
+                "99.0" : 1.0516203184016824,
+                "99.9" : 1.0516203184016824,
+                "99.99" : 1.0516203184016824,
+                "99.999" : 1.0516203184016824,
+                "99.9999" : 1.0516203184016824,
+                "100.0" : 1.0516203184016824
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.04905905811392,
+                    1.0511169947445869,
+                    1.0516203184016824
+                ],
+                [
+                    1.0141224495487273,
+                    1.0123964556590404,
+                    1.005991881299668
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01081488329496518,
+            "scoreError" : 8.28428328647149E-4,
+            "scoreConfidence" : [
+                0.009986454966318031,
+                0.011643311623612328
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010537190317536584,
+                "50.0" : 0.010813915724156197,
+                "90.0" : 0.011091561558630541,
+                "95.0" : 0.011091561558630541,
+                "99.0" : 0.011091561558630541,
+                "99.9" : 0.011091561558630541,
+                "99.99" : 0.011091561558630541,
+                "99.999" : 0.011091561558630541,
+                "99.9999" : 0.011091561558630541,
+                "100.0" : 0.011091561558630541
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010548979767591015,
+                    0.010537190317536584,
+                    0.010549597501925247
+                ],
+                [
+                    0.011091561558630541,
+                    0.011078233946387147,
+                    0.011083736677720538
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.248811588417676,
+            "scoreError" : 0.17519584091145213,
+            "scoreConfidence" : [
+                3.073615747506224,
+                3.424007429329128
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1823751933842237,
+                "50.0" : 3.2482974666539244,
+                "90.0" : 3.324752704787234,
+                "95.0" : 3.324752704787234,
+                "99.0" : 3.324752704787234,
+                "99.9" : 3.324752704787234,
+                "99.99" : 3.324752704787234,
+                "99.999" : 3.324752704787234,
+                "99.9999" : 3.324752704787234,
+                "100.0" : 3.324752704787234
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.2953993682476943,
+                    3.324752704787234,
+                    3.2937546471362737
+                ],
+                [
+                    3.1823751933842237,
+                    3.193747330779055,
+                    3.202840286171575
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.9687655092841534,
+            "scoreError" : 0.08496145717459545,
+            "scoreConfidence" : [
+                2.883804052109558,
+                3.0537269664587487
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9403944563363718,
+                "50.0" : 2.955544298882411,
+                "90.0" : 3.009702125489016,
+                "95.0" : 3.009702125489016,
+                "99.0" : 3.009702125489016,
+                "99.9" : 3.009702125489016,
+                "99.99" : 3.009702125489016,
+                "99.999" : 3.009702125489016,
+                "99.9999" : 3.009702125489016,
+                "100.0" : 3.009702125489016
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9520393193624557,
+                    3.009702125489016,
+                    3.0043281333333334
+                ],
+                [
+                    2.9590492784023668,
+                    2.947079742781379,
+                    2.9403944563363718
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3901803429118939,
+            "scoreError" : 0.009443641399748832,
+            "scoreConfidence" : [
+                0.38073670151214506,
+                0.39962398431164275
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.38651494152205,
+                "50.0" : 0.39029347112586876,
+                "90.0" : 0.39376280950505965,
+                "95.0" : 0.39376280950505965,
+                "99.0" : 0.39376280950505965,
+                "99.9" : 0.39376280950505965,
+                "99.99" : 0.39376280950505965,
+                "99.999" : 0.39376280950505965,
+                "99.9999" : 0.39376280950505965,
+                "100.0" : 0.39376280950505965
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.38651494152205,
+                    0.3876925931769723,
+                    0.38720415421845356
+                ],
+                [
+                    0.3930132099740627,
+                    0.3928943490747653,
+                    0.39376280950505965
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16017345973702188,
+            "scoreError" : 0.0024567751632407816,
+            "scoreConfidence" : [
+                0.1577166845737811,
+                0.16263023490026265
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1588412758231809,
+                "50.0" : 0.16017151080923364,
+                "90.0" : 0.16134093951469783,
+                "95.0" : 0.16134093951469783,
+                "99.0" : 0.16134093951469783,
+                "99.9" : 0.16134093951469783,
+                "99.99" : 0.16134093951469783,
+                "99.999" : 0.16134093951469783,
+                "99.9999" : 0.16134093951469783,
+                "100.0" : 0.16134093951469783
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1597280785362893,
+                    0.16134093951469783,
+                    0.16078744292949593
+                ],
+                [
+                    0.15992174035693724,
+                    0.1588412758231809,
+                    0.16042128126153007
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4121959754580329,
+            "scoreError" : 0.012807047532800661,
+            "scoreConfidence" : [
+                0.39938892792523223,
+                0.42500302299083353
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4079848406494778,
+                "50.0" : 0.41171224820869595,
+                "90.0" : 0.4184662561302201,
+                "95.0" : 0.4184662561302201,
+                "99.0" : 0.4184662561302201,
+                "99.9" : 0.4184662561302201,
+                "99.99" : 0.4184662561302201,
+                "99.999" : 0.4184662561302201,
+                "99.9999" : 0.4184662561302201,
+                "100.0" : 0.4184662561302201
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4184662561302201,
+                    0.41514990198845947,
+                    0.4150048156202017
+                ],
+                [
+                    0.4084196807971902,
+                    0.4079848406494778,
+                    0.40815035756264795
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14782619987312282,
+            "scoreError" : 0.003485737905528187,
+            "scoreConfidence" : [
+                0.14434046196759462,
+                0.151311937778651
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1468873599535847,
+                "50.0" : 0.14749644231525916,
+                "90.0" : 0.15029926118191655,
+                "95.0" : 0.15029926118191655,
+                "99.0" : 0.15029926118191655,
+                "99.9" : 0.15029926118191655,
+                "99.99" : 0.15029926118191655,
+                "99.999" : 0.15029926118191655,
+                "99.9999" : 0.15029926118191655,
+                "100.0" : 0.15029926118191655
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15029926118191655,
+                    0.14764142732493762,
+                    0.1468873599535847
+                ],
+                [
+                    0.14713626614777978,
+                    0.14747700073737613,
+                    0.14751588389314216
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04334541446392031,
+            "scoreError" : 1.6885899108337512E-4,
+            "scoreConfidence" : [
+                0.043176555472836935,
+                0.04351427345500369
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04328155782781067,
+                "50.0" : 0.04333660439916194,
+                "90.0" : 0.04345380464425074,
+                "95.0" : 0.04345380464425074,
+                "99.0" : 0.04345380464425074,
+                "99.9" : 0.04345380464425074,
+                "99.99" : 0.04345380464425074,
+                "99.999" : 0.04345380464425074,
+                "99.9999" : 0.04345380464425074,
+                "100.0" : 0.04345380464425074
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04328155782781067,
+                    0.04335113899028083,
+                    0.043358075473988615
+                ],
+                [
+                    0.04345380464425074,
+                    0.043305840039147926,
+                    0.04332206980804305
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8064975.535607054,
+            "scoreError" : 264341.68612436845,
+            "scoreConfidence" : [
+                7800633.849482685,
+                8329317.2217314225
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7963747.815286624,
+                "50.0" : 8052721.887894418,
+                "90.0" : 8206716.737489746,
+                "95.0" : 8206716.737489746,
+                "99.0" : 8206716.737489746,
+                "99.9" : 8206716.737489746,
+                "99.99" : 8206716.737489746,
+                "99.999" : 8206716.737489746,
+                "99.9999" : 8206716.737489746,
+                "100.0" : 8206716.737489746
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8206716.737489746,
+                    8091577.265372168,
+                    7963747.815286624
+                ],
+                [
+                    7984014.794094174,
+                    8129930.090982941,
+                    8013866.510416667
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-02T08-17-54Z-bae794f0421f37e9bbc8e680a8fb13e6a2adf035-jdk17.json
+++ b/performance-results/2026-03-02T08-17-54Z-bae794f0421f37e9bbc8e680a8fb13e6a2adf035-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.336255440491035,
+            "scoreError" : 0.018599390556120383,
+            "scoreConfidence" : [
+                3.317656049934915,
+                3.3548548310471555
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3328213080748075,
+                "50.0" : 3.3367810823668655,
+                "90.0" : 3.338638289155603,
+                "95.0" : 3.338638289155603,
+                "99.0" : 3.338638289155603,
+                "99.9" : 3.338638289155603,
+                "99.99" : 3.338638289155603,
+                "99.999" : 3.338638289155603,
+                "99.9999" : 3.338638289155603,
+                "100.0" : 3.338638289155603
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3328213080748075,
+                    3.338628998896854
+                ],
+                [
+                    3.3349331658368775,
+                    3.338638289155603
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6842348345234075,
+            "scoreError" : 0.04704736997853289,
+            "scoreConfidence" : [
+                1.6371874645448745,
+                1.7312822045019405
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6745736659758894,
+                "50.0" : 1.6856604557381853,
+                "90.0" : 1.6910447606413697,
+                "95.0" : 1.6910447606413697,
+                "99.0" : 1.6910447606413697,
+                "99.9" : 1.6910447606413697,
+                "99.99" : 1.6910447606413697,
+                "99.999" : 1.6910447606413697,
+                "99.9999" : 1.6910447606413697,
+                "100.0" : 1.6910447606413697
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6745736659758894,
+                    1.6910447606413697
+                ],
+                [
+                    1.6828995890925649,
+                    1.6884213223838058
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8495821096709308,
+            "scoreError" : 0.03075704745311751,
+            "scoreConfidence" : [
+                0.8188250622178134,
+                0.8803391571240483
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8434379473585502,
+                "50.0" : 0.8499762710166539,
+                "90.0" : 0.8549379492918654,
+                "95.0" : 0.8549379492918654,
+                "99.0" : 0.8549379492918654,
+                "99.9" : 0.8549379492918654,
+                "99.99" : 0.8549379492918654,
+                "99.999" : 0.8549379492918654,
+                "99.9999" : 0.8549379492918654,
+                "100.0" : 0.8549379492918654
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8491960819067658,
+                    0.8549379492918654
+                ],
+                [
+                    0.8434379473585502,
+                    0.850756460126542
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.910128697039617,
+            "scoreError" : 0.46450298456660355,
+            "scoreConfidence" : [
+                15.445625712473014,
+                16.37463168160622
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.715233288918236,
+                "50.0" : 15.92741503031284,
+                "90.0" : 16.08368817749546,
+                "95.0" : 16.08368817749546,
+                "99.0" : 16.08368817749546,
+                "99.9" : 16.08368817749546,
+                "99.99" : 16.08368817749546,
+                "99.999" : 16.08368817749546,
+                "99.9999" : 16.08368817749546,
+                "100.0" : 16.08368817749546
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.734235999974427,
+                    15.852938749910576,
+                    15.715233288918236
+                ],
+                [
+                    16.07278465522391,
+                    16.001891310715102,
+                    16.08368817749546
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2595.8269690867414,
+            "scoreError" : 160.21186755940366,
+            "scoreConfidence" : [
+                2435.6151015273376,
+                2756.0388366461452
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2542.5505066623036,
+                "50.0" : 2591.457825264729,
+                "90.0" : 2666.375612461634,
+                "95.0" : 2666.375612461634,
+                "99.0" : 2666.375612461634,
+                "99.9" : 2666.375612461634,
+                "99.99" : 2666.375612461634,
+                "99.999" : 2666.375612461634,
+                "99.9999" : 2666.375612461634,
+                "100.0" : 2666.375612461634
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2542.5505066623036,
+                    2542.64811663872,
+                    2548.760525549224
+                ],
+                [
+                    2640.471928228336,
+                    2666.375612461634,
+                    2634.1551249802333
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73246.68975638105,
+            "scoreError" : 2162.698974572867,
+            "scoreConfidence" : [
+                71083.99078180818,
+                75409.38873095391
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72540.04900096354,
+                "50.0" : 73205.54337929838,
+                "90.0" : 74043.55162894036,
+                "95.0" : 74043.55162894036,
+                "99.0" : 74043.55162894036,
+                "99.9" : 74043.55162894036,
+                "99.99" : 74043.55162894036,
+                "99.999" : 74043.55162894036,
+                "99.9999" : 74043.55162894036,
+                "100.0" : 74043.55162894036
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73944.31125874989,
+                    73858.17565412988,
+                    74043.55162894036
+                ],
+                [
+                    72552.9111044669,
+                    72541.13989103575,
+                    72540.04900096354
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 341.3813176005777,
+            "scoreError" : 12.281143063724583,
+            "scoreConfidence" : [
+                329.1001745368531,
+                353.6624606643023
+            ],
+            "scorePercentiles" : {
+                "0.0" : 337.0409281846808,
+                "50.0" : 341.16800518616964,
+                "90.0" : 345.7858377186017,
+                "95.0" : 345.7858377186017,
+                "99.0" : 345.7858377186017,
+                "99.9" : 345.7858377186017,
+                "99.99" : 345.7858377186017,
+                "99.999" : 345.7858377186017,
+                "99.9999" : 345.7858377186017,
+                "100.0" : 345.7858377186017
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    345.7858377186017,
+                    345.6867203409321,
+                    344.5951421448708
+                ],
+                [
+                    337.0409281846808,
+                    337.74086822746847,
+                    337.438408986912
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 120.02425942647984,
+            "scoreError" : 3.954018464598014,
+            "scoreConfidence" : [
+                116.07024096188184,
+                123.97827789107785
+            ],
+            "scorePercentiles" : {
+                "0.0" : 117.61950026130322,
+                "50.0" : 120.08545553347594,
+                "90.0" : 121.6021369106549,
+                "95.0" : 121.6021369106549,
+                "99.0" : 121.6021369106549,
+                "99.9" : 121.6021369106549,
+                "99.99" : 121.6021369106549,
+                "99.999" : 121.6021369106549,
+                "99.9999" : 121.6021369106549,
+                "100.0" : 121.6021369106549
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    121.6021369106549,
+                    121.20562045590275,
+                    120.22330482907365
+                ],
+                [
+                    117.61950026130322,
+                    119.5473878640664,
+                    119.94760623787822
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06246737967028701,
+            "scoreError" : 7.174820956104103E-4,
+            "scoreConfidence" : [
+                0.0617498975746766,
+                0.06318486176589742
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06202940611722089,
+                "50.0" : 0.06252277301132911,
+                "90.0" : 0.06269082228741944,
+                "95.0" : 0.06269082228741944,
+                "99.0" : 0.06269082228741944,
+                "99.9" : 0.06269082228741944,
+                "99.99" : 0.06269082228741944,
+                "99.999" : 0.06269082228741944,
+                "99.9999" : 0.06269082228741944,
+                "100.0" : 0.06269082228741944
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06235446864867561,
+                    0.06202940611722089,
+                    0.06262215016500616
+                ],
+                [
+                    0.0626840349457479,
+                    0.06269082228741944,
+                    0.062423395857652046
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8296609404331154E-4,
+            "scoreError" : 3.986860828152071E-6,
+            "scoreConfidence" : [
+                3.7897923321515947E-4,
+                3.869529548714636E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.814474256212908E-4,
+                "50.0" : 3.8296056685327635E-4,
+                "90.0" : 3.8500345286079826E-4,
+                "95.0" : 3.8500345286079826E-4,
+                "99.0" : 3.8500345286079826E-4,
+                "99.9" : 3.8500345286079826E-4,
+                "99.99" : 3.8500345286079826E-4,
+                "99.999" : 3.8500345286079826E-4,
+                "99.9999" : 3.8500345286079826E-4,
+                "100.0" : 3.8500345286079826E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.815001834802466E-4,
+                    3.814474256212908E-4,
+                    3.8242090125087776E-4
+                ],
+                [
+                    3.839243685909811E-4,
+                    3.8350023245567493E-4,
+                    3.8500345286079826E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.269512916422808,
+            "scoreError" : 0.07838843256752645,
+            "scoreConfidence" : [
+                2.1911244838552815,
+                2.3479013489903346
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.212292588807786,
+                "50.0" : 2.250497961226614,
+                "90.0" : 2.3532032720348255,
+                "95.0" : 2.35568833089967,
+                "99.0" : 2.35568833089967,
+                "99.9" : 2.35568833089967,
+                "99.99" : 2.35568833089967,
+                "99.999" : 2.35568833089967,
+                "99.9999" : 2.35568833089967,
+                "100.0" : 2.35568833089967
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3308377422512234,
+                    2.31547974537037,
+                    2.2218114632303934,
+                    2.212292588807786,
+                    2.245474642119443
+                ],
+                [
+                    2.35568833089967,
+                    2.302069276012891,
+                    2.2335222914247432,
+                    2.222431803777778,
+                    2.2555212803337845
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013911580462053735,
+            "scoreError" : 5.773863968978065E-4,
+            "scoreConfidence" : [
+                0.013334194065155928,
+                0.014488966858951543
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013700225222077915,
+                "50.0" : 0.013862026187271798,
+                "90.0" : 0.014166174913162473,
+                "95.0" : 0.014166174913162473,
+                "99.0" : 0.014166174913162473,
+                "99.9" : 0.014166174913162473,
+                "99.99" : 0.014166174913162473,
+                "99.999" : 0.014166174913162473,
+                "99.9999" : 0.014166174913162473,
+                "100.0" : 0.014166174913162473
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013762205877455304,
+                    0.013744466753255679,
+                    0.013700225222077915
+                ],
+                [
+                    0.014166174913162473,
+                    0.013961846497088294,
+                    0.01413456350928275
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0322647284307693,
+            "scoreError" : 0.02879018817451821,
+            "scoreConfidence" : [
+                1.003474540256251,
+                1.0610549166052876
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.020352931231507,
+                "50.0" : 1.0317500837271825,
+                "90.0" : 1.0440060595051674,
+                "95.0" : 1.0440060595051674,
+                "99.0" : 1.0440060595051674,
+                "99.9" : 1.0440060595051674,
+                "99.99" : 1.0440060595051674,
+                "99.999" : 1.0440060595051674,
+                "99.9999" : 1.0440060595051674,
+                "100.0" : 1.0440060595051674
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0382652733596345,
+                    1.0418408895718303,
+                    1.0440060595051674
+                ],
+                [
+                    1.0238883228217468,
+                    1.0252348940947305,
+                    1.020352931231507
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01056467140957981,
+            "scoreError" : 6.692762596937564E-4,
+            "scoreConfidence" : [
+                0.009895395149886054,
+                0.011233947669273566
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010322301185791966,
+                "50.0" : 0.010570624394401807,
+                "90.0" : 0.010787684017829403,
+                "95.0" : 0.010787684017829403,
+                "99.0" : 0.010787684017829403,
+                "99.9" : 0.010787684017829403,
+                "99.99" : 0.010787684017829403,
+                "99.999" : 0.010787684017829403,
+                "99.9999" : 0.010787684017829403,
+                "100.0" : 0.010787684017829403
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0107785457167493,
+                    0.01078026814381379,
+                    0.010787684017829403
+                ],
+                [
+                    0.010362703072054317,
+                    0.01035652632124009,
+                    0.010322301185791966
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.293073928208918,
+            "scoreError" : 0.04041518562308717,
+            "scoreConfidence" : [
+                3.252658742585831,
+                3.333489113832005
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.282163162073491,
+                "50.0" : 3.2879690499315517,
+                "90.0" : 3.319884690776377,
+                "95.0" : 3.319884690776377,
+                "99.0" : 3.319884690776377,
+                "99.9" : 3.319884690776377,
+                "99.99" : 3.319884690776377,
+                "99.999" : 3.319884690776377,
+                "99.9999" : 3.319884690776377,
+                "100.0" : 3.319884690776377
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.2919527728768925,
+                    3.319884690776377,
+                    3.282163162073491
+                ],
+                [
+                    3.2839853269862114,
+                    3.2831336725721787,
+                    3.2973239439683586
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.983783097984792,
+            "scoreError" : 0.0805565327973412,
+            "scoreConfidence" : [
+                2.903226565187451,
+                3.064339630782133
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9562556086313925,
+                "50.0" : 2.9757673800381363,
+                "90.0" : 3.026823799031477,
+                "95.0" : 3.026823799031477,
+                "99.0" : 3.026823799031477,
+                "99.9" : 3.026823799031477,
+                "99.99" : 3.026823799031477,
+                "99.999" : 3.026823799031477,
+                "99.9999" : 3.026823799031477,
+                "100.0" : 3.026823799031477
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.967566512462908,
+                    2.9590136313609467,
+                    2.9562556086313925
+                ],
+                [
+                    3.026823799031477,
+                    2.9839682476133653,
+                    3.009070788808664
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.37712165650097673,
+            "scoreError" : 0.015313073764539492,
+            "scoreConfidence" : [
+                0.36180858273643723,
+                0.39243473026551623
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3709271047067987,
+                "50.0" : 0.37695990323651263,
+                "90.0" : 0.38318237615417033,
+                "95.0" : 0.38318237615417033,
+                "99.0" : 0.38318237615417033,
+                "99.9" : 0.38318237615417033,
+                "99.99" : 0.38318237615417033,
+                "99.999" : 0.38318237615417033,
+                "99.9999" : 0.38318237615417033,
+                "100.0" : 0.38318237615417033
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3709271047067987,
+                    0.37268963134945776,
+                    0.37306148895769603
+                ],
+                [
+                    0.38318237615417033,
+                    0.3808583175153292,
+                    0.38201102032240813
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16051741901191627,
+            "scoreError" : 0.0020037484469216417,
+            "scoreConfidence" : [
+                0.15851367056499463,
+                0.1625211674588379
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15925390779373824,
+                "50.0" : 0.16068664586530598,
+                "90.0" : 0.16116119401782406,
+                "95.0" : 0.16116119401782406,
+                "99.0" : 0.16116119401782406,
+                "99.9" : 0.16116119401782406,
+                "99.99" : 0.16116119401782406,
+                "99.999" : 0.16116119401782406,
+                "99.9999" : 0.16116119401782406,
+                "100.0" : 0.16116119401782406
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16116119401782406,
+                    0.1607674269568992,
+                    0.15925390779373824
+                ],
+                [
+                    0.16060586477371278,
+                    0.1611229032320433,
+                    0.16019321729727998
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4050670313173113,
+            "scoreError" : 0.005063867109459794,
+            "scoreConfidence" : [
+                0.40000316420785154,
+                0.4101308984267711
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40303057852738483,
+                "50.0" : 0.40515880496438567,
+                "90.0" : 0.40678797059062805,
+                "95.0" : 0.40678797059062805,
+                "99.0" : 0.40678797059062805,
+                "99.9" : 0.40678797059062805,
+                "99.99" : 0.40678797059062805,
+                "99.999" : 0.40678797059062805,
+                "99.9999" : 0.40678797059062805,
+                "100.0" : 0.40678797059062805
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40678797059062805,
+                    0.40666052417551135,
+                    0.4066594883900614
+                ],
+                [
+                    0.40365812153870995,
+                    0.40360550468157236,
+                    0.40303057852738483
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1478034330863601,
+            "scoreError" : 0.01115435552911009,
+            "scoreConfidence" : [
+                0.13664907755725,
+                0.1589577886154702
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14379751072702174,
+                "50.0" : 0.1478150260699426,
+                "90.0" : 0.15224966633679948,
+                "95.0" : 0.15224966633679948,
+                "99.0" : 0.15224966633679948,
+                "99.9" : 0.15224966633679948,
+                "99.99" : 0.15224966633679948,
+                "99.999" : 0.15224966633679948,
+                "99.9999" : 0.15224966633679948,
+                "100.0" : 0.15224966633679948
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15224966633679948,
+                    0.151118353169626,
+                    0.1508175831360188
+                ],
+                [
+                    0.14481246900386638,
+                    0.14379751072702174,
+                    0.14402501614482818
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.0440442451724354,
+            "scoreError" : 0.0012104990369506416,
+            "scoreConfidence" : [
+                0.04283374613548476,
+                0.04525474420938604
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.043620512782597695,
+                "50.0" : 0.04401679528279852,
+                "90.0" : 0.04485040922912705,
+                "95.0" : 0.04485040922912705,
+                "99.0" : 0.04485040922912705,
+                "99.9" : 0.04485040922912705,
+                "99.99" : 0.04485040922912705,
+                "99.999" : 0.04485040922912705,
+                "99.9999" : 0.04485040922912705,
+                "100.0" : 0.04485040922912705
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04485040922912705,
+                    0.043727334260340284,
+                    0.043620512782597695
+                ],
+                [
+                    0.04403362419695028,
+                    0.0440063730791572,
+                    0.04402721748643984
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8142231.419100433,
+            "scoreError" : 233059.84719727372,
+            "scoreConfidence" : [
+                7909171.571903159,
+                8375291.266297706
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7983011.955307263,
+                "50.0" : 8172156.480564687,
+                "90.0" : 8216569.517241379,
+                "95.0" : 8216569.517241379,
+                "99.0" : 8216569.517241379,
+                "99.9" : 8216569.517241379,
+                "99.99" : 8216569.517241379,
+                "99.999" : 8216569.517241379,
+                "99.9999" : 8216569.517241379,
+                "100.0" : 8216569.517241379
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8179123.691741619,
+                    8181757.57726901,
+                    8216569.517241379
+                ],
+                [
+                    7983011.955307263,
+                    8165189.269387756,
+                    8127736.503655565
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-02T09-24-31Z-32c996c59be8a3387325aaac5fd232fc97306740-jdk17.json
+++ b/performance-results/2026-03-02T09-24-31Z-32c996c59be8a3387325aaac5fd232fc97306740-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3693104140239787,
+            "scoreError" : 0.027759221336109922,
+            "scoreConfidence" : [
+                3.3415511926878687,
+                3.3970696353600887
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.364198498987442,
+                "50.0" : 3.369562964190836,
+                "90.0" : 3.373917228726802,
+                "95.0" : 3.373917228726802,
+                "99.0" : 3.373917228726802,
+                "99.9" : 3.373917228726802,
+                "99.99" : 3.373917228726802,
+                "99.999" : 3.373917228726802,
+                "99.9999" : 3.373917228726802,
+                "100.0" : 3.373917228726802
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.364198498987442,
+                    3.371547774681735
+                ],
+                [
+                    3.367578153699937,
+                    3.373917228726802
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7028101201720873,
+            "scoreError" : 0.024855257855721773,
+            "scoreConfidence" : [
+                1.6779548623163656,
+                1.727665378027809
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6992108395878762,
+                "50.0" : 1.7019419182870301,
+                "90.0" : 1.7081458045264133,
+                "95.0" : 1.7081458045264133,
+                "99.0" : 1.7081458045264133,
+                "99.9" : 1.7081458045264133,
+                "99.99" : 1.7081458045264133,
+                "99.999" : 1.7081458045264133,
+                "99.9999" : 1.7081458045264133,
+                "100.0" : 1.7081458045264133
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6992108395878762,
+                    1.7010898651039479
+                ],
+                [
+                    1.7027939714701121,
+                    1.7081458045264133
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8570143013851702,
+            "scoreError" : 0.018073091448644926,
+            "scoreConfidence" : [
+                0.8389412099365253,
+                0.8750873928338151
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8531021315034393,
+                "50.0" : 0.8576043103768756,
+                "90.0" : 0.8597464532834904,
+                "95.0" : 0.8597464532834904,
+                "99.0" : 0.8597464532834904,
+                "99.9" : 0.8597464532834904,
+                "99.99" : 0.8597464532834904,
+                "99.999" : 0.8597464532834904,
+                "99.9999" : 0.8597464532834904,
+                "100.0" : 0.8597464532834904
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8575838046013535,
+                    0.8597464532834904
+                ],
+                [
+                    0.8531021315034393,
+                    0.8576248161523975
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.331674166805037,
+            "scoreError" : 0.09939449734820294,
+            "scoreConfidence" : [
+                16.232279669456833,
+                16.43106866415324
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.2973537192798,
+                "50.0" : 16.330694229740665,
+                "90.0" : 16.369169465545568,
+                "95.0" : 16.369169465545568,
+                "99.0" : 16.369169465545568,
+                "99.9" : 16.369169465545568,
+                "99.99" : 16.369169465545568,
+                "99.999" : 16.369169465545568,
+                "99.9999" : 16.369169465545568,
+                "100.0" : 16.369169465545568
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.361696673777704,
+                    16.369169465545568,
+                    16.360851402832314
+                ],
+                [
+                    16.30053705664902,
+                    16.2973537192798,
+                    16.300436682745826
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2742.9827981400085,
+            "scoreError" : 47.31230306845843,
+            "scoreConfidence" : [
+                2695.6704950715502,
+                2790.295101208467
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2727.4023435437057,
+                "50.0" : 2742.062056008691,
+                "90.0" : 2759.650397210891,
+                "95.0" : 2759.650397210891,
+                "99.0" : 2759.650397210891,
+                "99.9" : 2759.650397210891,
+                "99.99" : 2759.650397210891,
+                "99.999" : 2759.650397210891,
+                "99.9999" : 2759.650397210891,
+                "100.0" : 2759.650397210891
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2759.650397210891,
+                    2756.089634461503,
+                    2759.285425983538
+                ],
+                [
+                    2728.034477555879,
+                    2727.434510084534,
+                    2727.4023435437057
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73284.45338093115,
+            "scoreError" : 718.2827291688519,
+            "scoreConfidence" : [
+                72566.1706517623,
+                74002.73611010001
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73017.52883285203,
+                "50.0" : 73296.94666028074,
+                "90.0" : 73553.91469082143,
+                "95.0" : 73553.91469082143,
+                "99.0" : 73553.91469082143,
+                "99.9" : 73553.91469082143,
+                "99.99" : 73553.91469082143,
+                "99.999" : 73553.91469082143,
+                "99.9999" : 73553.91469082143,
+                "100.0" : 73553.91469082143
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73017.52883285203,
+                    73106.90570809087,
+                    73034.81560754131
+                ],
+                [
+                    73486.9876124706,
+                    73553.91469082143,
+                    73506.56783381067
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 367.4488770681164,
+            "scoreError" : 12.812930356696725,
+            "scoreConfidence" : [
+                354.6359467114197,
+                380.2618074248131
+            ],
+            "scorePercentiles" : {
+                "0.0" : 363.06678320153827,
+                "50.0" : 367.26274029827505,
+                "90.0" : 372.1692299040608,
+                "95.0" : 372.1692299040608,
+                "99.0" : 372.1692299040608,
+                "99.9" : 372.1692299040608,
+                "99.99" : 372.1692299040608,
+                "99.999" : 372.1692299040608,
+                "99.9999" : 372.1692299040608,
+                "100.0" : 372.1692299040608
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    371.0880107401138,
+                    371.5627650636563,
+                    372.1692299040608
+                ],
+                [
+                    363.06678320153827,
+                    363.4374698564363,
+                    363.36900364289295
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 127.01282301604952,
+            "scoreError" : 0.7011239273912583,
+            "scoreConfidence" : [
+                126.31169908865826,
+                127.71394694344079
+            ],
+            "scorePercentiles" : {
+                "0.0" : 126.72237642374967,
+                "50.0" : 126.98790442428646,
+                "90.0" : 127.46932645686886,
+                "95.0" : 127.46932645686886,
+                "99.0" : 127.46932645686886,
+                "99.9" : 127.46932645686886,
+                "99.99" : 127.46932645686886,
+                "99.999" : 127.46932645686886,
+                "99.9999" : 127.46932645686886,
+                "100.0" : 127.46932645686886
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    126.72237642374967,
+                    126.97553328765166,
+                    126.87884228059185
+                ],
+                [
+                    127.00027556092127,
+                    127.03058408651368,
+                    127.46932645686886
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06077251414891217,
+            "scoreError" : 4.779761115998836E-4,
+            "scoreConfidence" : [
+                0.06029453803731229,
+                0.06125049026051205
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.060603033197786815,
+                "50.0" : 0.06074183455914822,
+                "90.0" : 0.06103778947850289,
+                "95.0" : 0.06103778947850289,
+                "99.0" : 0.06103778947850289,
+                "99.9" : 0.06103778947850289,
+                "99.99" : 0.06103778947850289,
+                "99.999" : 0.06103778947850289,
+                "99.9999" : 0.06103778947850289,
+                "100.0" : 0.06103778947850289
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06083611028781049,
+                    0.06086914192063985,
+                    0.06103778947850289
+                ],
+                [
+                    0.060603033197786815,
+                    0.060641451178247,
+                    0.06064755883048596
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6394967321865115E-4,
+            "scoreError" : 1.896813087935043E-5,
+            "scoreConfidence" : [
+                3.449815423393007E-4,
+                3.829178040980016E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5746796661075534E-4,
+                "50.0" : 3.6386224886938566E-4,
+                "90.0" : 3.7039422193186944E-4,
+                "95.0" : 3.7039422193186944E-4,
+                "99.0" : 3.7039422193186944E-4,
+                "99.9" : 3.7039422193186944E-4,
+                "99.99" : 3.7039422193186944E-4,
+                "99.999" : 3.7039422193186944E-4,
+                "99.9999" : 3.7039422193186944E-4,
+                "100.0" : 3.7039422193186944E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.579913194302741E-4,
+                    3.57880924464805E-4,
+                    3.5746796661075534E-4
+                ],
+                [
+                    3.702304285657059E-4,
+                    3.697331783084972E-4,
+                    3.7039422193186944E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.168092001504482,
+            "scoreError" : 0.05015787330247994,
+            "scoreConfidence" : [
+                2.117934128202002,
+                2.218249874806962
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.139387906096257,
+                "50.0" : 2.1522279126229407,
+                "90.0" : 2.2219080132834215,
+                "95.0" : 2.2234898983992886,
+                "99.0" : 2.2234898983992886,
+                "99.9" : 2.2234898983992886,
+                "99.99" : 2.2234898983992886,
+                "99.999" : 2.2234898983992886,
+                "99.9999" : 2.2234898983992886,
+                "100.0" : 2.2234898983992886
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.2234898983992886,
+                    2.207671047240618,
+                    2.1452357568089213,
+                    2.141101265039606,
+                    2.139838559477963
+                ],
+                [
+                    2.206724773389232,
+                    2.177366772262138,
+                    2.1592200684369605,
+                    2.139387906096257,
+                    2.140883967893836
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013586589486432743,
+            "scoreError" : 4.7847435721565647E-4,
+            "scoreConfidence" : [
+                0.013108115129217087,
+                0.014065063843648399
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01342417568378449,
+                "50.0" : 0.013572140646666318,
+                "90.0" : 0.01377120005591039,
+                "95.0" : 0.01377120005591039,
+                "99.0" : 0.01377120005591039,
+                "99.9" : 0.01377120005591039,
+                "99.99" : 0.01377120005591039,
+                "99.999" : 0.01377120005591039,
+                "99.9999" : 0.01377120005591039,
+                "100.0" : 0.01377120005591039
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013701602933479481,
+                    0.01377120005591039,
+                    0.013749862226707677
+                ],
+                [
+                    0.013442678359853154,
+                    0.01342417568378449,
+                    0.01343001765886126
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0091991017830622,
+            "scoreError" : 0.03384011660610752,
+            "scoreConfidence" : [
+                0.9753589851769546,
+                1.0430392183891697
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9978180921971662,
+                "50.0" : 1.0090441257115268,
+                "90.0" : 1.0210242814701378,
+                "95.0" : 1.0210242814701378,
+                "99.0" : 1.0210242814701378,
+                "99.9" : 1.0210242814701378,
+                "99.99" : 1.0210242814701378,
+                "99.999" : 1.0210242814701378,
+                "99.9999" : 1.0210242814701378,
+                "100.0" : 1.0210242814701378
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.9986579193129619,
+                    0.9978180921971662,
+                    0.9981096870259482
+                ],
+                [
+                    1.0210242814701378,
+                    1.0194303321100917,
+                    1.0201542985820666
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010448236923251043,
+            "scoreError" : 2.8227274487575203E-4,
+            "scoreConfidence" : [
+                0.010165964178375292,
+                0.010730509668126794
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010345798799917236,
+                "50.0" : 0.01044946800307719,
+                "90.0" : 0.010546629259413158,
+                "95.0" : 0.010546629259413158,
+                "99.0" : 0.010546629259413158,
+                "99.9" : 0.010546629259413158,
+                "99.99" : 0.010546629259413158,
+                "99.999" : 0.010546629259413158,
+                "99.9999" : 0.010546629259413158,
+                "100.0" : 0.010546629259413158
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010364789024847798,
+                    0.010359186093777192,
+                    0.010345798799917236
+                ],
+                [
+                    0.01053414698130658,
+                    0.010546629259413158,
+                    0.010538871380244286
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.00680430188077,
+            "scoreError" : 0.055156651397676455,
+            "scoreConfidence" : [
+                2.9516476504830935,
+                3.0619609532784464
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.984406606205251,
+                "50.0" : 3.0064196045562466,
+                "90.0" : 3.0286536935190793,
+                "95.0" : 3.0286536935190793,
+                "99.0" : 3.0286536935190793,
+                "99.9" : 3.0286536935190793,
+                "99.99" : 3.0286536935190793,
+                "99.999" : 3.0286536935190793,
+                "99.9999" : 3.0286536935190793,
+                "100.0" : 3.0286536935190793
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9941406538922157,
+                    2.984406606205251,
+                    2.9893985026897787
+                ],
+                [
+                    3.0255277997580157,
+                    3.0286536935190793,
+                    3.0186985552202774
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7627103312443357,
+            "scoreError" : 0.031016850436280424,
+            "scoreConfidence" : [
+                2.7316934808080555,
+                2.793727181680616
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.750984371287129,
+                "50.0" : 2.762171124221677,
+                "90.0" : 2.7755559072994727,
+                "95.0" : 2.7755559072994727,
+                "99.0" : 2.7755559072994727,
+                "99.9" : 2.7755559072994727,
+                "99.99" : 2.7755559072994727,
+                "99.999" : 2.7755559072994727,
+                "99.9999" : 2.7755559072994727,
+                "100.0" : 2.7755559072994727
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.750984371287129,
+                    2.753696641795154,
+                    2.753606906112335
+                ],
+                [
+                    2.7755559072994727,
+                    2.771772554323725,
+                    2.7706456066481993
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.37934398450598367,
+            "scoreError" : 0.009258044597623685,
+            "scoreConfidence" : [
+                0.37008593990836,
+                0.38860202910360736
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3759727172450092,
+                "50.0" : 0.3793594624781804,
+                "90.0" : 0.3825197305588494,
+                "95.0" : 0.3825197305588494,
+                "99.0" : 0.3825197305588494,
+                "99.9" : 0.3825197305588494,
+                "99.99" : 0.3825197305588494,
+                "99.999" : 0.3825197305588494,
+                "99.9999" : 0.3825197305588494,
+                "100.0" : 0.3825197305588494
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.37657463518602197,
+                    0.3759727172450092,
+                    0.37646616413190787
+                ],
+                [
+                    0.3825197305588494,
+                    0.38238637014377486,
+                    0.38214428977033893
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15604235177883463,
+            "scoreError" : 0.0015673022018424204,
+            "scoreConfidence" : [
+                0.1544750495769922,
+                0.15760965398067706
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1552713251766167,
+                "50.0" : 0.1562050667249692,
+                "90.0" : 0.15658583309845922,
+                "95.0" : 0.15658583309845922,
+                "99.0" : 0.15658583309845922,
+                "99.9" : 0.15658583309845922,
+                "99.99" : 0.15658583309845922,
+                "99.999" : 0.15658583309845922,
+                "99.9999" : 0.15658583309845922,
+                "100.0" : 0.15658583309845922
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15653307247284226,
+                    0.15633128273511757,
+                    0.15658583309845922
+                ],
+                [
+                    0.15607885071482083,
+                    0.15545374647515117,
+                    0.1552713251766167
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40847529385022857,
+            "scoreError" : 0.005316662178859268,
+            "scoreConfidence" : [
+                0.4031586316713693,
+                0.41379195602908786
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4064888146492155,
+                "50.0" : 0.4079228127431598,
+                "90.0" : 0.41097232219619445,
+                "95.0" : 0.41097232219619445,
+                "99.0" : 0.41097232219619445,
+                "99.9" : 0.41097232219619445,
+                "99.99" : 0.41097232219619445,
+                "99.999" : 0.41097232219619445,
+                "99.9999" : 0.41097232219619445,
+                "100.0" : 0.41097232219619445
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4106439014084507,
+                    0.40690109936119134,
+                    0.4064888146492155
+                ],
+                [
+                    0.41097232219619445,
+                    0.40794401603165537,
+                    0.40790160945466414
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14699700237688015,
+            "scoreError" : 0.013987791453254668,
+            "scoreConfidence" : [
+                0.1330092109236255,
+                0.1609847938301348
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14244981731289708,
+                "50.0" : 0.14680221705877927,
+                "90.0" : 0.15231604388089254,
+                "95.0" : 0.15231604388089254,
+                "99.0" : 0.15231604388089254,
+                "99.9" : 0.15231604388089254,
+                "99.99" : 0.15231604388089254,
+                "99.999" : 0.15231604388089254,
+                "99.9999" : 0.15231604388089254,
+                "100.0" : 0.15231604388089254
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15113523244215393,
+                    0.15231604388089254,
+                    0.15114991658227656
+                ],
+                [
+                    0.14244981731289708,
+                    0.1424692016754046,
+                    0.14246180236765627
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04273501523289607,
+            "scoreError" : 8.755337277940193E-4,
+            "scoreConfidence" : [
+                0.041859481505102054,
+                0.04361054896069009
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04237876489808026,
+                "50.0" : 0.04273428193719846,
+                "90.0" : 0.043193786198049394,
+                "95.0" : 0.043193786198049394,
+                "99.0" : 0.043193786198049394,
+                "99.9" : 0.043193786198049394,
+                "99.99" : 0.043193786198049394,
+                "99.999" : 0.043193786198049394,
+                "99.9999" : 0.043193786198049394,
+                "100.0" : 0.043193786198049394
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.043193786198049394,
+                    0.04272414960993241,
+                    0.04274441426446451
+                ],
+                [
+                    0.042953487212968294,
+                    0.04241548921388156,
+                    0.04237876489808026
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7858625.06099766,
+            "scoreError" : 62695.01889915174,
+            "scoreConfidence" : [
+                7795930.042098508,
+                7921320.079896812
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7835110.302270948,
+                "50.0" : 7849657.917310001,
+                "90.0" : 7889688.858044164,
+                "95.0" : 7889688.858044164,
+                "99.0" : 7889688.858044164,
+                "99.9" : 7889688.858044164,
+                "99.99" : 7889688.858044164,
+                "99.999" : 7889688.858044164,
+                "99.9999" : 7889688.858044164,
+                "100.0" : 7889688.858044164
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7883284.0149724195,
+                    7851755.140502355,
+                    7835110.302270948
+                ],
+                [
+                    7889688.858044164,
+                    7844351.356078431,
+                    7847560.694117647
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-04T15-55-32Z-5b63591c242cd2ec5799fd60b5112ca326fb3eaf-jdk17.json
+++ b/performance-results/2026-03-04T15-55-32Z-5b63591c242cd2ec5799fd60b5112ca326fb3eaf-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3464877237382056,
+            "scoreError" : 0.02677753841586811,
+            "scoreConfidence" : [
+                3.3197101853223376,
+                3.3732652621540735
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.34224906056781,
+                "50.0" : 3.3460017732689202,
+                "90.0" : 3.3516982878471726,
+                "95.0" : 3.3516982878471726,
+                "99.0" : 3.3516982878471726,
+                "99.9" : 3.3516982878471726,
+                "99.99" : 3.3516982878471726,
+                "99.999" : 3.3516982878471726,
+                "99.9999" : 3.3516982878471726,
+                "100.0" : 3.3516982878471726
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.34224906056781,
+                    3.3477231144910773
+                ],
+                [
+                    3.3442804320467627,
+                    3.3516982878471726
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.685006573698312,
+            "scoreError" : 0.054075395962405085,
+            "scoreConfidence" : [
+                1.6309311777359068,
+                1.7390819696607172
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6762060965607064,
+                "50.0" : 1.684899061902684,
+                "90.0" : 1.6940220744271732,
+                "95.0" : 1.6940220744271732,
+                "99.0" : 1.6940220744271732,
+                "99.9" : 1.6940220744271732,
+                "99.99" : 1.6940220744271732,
+                "99.999" : 1.6940220744271732,
+                "99.9999" : 1.6940220744271732,
+                "100.0" : 1.6940220744271732
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6762060965607064,
+                    1.679832952952684
+                ],
+                [
+                    1.689965170852684,
+                    1.6940220744271732
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8468124553872491,
+            "scoreError" : 0.029691676169778476,
+            "scoreConfidence" : [
+                0.8171207792174706,
+                0.8765041315570277
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8428549067108986,
+                "50.0" : 0.8462410675776768,
+                "90.0" : 0.8519127796827443,
+                "95.0" : 0.8519127796827443,
+                "99.0" : 0.8519127796827443,
+                "99.9" : 0.8519127796827443,
+                "99.99" : 0.8519127796827443,
+                "99.999" : 0.8519127796827443,
+                "99.9999" : 0.8519127796827443,
+                "100.0" : 0.8519127796827443
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8494821043108255,
+                    0.8519127796827443
+                ],
+                [
+                    0.8428549067108986,
+                    0.8430000308445281
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.929889624342458,
+            "scoreError" : 0.1455936799278864,
+            "scoreConfidence" : [
+                15.784295944414572,
+                16.075483304270346
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.868892648113412,
+                "50.0" : 15.914855129901788,
+                "90.0" : 15.997330011461663,
+                "95.0" : 15.997330011461663,
+                "99.0" : 15.997330011461663,
+                "99.9" : 15.997330011461663,
+                "99.99" : 15.997330011461663,
+                "99.999" : 15.997330011461663,
+                "99.9999" : 15.997330011461663,
+                "100.0" : 15.997330011461663
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.987489144203176,
+                    15.997330011461663,
+                    15.89591568247292
+                ],
+                [
+                    15.868892648113412,
+                    15.902904270234822,
+                    15.926805989568752
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2648.271888202066,
+            "scoreError" : 17.047507270710934,
+            "scoreConfidence" : [
+                2631.224380931355,
+                2665.3193954727767
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2640.2483471921246,
+                "50.0" : 2648.9679112599943,
+                "90.0" : 2654.485960291809,
+                "95.0" : 2654.485960291809,
+                "99.0" : 2654.485960291809,
+                "99.9" : 2654.485960291809,
+                "99.99" : 2654.485960291809,
+                "99.999" : 2654.485960291809,
+                "99.9999" : 2654.485960291809,
+                "100.0" : 2654.485960291809
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2653.751410618996,
+                    2652.5160761771544,
+                    2654.485960291809
+                ],
+                [
+                    2640.2483471921246,
+                    2645.4197463428345,
+                    2643.2097885894764
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73841.40088795895,
+            "scoreError" : 1288.2825613815403,
+            "scoreConfidence" : [
+                72553.11832657742,
+                75129.68344934049
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73406.353225403,
+                "50.0" : 73844.54766941488,
+                "90.0" : 74269.75103226713,
+                "95.0" : 74269.75103226713,
+                "99.0" : 74269.75103226713,
+                "99.9" : 74269.75103226713,
+                "99.99" : 74269.75103226713,
+                "99.999" : 74269.75103226713,
+                "99.9999" : 74269.75103226713,
+                "100.0" : 74269.75103226713
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73440.85279219187,
+                    73419.34898613728,
+                    73406.353225403
+                ],
+                [
+                    74248.24254663789,
+                    74269.75103226713,
+                    74263.85674511653
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 347.5269583886741,
+            "scoreError" : 5.802707852577095,
+            "scoreConfidence" : [
+                341.724250536097,
+                353.3296662412512
+            ],
+            "scorePercentiles" : {
+                "0.0" : 345.2809427362871,
+                "50.0" : 347.5860237205561,
+                "90.0" : 349.6097874246335,
+                "95.0" : 349.6097874246335,
+                "99.0" : 349.6097874246335,
+                "99.9" : 349.6097874246335,
+                "99.99" : 349.6097874246335,
+                "99.999" : 349.6097874246335,
+                "99.9999" : 349.6097874246335,
+                "100.0" : 349.6097874246335
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    345.72882525619195,
+                    345.2809427362871,
+                    345.94442776387956
+                ],
+                [
+                    349.22761967723267,
+                    349.3701474738198,
+                    349.6097874246335
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 123.14686860363175,
+            "scoreError" : 5.8538860077522985,
+            "scoreConfidence" : [
+                117.29298259587945,
+                129.00075461138405
+            ],
+            "scorePercentiles" : {
+                "0.0" : 120.97857725871332,
+                "50.0" : 123.05724312536431,
+                "90.0" : 125.24994258289733,
+                "95.0" : 125.24994258289733,
+                "99.0" : 125.24994258289733,
+                "99.9" : 125.24994258289733,
+                "99.99" : 125.24994258289733,
+                "99.999" : 125.24994258289733,
+                "99.9999" : 125.24994258289733,
+                "100.0" : 125.24994258289733
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    120.97857725871332,
+                    121.29170369598387,
+                    121.50824341451026
+                ],
+                [
+                    125.24650183346735,
+                    125.24994258289733,
+                    124.60624283621836
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06218009018753479,
+            "scoreError" : 0.0016397103187336863,
+            "scoreConfidence" : [
+                0.0605403798688011,
+                0.06381980050626847
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06163635879688126,
+                "50.0" : 0.0621355931869198,
+                "90.0" : 0.06278144557588237,
+                "95.0" : 0.06278144557588237,
+                "99.0" : 0.06278144557588237,
+                "99.9" : 0.06278144557588237,
+                "99.99" : 0.06278144557588237,
+                "99.999" : 0.06278144557588237,
+                "99.9999" : 0.06278144557588237,
+                "100.0" : 0.06278144557588237
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06165410185698961,
+                    0.06163635879688126,
+                    0.06165546835271342
+                ],
+                [
+                    0.06278144557588237,
+                    0.06273744852161584,
+                    0.06261571802112618
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.80740728780994E-4,
+            "scoreError" : 7.504226162553439E-6,
+            "scoreConfidence" : [
+                3.7323650261844056E-4,
+                3.8824495494354746E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.775804837283539E-4,
+                "50.0" : 3.8075375822329313E-4,
+                "90.0" : 3.837914559426028E-4,
+                "95.0" : 3.837914559426028E-4,
+                "99.0" : 3.837914559426028E-4,
+                "99.9" : 3.837914559426028E-4,
+                "99.99" : 3.837914559426028E-4,
+                "99.999" : 3.837914559426028E-4,
+                "99.9999" : 3.837914559426028E-4,
+                "100.0" : 3.837914559426028E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.775804837283539E-4,
+                    3.795544094572079E-4,
+                    3.7817169010614054E-4
+                ],
+                [
+                    3.833932264622808E-4,
+                    3.837914559426028E-4,
+                    3.8195310698937833E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1931132494989747,
+            "scoreError" : 0.04797815952921766,
+            "scoreConfidence" : [
+                2.145135089969757,
+                2.241091409028192
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.157861086515642,
+                "50.0" : 2.1766284781849157,
+                "90.0" : 2.241341995225376,
+                "95.0" : 2.2418490755436,
+                "99.0" : 2.2418490755436,
+                "99.9" : 2.2418490755436,
+                "99.99" : 2.2418490755436,
+                "99.999" : 2.2418490755436,
+                "99.9999" : 2.2418490755436,
+                "100.0" : 2.2418490755436
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.2328916601920072,
+                    2.1925548724243753,
+                    2.176793519373095,
+                    2.157861086515642,
+                    2.165041175974026
+                ],
+                [
+                    2.2418490755436,
+                    2.2367782723613594,
+                    2.1764634369967357,
+                    2.1761554684508266,
+                    2.1747439271580777
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013691086472446802,
+            "scoreError" : 1.842949091675639E-4,
+            "scoreConfidence" : [
+                0.013506791563279238,
+                0.013875381381614366
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013628202177488924,
+                "50.0" : 0.013688678633520255,
+                "90.0" : 0.013763779404478113,
+                "95.0" : 0.013763779404478113,
+                "99.0" : 0.013763779404478113,
+                "99.9" : 0.013763779404478113,
+                "99.99" : 0.013763779404478113,
+                "99.999" : 0.013763779404478113,
+                "99.9999" : 0.013763779404478113,
+                "100.0" : 0.013763779404478113
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013744393613906905,
+                    0.013743930906097273,
+                    0.013763779404478113
+                ],
+                [
+                    0.013628202177488924,
+                    0.013632786371766348,
+                    0.013633426360943236
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0286886212528175,
+            "scoreError" : 0.06807667097271303,
+            "scoreConfidence" : [
+                0.9606119502801045,
+                1.0967652922255304
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0061782717577221,
+                "50.0" : 1.0287468819766037,
+                "90.0" : 1.0511103775488753,
+                "95.0" : 1.0511103775488753,
+                "99.0" : 1.0511103775488753,
+                "99.9" : 1.0511103775488753,
+                "99.99" : 1.0511103775488753,
+                "99.999" : 1.0511103775488753,
+                "99.9999" : 1.0511103775488753,
+                "100.0" : 1.0511103775488753
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0068852346959323,
+                    1.0065218597020933,
+                    1.0061782717577221
+                ],
+                [
+                    1.050827454555007,
+                    1.0511103775488753,
+                    1.0506085292572749
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.011085408376674115,
+            "scoreError" : 6.651684262192348E-4,
+            "scoreConfidence" : [
+                0.010420239950454881,
+                0.01175057680289335
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010849377463541858,
+                "50.0" : 0.011091545901436406,
+                "90.0" : 0.011306787801767413,
+                "95.0" : 0.011306787801767413,
+                "99.0" : 0.011306787801767413,
+                "99.9" : 0.011306787801767413,
+                "99.99" : 0.011306787801767413,
+                "99.999" : 0.011306787801767413,
+                "99.9999" : 0.011306787801767413,
+                "100.0" : 0.011306787801767413
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01086725511725457,
+                    0.010891154785449794,
+                    0.010849377463541858
+                ],
+                [
+                    0.011306787801767413,
+                    0.011305938074608035,
+                    0.01129193701742302
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.180608520996728,
+            "scoreError" : 0.06840971458320794,
+            "scoreConfidence" : [
+                3.1121988064135198,
+                3.249018235579936
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1578823011363637,
+                "50.0" : 3.1778083918541453,
+                "90.0" : 3.2089174041051955,
+                "95.0" : 3.2089174041051955,
+                "99.0" : 3.2089174041051955,
+                "99.9" : 3.2089174041051955,
+                "99.99" : 3.2089174041051955,
+                "99.999" : 3.2089174041051955,
+                "99.9999" : 3.2089174041051955,
+                "100.0" : 3.2089174041051955
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.195664089456869,
+                    3.2089174041051955,
+                    3.203028366197183
+                ],
+                [
+                    3.1578823011363637,
+                    3.1599526942514213,
+                    3.1582062708333334
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.825187411109074,
+            "scoreError" : 0.1218511299071568,
+            "scoreConfidence" : [
+                2.703336281201917,
+                2.947038541016231
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.783738078485945,
+                "50.0" : 2.825649311482899,
+                "90.0" : 2.868744246987952,
+                "95.0" : 2.868744246987952,
+                "99.0" : 2.868744246987952,
+                "99.9" : 2.868744246987952,
+                "99.99" : 2.868744246987952,
+                "99.999" : 2.868744246987952,
+                "99.9999" : 2.868744246987952,
+                "100.0" : 2.868744246987952
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.862273651688609,
+                    2.863282299456055,
+                    2.868744246987952
+                ],
+                [
+                    2.7840612187586973,
+                    2.783738078485945,
+                    2.789024971277189
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.38396336683685744,
+            "scoreError" : 0.010405836203516037,
+            "scoreConfidence" : [
+                0.3735575306333414,
+                0.3943692030403735
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3804131040779063,
+                "50.0" : 0.3835057972221488,
+                "90.0" : 0.3889864963242444,
+                "95.0" : 0.3889864963242444,
+                "99.0" : 0.3889864963242444,
+                "99.9" : 0.3889864963242444,
+                "99.99" : 0.3889864963242444,
+                "99.999" : 0.3889864963242444,
+                "99.9999" : 0.3889864963242444,
+                "100.0" : 0.3889864963242444
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3809135803527216,
+                    0.38076891254188244,
+                    0.3804131040779063
+                ],
+                [
+                    0.38609801409157596,
+                    0.386600093632814,
+                    0.3889864963242444
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15972375694606614,
+            "scoreError" : 0.00682195759368576,
+            "scoreConfidence" : [
+                0.15290179935238038,
+                0.1665457145397519
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1577232266662461,
+                "50.0" : 0.15902344703564314,
+                "90.0" : 0.16398960505731294,
+                "95.0" : 0.16398960505731294,
+                "99.0" : 0.16398960505731294,
+                "99.9" : 0.16398960505731294,
+                "99.99" : 0.16398960505731294,
+                "99.999" : 0.16398960505731294,
+                "99.9999" : 0.16398960505731294,
+                "100.0" : 0.16398960505731294
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15815126375885627,
+                    0.15778869668807297,
+                    0.1577232266662461
+                ],
+                [
+                    0.16398960505731294,
+                    0.16079411919347836,
+                    0.15989563031243004
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40790740638361406,
+            "scoreError" : 0.021603432392591267,
+            "scoreConfidence" : [
+                0.3863039739910228,
+                0.42951083877620533
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40065878982371794,
+                "50.0" : 0.406807284285192,
+                "90.0" : 0.4186054043114274,
+                "95.0" : 0.4186054043114274,
+                "99.0" : 0.4186054043114274,
+                "99.9" : 0.4186054043114274,
+                "99.99" : 0.4186054043114274,
+                "99.999" : 0.4186054043114274,
+                "99.9999" : 0.4186054043114274,
+                "100.0" : 0.4186054043114274
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40115851871314534,
+                    0.40173024814204794,
+                    0.40065878982371794
+                ],
+                [
+                    0.4186054043114274,
+                    0.4134071568830095,
+                    0.41188432042833606
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1487737508585856,
+            "scoreError" : 0.003478749025633361,
+            "scoreConfidence" : [
+                0.14529500183295224,
+                0.15225249988421896
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1474804434792868,
+                "50.0" : 0.14847191743228505,
+                "90.0" : 0.15076869664852477,
+                "95.0" : 0.15076869664852477,
+                "99.0" : 0.15076869664852477,
+                "99.9" : 0.15076869664852477,
+                "99.99" : 0.15076869664852477,
+                "99.999" : 0.15076869664852477,
+                "99.9999" : 0.15076869664852477,
+                "100.0" : 0.15076869664852477
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14798189671194767,
+                    0.14789555179910377,
+                    0.1474804434792868
+                ],
+                [
+                    0.15076869664852477,
+                    0.14955397836002812,
+                    0.1489619381526224
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04269175877827907,
+            "scoreError" : 0.001883779583585987,
+            "scoreConfidence" : [
+                0.04080797919469308,
+                0.04457553836186506
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04207145036748466,
+                "50.0" : 0.042663749738822365,
+                "90.0" : 0.043382238303262724,
+                "95.0" : 0.043382238303262724,
+                "99.0" : 0.043382238303262724,
+                "99.9" : 0.043382238303262724,
+                "99.99" : 0.043382238303262724,
+                "99.999" : 0.043382238303262724,
+                "99.9999" : 0.043382238303262724,
+                "100.0" : 0.043382238303262724
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.042092600178469206,
+                    0.042076092141138055,
+                    0.04207145036748466
+                ],
+                [
+                    0.043382238303262724,
+                    0.043234899299175525,
+                    0.04329327238014425
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7920068.788791708,
+            "scoreError" : 175692.1780214243,
+            "scoreConfidence" : [
+                7744376.610770283,
+                8095760.966813132
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7844983.267450981,
+                "50.0" : 7920689.755395299,
+                "90.0" : 7992336.044728435,
+                "95.0" : 7992336.044728435,
+                "99.0" : 7992336.044728435,
+                "99.9" : 7992336.044728435,
+                "99.99" : 7992336.044728435,
+                "99.999" : 7992336.044728435,
+                "99.9999" : 7992336.044728435,
+                "100.0" : 7992336.044728435
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7960995.823389022,
+                    7992336.044728435,
+                    7973372.45816733
+                ],
+                [
+                    7868341.451612903,
+                    7880383.687401575,
+                    7844983.267450981
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-04T15-57-01Z-5b63591c242cd2ec5799fd60b5112ca326fb3eaf-jdk17.json
+++ b/performance-results/2026-03-04T15-57-01Z-5b63591c242cd2ec5799fd60b5112ca326fb3eaf-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3549126192104644,
+            "scoreError" : 0.03312996843740769,
+            "scoreConfidence" : [
+                3.3217826507730566,
+                3.388042587647872
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.349061174391813,
+                "50.0" : 3.355269085362843,
+                "90.0" : 3.360051131724358,
+                "95.0" : 3.360051131724358,
+                "99.0" : 3.360051131724358,
+                "99.9" : 3.360051131724358,
+                "99.99" : 3.360051131724358,
+                "99.999" : 3.360051131724358,
+                "99.9999" : 3.360051131724358,
+                "100.0" : 3.360051131724358
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.35227263451382,
+                    3.360051131724358
+                ],
+                [
+                    3.349061174391813,
+                    3.3582655362118654
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6905864552927605,
+            "scoreError" : 0.030493036247896968,
+            "scoreConfidence" : [
+                1.6600934190448635,
+                1.7210794915406575
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6851073469984776,
+                "50.0" : 1.6912421738139023,
+                "90.0" : 1.69475412654476,
+                "95.0" : 1.69475412654476,
+                "99.0" : 1.69475412654476,
+                "99.9" : 1.69475412654476,
+                "99.99" : 1.69475412654476,
+                "99.999" : 1.69475412654476,
+                "99.9999" : 1.69475412654476,
+                "100.0" : 1.69475412654476
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6851073469984776,
+                    1.69475412654476
+                ],
+                [
+                    1.688196516553262,
+                    1.6942878310745424
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8529954667737984,
+            "scoreError" : 0.01623082685514137,
+            "scoreConfidence" : [
+                0.8367646399186571,
+                0.8692262936289398
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8501040428689175,
+                "50.0" : 0.8532698581178222,
+                "90.0" : 0.855338107990632,
+                "95.0" : 0.855338107990632,
+                "99.0" : 0.855338107990632,
+                "99.9" : 0.855338107990632,
+                "99.99" : 0.855338107990632,
+                "99.999" : 0.855338107990632,
+                "99.9999" : 0.855338107990632,
+                "100.0" : 0.855338107990632
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8501040428689175,
+                    0.8548395091009615
+                ],
+                [
+                    0.8517002071346828,
+                    0.855338107990632
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.246665114396777,
+            "scoreError" : 0.14093471234268778,
+            "scoreConfidence" : [
+                16.10573040205409,
+                16.387599826739464
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.189635103571472,
+                "50.0" : 16.249526762857553,
+                "90.0" : 16.3003077338523,
+                "95.0" : 16.3003077338523,
+                "99.0" : 16.3003077338523,
+                "99.9" : 16.3003077338523,
+                "99.99" : 16.3003077338523,
+                "99.999" : 16.3003077338523,
+                "99.9999" : 16.3003077338523,
+                "100.0" : 16.3003077338523
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.19451817489746,
+                    16.189635103571472,
+                    16.2241999058416
+                ],
+                [
+                    16.274853619873504,
+                    16.3003077338523,
+                    16.296476148344333
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2773.2377385711425,
+            "scoreError" : 157.82446730707179,
+            "scoreConfidence" : [
+                2615.4132712640708,
+                2931.062205878214
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2714.4100834619353,
+                "50.0" : 2774.3980573149097,
+                "90.0" : 2826.846584758903,
+                "95.0" : 2826.846584758903,
+                "99.0" : 2826.846584758903,
+                "99.9" : 2826.846584758903,
+                "99.99" : 2826.846584758903,
+                "99.999" : 2826.846584758903,
+                "99.9999" : 2826.846584758903,
+                "100.0" : 2826.846584758903
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2724.690665761759,
+                    2714.4100834619353,
+                    2726.977399633983
+                ],
+                [
+                    2821.818714995836,
+                    2824.682982814438,
+                    2826.846584758903
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74060.49439965603,
+            "scoreError" : 3394.6050336656845,
+            "scoreConfidence" : [
+                70665.88936599036,
+                77455.09943332171
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72909.82466028706,
+                "50.0" : 74075.2174792141,
+                "90.0" : 75196.05991689468,
+                "95.0" : 75196.05991689468,
+                "99.0" : 75196.05991689468,
+                "99.9" : 75196.05991689468,
+                "99.99" : 75196.05991689468,
+                "99.999" : 75196.05991689468,
+                "99.9999" : 75196.05991689468,
+                "100.0" : 75196.05991689468
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72933.73823008733,
+                    73024.95219454047,
+                    72909.82466028706
+                ],
+                [
+                    75125.48276388775,
+                    75172.90863223896,
+                    75196.05991689468
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 351.025982899979,
+            "scoreError" : 2.3970918599553492,
+            "scoreConfidence" : [
+                348.62889104002363,
+                353.42307475993437
+            ],
+            "scorePercentiles" : {
+                "0.0" : 350.1755588315378,
+                "50.0" : 350.99176692249057,
+                "90.0" : 352.4351154617206,
+                "95.0" : 352.4351154617206,
+                "99.0" : 352.4351154617206,
+                "99.9" : 352.4351154617206,
+                "99.99" : 352.4351154617206,
+                "99.999" : 352.4351154617206,
+                "99.9999" : 352.4351154617206,
+                "100.0" : 352.4351154617206
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    350.1755588315378,
+                    350.2219149771252,
+                    350.67757711463514
+                ],
+                [
+                    351.33977428450953,
+                    351.30595673034594,
+                    352.4351154617206
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 126.99493372298038,
+            "scoreError" : 3.2838691774761504,
+            "scoreConfidence" : [
+                123.71106454550423,
+                130.27880290045653
+            ],
+            "scorePercentiles" : {
+                "0.0" : 125.81686930932005,
+                "50.0" : 127.00270872643219,
+                "90.0" : 128.14457465228224,
+                "95.0" : 128.14457465228224,
+                "99.0" : 128.14457465228224,
+                "99.9" : 128.14457465228224,
+                "99.99" : 128.14457465228224,
+                "99.999" : 128.14457465228224,
+                "99.9999" : 128.14457465228224,
+                "100.0" : 128.14457465228224
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    127.96946273668577,
+                    128.06860051192544,
+                    128.14457465228224
+                ],
+                [
+                    125.93414041149022,
+                    125.81686930932005,
+                    126.03595471617861
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06141208783219106,
+            "scoreError" : 0.0014782923498632768,
+            "scoreConfidence" : [
+                0.05993379548232779,
+                0.06289038018205434
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06090363275212093,
+                "50.0" : 0.06141443053810175,
+                "90.0" : 0.06198523540605204,
+                "95.0" : 0.06198523540605204,
+                "99.0" : 0.06198523540605204,
+                "99.9" : 0.06198523540605204,
+                "99.99" : 0.06198523540605204,
+                "99.999" : 0.06198523540605204,
+                "99.9999" : 0.06198523540605204,
+                "100.0" : 0.06198523540605204
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06099095198248364,
+                    0.060907586207106575,
+                    0.06090363275212093
+                ],
+                [
+                    0.06198523540605204,
+                    0.061837909093719855,
+                    0.06184721155166336
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.672482376152878E-4,
+            "scoreError" : 4.717341847780108E-5,
+            "scoreConfidence" : [
+                3.200748191374867E-4,
+                4.1442165609308887E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.513697659956267E-4,
+                "50.0" : 3.6764803129163583E-4,
+                "90.0" : 3.828423239780553E-4,
+                "95.0" : 3.828423239780553E-4,
+                "99.0" : 3.828423239780553E-4,
+                "99.9" : 3.828423239780553E-4,
+                "99.99" : 3.828423239780553E-4,
+                "99.999" : 3.828423239780553E-4,
+                "99.9999" : 3.828423239780553E-4,
+                "100.0" : 3.828423239780553E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.8250288784459147E-4,
+                    3.828423239780553E-4,
+                    3.8244614114088277E-4
+                ],
+                [
+                    3.5147838529018144E-4,
+                    3.513697659956267E-4,
+                    3.528499214423889E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1069612903949304,
+            "scoreError" : 0.05127496617884265,
+            "scoreConfidence" : [
+                2.055686324216088,
+                2.158236256573773
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.061325843981863,
+                "50.0" : 2.107094311993527,
+                "90.0" : 2.162253085201889,
+                "95.0" : 2.163710775254164,
+                "99.0" : 2.163710775254164,
+                "99.9" : 2.163710775254164,
+                "99.99" : 2.163710775254164,
+                "99.999" : 2.163710775254164,
+                "99.9999" : 2.163710775254164,
+                "100.0" : 2.163710775254164
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.163710775254164,
+                    2.149133874731414,
+                    2.1115154341216216,
+                    2.0989091294858344,
+                    2.102673189865433
+                ],
+                [
+                    2.1237417976215758,
+                    2.1187095262711866,
+                    2.068100717948718,
+                    2.0717926146674954,
+                    2.061325843981863
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013521800744887949,
+            "scoreError" : 1.1005459308230965E-4,
+            "scoreConfidence" : [
+                0.01341174615180564,
+                0.013631855337970258
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013471980220721765,
+                "50.0" : 0.013524969335937968,
+                "90.0" : 0.01356039041780403,
+                "95.0" : 0.01356039041780403,
+                "99.0" : 0.01356039041780403,
+                "99.9" : 0.01356039041780403,
+                "99.99" : 0.01356039041780403,
+                "99.999" : 0.01356039041780403,
+                "99.9999" : 0.01356039041780403,
+                "100.0" : 0.01356039041780403
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013496535164031332,
+                    0.013491989680136861,
+                    0.013471980220721765
+                ],
+                [
+                    0.01356039041780403,
+                    0.013553403507844604,
+                    0.013556505478789095
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.02562404533425,
+            "scoreError" : 0.018667920988045615,
+            "scoreConfidence" : [
+                1.0069561243462044,
+                1.0442919663222956
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0188704986245543,
+                "50.0" : 1.0252968219650294,
+                "90.0" : 1.0331605598140496,
+                "95.0" : 1.0331605598140496,
+                "99.0" : 1.0331605598140496,
+                "99.9" : 1.0331605598140496,
+                "99.99" : 1.0331605598140496,
+                "99.999" : 1.0331605598140496,
+                "99.9999" : 1.0331605598140496,
+                "100.0" : 1.0331605598140496
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0331605598140496,
+                    1.031317108796535,
+                    1.0304282698608964
+                ],
+                [
+                    1.0188704986245543,
+                    1.0198024608403018,
+                    1.0201653740691625
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010351818989801661,
+            "scoreError" : 1.343031565945526E-4,
+            "scoreConfidence" : [
+                0.01021751583320711,
+                0.010486122146396213
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01030365934165571,
+                "50.0" : 0.010351094388523815,
+                "90.0" : 0.010401389739471955,
+                "95.0" : 0.010401389739471955,
+                "99.0" : 0.010401389739471955,
+                "99.9" : 0.010401389739471955,
+                "99.99" : 0.010401389739471955,
+                "99.999" : 0.010401389739471955,
+                "99.9999" : 0.010401389739471955,
+                "100.0" : 0.010401389739471955
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010384323401321269,
+                    0.010401389739471955,
+                    0.010399182964899474
+                ],
+                [
+                    0.01031786537572636,
+                    0.01030365934165571,
+                    0.010304493115735197
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1610999888332394,
+            "scoreError" : 0.40575904724918394,
+            "scoreConfidence" : [
+                2.7553409415840555,
+                3.5668590360824233
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0235904957678357,
+                "50.0" : 3.158208443348144,
+                "90.0" : 3.29845551055409,
+                "95.0" : 3.29845551055409,
+                "99.0" : 3.29845551055409,
+                "99.9" : 3.29845551055409,
+                "99.99" : 3.29845551055409,
+                "99.999" : 3.29845551055409,
+                "99.9999" : 3.29845551055409,
+                "100.0" : 3.29845551055409
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.297147691496374,
+                    3.29845551055409,
+                    3.283621913985555
+                ],
+                [
+                    3.0235904957678357,
+                    3.0327949727107337,
+                    3.0309893484848485
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8657484517966574,
+            "scoreError" : 0.18004490788443717,
+            "scoreConfidence" : [
+                2.6857035439122203,
+                3.0457933596810944
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.798987339770501,
+                "50.0" : 2.8673118518440566,
+                "90.0" : 2.9274537085162424,
+                "95.0" : 2.9274537085162424,
+                "99.0" : 2.9274537085162424,
+                "99.9" : 2.9274537085162424,
+                "99.99" : 2.9274537085162424,
+                "99.999" : 2.9274537085162424,
+                "99.9999" : 2.9274537085162424,
+                "100.0" : 2.9274537085162424
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9274537085162424,
+                    2.9219104910896876,
+                    2.923186575270389
+                ],
+                [
+                    2.798987339770501,
+                    2.8102393835347006,
+                    2.812713212598425
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3921168642172456,
+            "scoreError" : 0.03478309545813318,
+            "scoreConfidence" : [
+                0.35733376875911244,
+                0.4268999596753788
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3805507246090034,
+                "50.0" : 0.3919750554403152,
+                "90.0" : 0.404115971995474,
+                "95.0" : 0.404115971995474,
+                "99.0" : 0.404115971995474,
+                "99.9" : 0.404115971995474,
+                "99.99" : 0.404115971995474,
+                "99.999" : 0.404115971995474,
+                "99.9999" : 0.404115971995474,
+                "100.0" : 0.404115971995474
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.38107054589795375,
+                    0.3805507246090034,
+                    0.3807800342687431
+                ],
+                [
+                    0.4033043435496229,
+                    0.40287956498267663,
+                    0.404115971995474
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15760507529158188,
+            "scoreError" : 0.003812898782618101,
+            "scoreConfidence" : [
+                0.1537921765089638,
+                0.16141797407419997
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15623508811536238,
+                "50.0" : 0.15754509265593641,
+                "90.0" : 0.15938556441356008,
+                "95.0" : 0.15938556441356008,
+                "99.0" : 0.15938556441356008,
+                "99.9" : 0.15938556441356008,
+                "99.99" : 0.15938556441356008,
+                "99.999" : 0.15938556441356008,
+                "99.9999" : 0.15938556441356008,
+                "100.0" : 0.15938556441356008
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15938556441356008,
+                    0.15861104529810147,
+                    0.158410262145765
+                ],
+                [
+                    0.15667992316610785,
+                    0.15630856861059444,
+                    0.15623508811536238
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4084600893020445,
+            "scoreError" : 8.895951645527897E-4,
+            "scoreConfidence" : [
+                0.40757049413749175,
+                0.4093496844665973
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40811891980901077,
+                "50.0" : 0.4084695012651397,
+                "90.0" : 0.4089208489470456,
+                "95.0" : 0.4089208489470456,
+                "99.0" : 0.4089208489470456,
+                "99.9" : 0.4089208489470456,
+                "99.99" : 0.4089208489470456,
+                "99.999" : 0.4089208489470456,
+                "99.9999" : 0.4089208489470456,
+                "100.0" : 0.4089208489470456
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4089208489470456,
+                    0.4086349108405181,
+                    0.40862057745270297
+                ],
+                [
+                    0.4083184250775764,
+                    0.40811891980901077,
+                    0.4081468536854134
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14217875872014654,
+            "scoreError" : 0.00688123694686036,
+            "scoreConfidence" : [
+                0.1352975217732862,
+                0.1490599956670069
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.13986034207913176,
+                "50.0" : 0.14213825182404577,
+                "90.0" : 0.1445066746047802,
+                "95.0" : 0.1445066746047802,
+                "99.0" : 0.1445066746047802,
+                "99.9" : 0.1445066746047802,
+                "99.99" : 0.1445066746047802,
+                "99.999" : 0.1445066746047802,
+                "99.9999" : 0.1445066746047802,
+                "100.0" : 0.1445066746047802
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1445066746047802,
+                    0.14427649862219208,
+                    0.1444688693296735
+                ],
+                [
+                    0.1400000050258995,
+                    0.13986034207913176,
+                    0.13996016265920225
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04370382904615763,
+            "scoreError" : 7.486903300073452E-4,
+            "scoreConfidence" : [
+                0.04295513871615029,
+                0.04445251937616498
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04334781497743891,
+                "50.0" : 0.04366545411616745,
+                "90.0" : 0.04403792991078113,
+                "95.0" : 0.04403792991078113,
+                "99.0" : 0.04403792991078113,
+                "99.9" : 0.04403792991078113,
+                "99.99" : 0.04403792991078113,
+                "99.999" : 0.04403792991078113,
+                "99.9999" : 0.04403792991078113,
+                "100.0" : 0.04403792991078113
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04403792991078113,
+                    0.0439671931315565,
+                    0.04334781497743891
+                ],
+                [
+                    0.04376193480896054,
+                    0.04356897342337436,
+                    0.04353912802483434
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7729330.838420552,
+            "scoreError" : 241375.78578702305,
+            "scoreConfidence" : [
+                7487955.0526335295,
+                7970706.624207575
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7647972.928899082,
+                "50.0" : 7723805.352991283,
+                "90.0" : 7836951.089271731,
+                "95.0" : 7836951.089271731,
+                "99.0" : 7836951.089271731,
+                "99.9" : 7836951.089271731,
+                "99.99" : 7836951.089271731,
+                "99.999" : 7836951.089271731,
+                "99.9999" : 7836951.089271731,
+                "100.0" : 7836951.089271731
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7836951.089271731,
+                    7787049.048249028,
+                    7794761.709275137
+                ],
+                [
+                    7648688.597094801,
+                    7660561.657733537,
+                    7647972.928899082
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-04T15-57-45Z-5b63591c242cd2ec5799fd60b5112ca326fb3eaf-jdk17.json
+++ b/performance-results/2026-03-04T15-57-45Z-5b63591c242cd2ec5799fd60b5112ca326fb3eaf-jdk17.json
@@ -1,0 +1,1226 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3484660090575824,
+            "scoreError" : 0.03794026240993792,
+            "scoreConfidence" : [
+                3.3105257466476443,
+                3.3864062714675205
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.344529495684153,
+                "50.0" : 3.3460893249824837,
+                "90.0" : 3.3571558905812116,
+                "95.0" : 3.3571558905812116,
+                "99.0" : 3.3571558905812116,
+                "99.9" : 3.3571558905812116,
+                "99.99" : 3.3571558905812116,
+                "99.999" : 3.3571558905812116,
+                "99.9999" : 3.3571558905812116,
+                "100.0" : 3.3571558905812116
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.344529495684153,
+                    3.346833963783715
+                ],
+                [
+                    3.345344686181252,
+                    3.3571558905812116
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6836340173207045,
+            "scoreError" : 0.050364492998589416,
+            "scoreConfidence" : [
+                1.6332695243221151,
+                1.7339985103192939
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6753899201853655,
+                "50.0" : 1.6843149637595691,
+                "90.0" : 1.6905162215783143,
+                "95.0" : 1.6905162215783143,
+                "99.0" : 1.6905162215783143,
+                "99.9" : 1.6905162215783143,
+                "99.99" : 1.6905162215783143,
+                "99.999" : 1.6905162215783143,
+                "99.9999" : 1.6905162215783143,
+                "100.0" : 1.6905162215783143
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6905162215783143,
+                    1.6900586662688213
+                ],
+                [
+                    1.6753899201853655,
+                    1.6785712612503167
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8469004936731376,
+            "scoreError" : 0.06696856368957471,
+            "scoreConfidence" : [
+                0.7799319299835629,
+                0.9138690573627123
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8340371579845408,
+                "50.0" : 0.8489548163173752,
+                "90.0" : 0.8556551840732588,
+                "95.0" : 0.8556551840732588,
+                "99.0" : 0.8556551840732588,
+                "99.9" : 0.8556551840732588,
+                "99.99" : 0.8556551840732588,
+                "99.999" : 0.8556551840732588,
+                "99.9999" : 0.8556551840732588,
+                "100.0" : 0.8556551840732588
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8340371579845408,
+                    0.8549403562957836
+                ],
+                [
+                    0.8429692763389668,
+                    0.8556551840732588
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.919676780257303,
+            "scoreError" : 0.09132179978541625,
+            "scoreConfidence" : [
+                15.828354980471888,
+                16.01099858004272
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.870314123270603,
+                "50.0" : 15.924523761505533,
+                "90.0" : 15.962909203327747,
+                "95.0" : 15.962909203327747,
+                "99.0" : 15.962909203327747,
+                "99.9" : 15.962909203327747,
+                "99.99" : 15.962909203327747,
+                "99.999" : 15.962909203327747,
+                "99.9999" : 15.962909203327747,
+                "100.0" : 15.962909203327747
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.870314123270603,
+                    15.897010532924908,
+                    15.93050005098674
+                ],
+                [
+                    15.918547472024327,
+                    15.962909203327747,
+                    15.93877929900948
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2659.0825802299264,
+            "scoreError" : 35.95470751700157,
+            "scoreConfidence" : [
+                2623.1278727129247,
+                2695.037287746928
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2645.2946491859684,
+                "50.0" : 2660.027262758361,
+                "90.0" : 2672.793525676381,
+                "95.0" : 2672.793525676381,
+                "99.0" : 2672.793525676381,
+                "99.9" : 2672.793525676381,
+                "99.99" : 2672.793525676381,
+                "99.999" : 2672.793525676381,
+                "99.9999" : 2672.793525676381,
+                "100.0" : 2672.793525676381
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2651.6368866535586,
+                    2668.417638863163,
+                    2645.9356584444063
+                ],
+                [
+                    2670.4171225560826,
+                    2645.2946491859684,
+                    2672.793525676381
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 72684.28167083,
+            "scoreError" : 807.8980108133322,
+            "scoreConfidence" : [
+                71876.38366001667,
+                73492.17968164332
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72390.02207799129,
+                "50.0" : 72617.8016597506,
+                "90.0" : 73129.49667520527,
+                "95.0" : 73129.49667520527,
+                "99.0" : 73129.49667520527,
+                "99.9" : 73129.49667520527,
+                "99.99" : 73129.49667520527,
+                "99.999" : 73129.49667520527,
+                "99.9999" : 73129.49667520527,
+                "100.0" : 73129.49667520527
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72920.11638055014,
+                    72592.03184236746,
+                    73129.49667520527
+                ],
+                [
+                    72643.57147713374,
+                    72430.45157173206,
+                    72390.02207799129
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 352.89489459655084,
+            "scoreError" : 1.4176480857930351,
+            "scoreConfidence" : [
+                351.4772465107578,
+                354.31254268234386
+            ],
+            "scorePercentiles" : {
+                "0.0" : 352.1676100179703,
+                "50.0" : 352.9676817274718,
+                "90.0" : 353.4088021871189,
+                "95.0" : 353.4088021871189,
+                "99.0" : 353.4088021871189,
+                "99.9" : 353.4088021871189,
+                "99.99" : 353.4088021871189,
+                "99.999" : 353.4088021871189,
+                "99.9999" : 353.4088021871189,
+                "100.0" : 353.4088021871189
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    352.4853167658992,
+                    352.769436091334,
+                    353.16592736360957
+                ],
+                [
+                    352.1676100179703,
+                    353.4088021871189,
+                    353.37227515337327
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 125.11775572752106,
+            "scoreError" : 1.4273704703753871,
+            "scoreConfidence" : [
+                123.69038525714566,
+                126.54512619789645
+            ],
+            "scorePercentiles" : {
+                "0.0" : 124.56620004534363,
+                "50.0" : 125.08811289845346,
+                "90.0" : 125.87894239147361,
+                "95.0" : 125.87894239147361,
+                "99.0" : 125.87894239147361,
+                "99.9" : 125.87894239147361,
+                "99.99" : 125.87894239147361,
+                "99.999" : 125.87894239147361,
+                "99.9999" : 125.87894239147361,
+                "100.0" : 125.87894239147361
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    125.1075625634264,
+                    124.56620004534363,
+                    124.5964654100903
+                ],
+                [
+                    125.48870072131191,
+                    125.06866323348054,
+                    125.87894239147361
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.0626575361305658,
+            "scoreError" : 9.198229383410374E-4,
+            "scoreConfidence" : [
+                0.06173771319222476,
+                0.06357735906890682
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.062159738938823206,
+                "50.0" : 0.06270282227196337,
+                "90.0" : 0.06302511641215361,
+                "95.0" : 0.06302511641215361,
+                "99.0" : 0.06302511641215361,
+                "99.9" : 0.06302511641215361,
+                "99.99" : 0.06302511641215361,
+                "99.999" : 0.06302511641215361,
+                "99.9999" : 0.06302511641215361,
+                "100.0" : 0.06302511641215361
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06291998788805415,
+                    0.06257547391902885,
+                    0.06302511641215361
+                ],
+                [
+                    0.062159738938823206,
+                    0.0628301706248979,
+                    0.062434729000437034
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.909619518381702E-4,
+            "scoreError" : 1.700535451019374E-5,
+            "scoreConfidence" : [
+                3.7395659732797646E-4,
+                4.079673063483639E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.845972698299958E-4,
+                "50.0" : 3.9058712781215156E-4,
+                "90.0" : 3.984832415758396E-4,
+                "95.0" : 3.984832415758396E-4,
+                "99.0" : 3.984832415758396E-4,
+                "99.9" : 3.984832415758396E-4,
+                "99.99" : 3.984832415758396E-4,
+                "99.999" : 3.984832415758396E-4,
+                "99.9999" : 3.984832415758396E-4,
+                "100.0" : 3.984832415758396E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.845972698299958E-4,
+                    3.8704929291296666E-4,
+                    3.8521763600372406E-4
+                ],
+                [
+                    3.941249627113364E-4,
+                    3.962993079951587E-4,
+                    3.984832415758396E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1790845387006597,
+            "scoreError" : 0.06308314314083603,
+            "scoreConfidence" : [
+                2.116001395559824,
+                2.2421676818414955
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1223789904499153,
+                "50.0" : 2.1758705942784404,
+                "90.0" : 2.2493507538505164,
+                "95.0" : 2.2508987787530947,
+                "99.0" : 2.2508987787530947,
+                "99.9" : 2.2508987787530947,
+                "99.99" : 2.2508987787530947,
+                "99.999" : 2.2508987787530947,
+                "99.9999" : 2.2508987787530947,
+                "100.0" : 2.2508987787530947
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.19205308022797,
+                    2.1548736127989656,
+                    2.139745345314506,
+                    2.1223789904499153,
+                    2.1434498094727816
+                ],
+                [
+                    2.2508987787530947,
+                    2.2354185297273133,
+                    2.2002860517051706,
+                    2.169507327548807,
+                    2.1822338610080734
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.01365956951180236,
+            "scoreError" : 1.238634061468806E-4,
+            "scoreConfidence" : [
+                0.01353570610565548,
+                0.013783432917949241
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013585298861161716,
+                "50.0" : 0.013667867512609889,
+                "90.0" : 0.01370674197686882,
+                "95.0" : 0.01370674197686882,
+                "99.0" : 0.01370674197686882,
+                "99.9" : 0.01370674197686882,
+                "99.99" : 0.01370674197686882,
+                "99.999" : 0.01370674197686882,
+                "99.9999" : 0.01370674197686882,
+                "100.0" : 0.01370674197686882
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013692213686787504,
+                    0.01370674197686882,
+                    0.013655211677636071
+                ],
+                [
+                    0.013680523347583707,
+                    0.013585298861161716,
+                    0.013637427520776341
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0434476176802732,
+            "scoreError" : 0.07602021388162407,
+            "scoreConfidence" : [
+                0.9674274037986491,
+                1.1194678315618973
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0182023093056405,
+                "50.0" : 1.0429386245470869,
+                "90.0" : 1.0699246219107734,
+                "95.0" : 1.0699246219107734,
+                "99.0" : 1.0699246219107734,
+                "99.9" : 1.0699246219107734,
+                "99.99" : 1.0699246219107734,
+                "99.999" : 1.0699246219107734,
+                "99.9999" : 1.0699246219107734,
+                "100.0" : 1.0699246219107734
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0664792785539086,
+                    1.0699246219107734,
+                    1.068113861582826
+                ],
+                [
+                    1.019397970540265,
+                    1.0185676641882258,
+                    1.0182023093056405
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010119677550476535,
+            "scoreError" : 2.2558504669680405E-4,
+            "scoreConfidence" : [
+                0.00989409250377973,
+                0.01034526259717334
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.009992335476302768,
+                "50.0" : 0.010159348530938575,
+                "90.0" : 0.010190528691147279,
+                "95.0" : 0.010190528691147279,
+                "99.0" : 0.010190528691147279,
+                "99.9" : 0.010190528691147279,
+                "99.99" : 0.010190528691147279,
+                "99.999" : 0.010190528691147279,
+                "99.9999" : 0.010190528691147279,
+                "100.0" : 0.010190528691147279
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010190528691147279,
+                    0.010170333216716364,
+                    0.01015777653043397
+                ],
+                [
+                    0.01016092053144318,
+                    0.009992335476302768,
+                    0.010046170856815648
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0893382932757287,
+            "scoreError" : 0.16298060049813018,
+            "scoreConfidence" : [
+                2.9263576927775987,
+                3.2523188937738587
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0209082608695654,
+                "50.0" : 3.0945886769028377,
+                "90.0" : 3.1695023884664133,
+                "95.0" : 3.1695023884664133,
+                "99.0" : 3.1695023884664133,
+                "99.9" : 3.1695023884664133,
+                "99.99" : 3.1695023884664133,
+                "99.999" : 3.1695023884664133,
+                "99.9999" : 3.1695023884664133,
+                "100.0" : 3.1695023884664133
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0209082608695654,
+                    3.0305641290127197,
+                    3.072951614864865
+                ],
+                [
+                    3.1258776275,
+                    3.1695023884664133,
+                    3.11622573894081
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.864602280789285,
+            "scoreError" : 0.029378797457866056,
+            "scoreConfidence" : [
+                2.835223483331419,
+                2.8939810782471507
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.8483977852463687,
+                "50.0" : 2.864931935298651,
+                "90.0" : 2.8758839240943073,
+                "95.0" : 2.8758839240943073,
+                "99.0" : 2.8758839240943073,
+                "99.9" : 2.8758839240943073,
+                "99.99" : 2.8758839240943073,
+                "99.999" : 2.8758839240943073,
+                "99.9999" : 2.8758839240943073,
+                "100.0" : 2.8758839240943073
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.867228644495413,
+                    2.8758839240943073,
+                    2.862635226101889
+                ],
+                [
+                    2.8750735843633226,
+                    2.8483977852463687,
+                    2.85839452043441
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3844712021606269,
+            "scoreError" : 0.008684940310448528,
+            "scoreConfidence" : [
+                0.3757862618501784,
+                0.39315614247107544
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3797548177261335,
+                "50.0" : 0.3852604235593766,
+                "90.0" : 0.38810566045717393,
+                "95.0" : 0.38810566045717393,
+                "99.0" : 0.38810566045717393,
+                "99.9" : 0.38810566045717393,
+                "99.99" : 0.38810566045717393,
+                "99.999" : 0.38810566045717393,
+                "99.9999" : 0.38810566045717393,
+                "100.0" : 0.38810566045717393
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.381871749465404,
+                    0.3850574809210273,
+                    0.3797548177261335
+                ],
+                [
+                    0.385463366197726,
+                    0.38810566045717393,
+                    0.3865741381962967
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16116914297477639,
+            "scoreError" : 0.005798043692144599,
+            "scoreConfidence" : [
+                0.1553710992826318,
+                0.16696718666692098
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1590712352145834,
+                "50.0" : 0.1609355591477213,
+                "90.0" : 0.16387652378611342,
+                "95.0" : 0.16387652378611342,
+                "99.0" : 0.16387652378611342,
+                "99.9" : 0.16387652378611342,
+                "99.99" : 0.16387652378611342,
+                "99.999" : 0.16387652378611342,
+                "99.9999" : 0.16387652378611342,
+                "100.0" : 0.16387652378611342
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1597660369370377,
+                    0.1590712352145834,
+                    0.159255478556527
+                ],
+                [
+                    0.16387652378611342,
+                    0.16210508135840493,
+                    0.16294050199599172
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4032388550636767,
+            "scoreError" : 0.035384135485175904,
+            "scoreConfidence" : [
+                0.3678547195785008,
+                0.43862299054885256
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39172749473148183,
+                "50.0" : 0.40247321234564215,
+                "90.0" : 0.4173104228843265,
+                "95.0" : 0.4173104228843265,
+                "99.0" : 0.4173104228843265,
+                "99.9" : 0.4173104228843265,
+                "99.99" : 0.4173104228843265,
+                "99.999" : 0.4173104228843265,
+                "99.9999" : 0.4173104228843265,
+                "100.0" : 0.4173104228843265
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.39181346115268584,
+                    0.39172749473148183,
+                    0.39184797492261275
+                ],
+                [
+                    0.4173104228843265,
+                    0.4136353269222815,
+                    0.4130984497686715
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14631589372628104,
+            "scoreError" : 0.00425699191741186,
+            "scoreConfidence" : [
+                0.14205890180886918,
+                0.1505728856436929
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14479010760565827,
+                "50.0" : 0.14604237817359597,
+                "90.0" : 0.14876871745016365,
+                "95.0" : 0.14876871745016365,
+                "99.0" : 0.14876871745016365,
+                "99.9" : 0.14876871745016365,
+                "99.99" : 0.14876871745016365,
+                "99.999" : 0.14876871745016365,
+                "99.9999" : 0.14876871745016365,
+                "100.0" : 0.14876871745016365
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14876871745016365,
+                    0.14709304392080721,
+                    0.14677924215114999
+                ],
+                [
+                    0.14479010760565827,
+                    0.14530551419604196,
+                    0.1451587370338651
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04353741094564297,
+            "scoreError" : 0.0010652984017790453,
+            "scoreConfidence" : [
+                0.042472112543863925,
+                0.04460270934742202
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.043153598690740244,
+                "50.0" : 0.043541032075151545,
+                "90.0" : 0.04419093080240749,
+                "95.0" : 0.04419093080240749,
+                "99.0" : 0.04419093080240749,
+                "99.9" : 0.04419093080240749,
+                "99.99" : 0.04419093080240749,
+                "99.999" : 0.04419093080240749,
+                "99.9999" : 0.04419093080240749,
+                "100.0" : 0.04419093080240749
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.043530044761241456,
+                    0.043153598690740244,
+                    0.04316592820577013
+                ],
+                [
+                    0.04419093080240749,
+                    0.04363194382463688,
+                    0.04355201938906164
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7896708.849825873,
+            "scoreError" : 141012.81885034815,
+            "scoreConfidence" : [
+                7755696.030975525,
+                8037721.668676221
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7842704.422413793,
+                "50.0" : 7886911.367365094,
+                "90.0" : 7977026.621212121,
+                "95.0" : 7977026.621212121,
+                "99.0" : 7977026.621212121,
+                "99.9" : 7977026.621212121,
+                "99.99" : 7977026.621212121,
+                "99.999" : 7977026.621212121,
+                "99.9999" : 7977026.621212121,
+                "100.0" : 7977026.621212121
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7879526.032283464,
+                    7854926.90188383,
+                    7842704.422413793
+                ],
+                [
+                    7977026.621212121,
+                    7931772.418715306,
+                    7894296.702446724
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-04T21-25-35Z-5273839fbc070918673ee83e07b92285afb9d0f7-jdk17.json
+++ b/performance-results/2026-03-04T21-25-35Z-5273839fbc070918673ee83e07b92285afb9d0f7-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.377941412861057,
+            "scoreError" : 0.03663161663180042,
+            "scoreConfidence" : [
+                3.3413097962292566,
+                3.414573029492858
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3730109075288834,
+                "50.0" : 3.3764157154656136,
+                "90.0" : 3.3859233129841195,
+                "95.0" : 3.3859233129841195,
+                "99.0" : 3.3859233129841195,
+                "99.9" : 3.3859233129841195,
+                "99.99" : 3.3859233129841195,
+                "99.999" : 3.3859233129841195,
+                "99.9999" : 3.3859233129841195,
+                "100.0" : 3.3859233129841195
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3730109075288834,
+                    3.3777812176042
+                ],
+                [
+                    3.375050213327027,
+                    3.3859233129841195
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7030034953750988,
+            "scoreError" : 0.02013446648154818,
+            "scoreConfidence" : [
+                1.6828690288935506,
+                1.723137961856647
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6993385289090113,
+                "50.0" : 1.7028687253074275,
+                "90.0" : 1.7069380019765292,
+                "95.0" : 1.7069380019765292,
+                "99.0" : 1.7069380019765292,
+                "99.9" : 1.7069380019765292,
+                "99.99" : 1.7069380019765292,
+                "99.999" : 1.7069380019765292,
+                "99.9999" : 1.7069380019765292,
+                "100.0" : 1.7069380019765292
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7031658453735707,
+                    1.7069380019765292
+                ],
+                [
+                    1.6993385289090113,
+                    1.7025716052412845
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8573574737662649,
+            "scoreError" : 0.027386981850622667,
+            "scoreConfidence" : [
+                0.8299704919156422,
+                0.8847444556168876
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8535311189155325,
+                "50.0" : 0.8562398750174421,
+                "90.0" : 0.8634190261146429,
+                "95.0" : 0.8634190261146429,
+                "99.0" : 0.8634190261146429,
+                "99.9" : 0.8634190261146429,
+                "99.99" : 0.8634190261146429,
+                "99.999" : 0.8634190261146429,
+                "99.9999" : 0.8634190261146429,
+                "100.0" : 0.8634190261146429
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8562882728836365,
+                    0.8634190261146429
+                ],
+                [
+                    0.8535311189155325,
+                    0.8561914771512478
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.38163084762097,
+            "scoreError" : 0.2775715840885871,
+            "scoreConfidence" : [
+                16.10405926353238,
+                16.659202431709556
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.28621750235265,
+                "50.0" : 16.37850992494132,
+                "90.0" : 16.486175095407074,
+                "95.0" : 16.486175095407074,
+                "99.0" : 16.486175095407074,
+                "99.9" : 16.486175095407074,
+                "99.99" : 16.486175095407074,
+                "99.999" : 16.486175095407074,
+                "99.9999" : 16.486175095407074,
+                "100.0" : 16.486175095407074
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.486175095407074,
+                    16.466913869257915,
+                    16.461845569007256
+                ],
+                [
+                    16.28621750235265,
+                    16.293458768825545,
+                    16.29517428087538
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2673.214903132862,
+            "scoreError" : 15.40619906398037,
+            "scoreConfidence" : [
+                2657.808704068882,
+                2688.6211021968425
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2666.932631496291,
+                "50.0" : 2672.5882366235633,
+                "90.0" : 2680.1413736284558,
+                "95.0" : 2680.1413736284558,
+                "99.0" : 2680.1413736284558,
+                "99.9" : 2680.1413736284558,
+                "99.99" : 2680.1413736284558,
+                "99.999" : 2680.1413736284558,
+                "99.9999" : 2680.1413736284558,
+                "100.0" : 2680.1413736284558
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2680.1413736284558,
+                    2675.9824875268782,
+                    2677.9615627341313
+                ],
+                [
+                    2666.932631496291,
+                    2669.1939857202483,
+                    2669.0773776911656
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73998.36464927782,
+            "scoreError" : 947.4918557385771,
+            "scoreConfidence" : [
+                73050.87279353924,
+                74945.8565050164
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73657.77946409975,
+                "50.0" : 74000.85627137258,
+                "90.0" : 74337.87180989879,
+                "95.0" : 74337.87180989879,
+                "99.0" : 74337.87180989879,
+                "99.9" : 74337.87180989879,
+                "99.99" : 74337.87180989879,
+                "99.999" : 74337.87180989879,
+                "99.9999" : 74337.87180989879,
+                "100.0" : 74337.87180989879
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73657.77946409975,
+                    73711.88932893261,
+                    73702.69174698906
+                ],
+                [
+                    74337.87180989879,
+                    74289.82321381257,
+                    74290.13233193418
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 377.3486128078748,
+            "scoreError" : 4.707845584350197,
+            "scoreConfidence" : [
+                372.6407672235246,
+                382.056458392225
+            ],
+            "scorePercentiles" : {
+                "0.0" : 375.4943553811027,
+                "50.0" : 377.216305109113,
+                "90.0" : 379.1810005292789,
+                "95.0" : 379.1810005292789,
+                "99.0" : 379.1810005292789,
+                "99.9" : 379.1810005292789,
+                "99.99" : 379.1810005292789,
+                "99.999" : 379.1810005292789,
+                "99.9999" : 379.1810005292789,
+                "100.0" : 379.1810005292789
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    378.1356625992634,
+                    379.1810005292789,
+                    379.15476050518726
+                ],
+                [
+                    375.4943553811027,
+                    376.29694761896263,
+                    375.8289502134543
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 127.00401995182578,
+            "scoreError" : 2.522389477542378,
+            "scoreConfidence" : [
+                124.4816304742834,
+                129.52640942936816
+            ],
+            "scorePercentiles" : {
+                "0.0" : 125.67912300100137,
+                "50.0" : 127.10197697881318,
+                "90.0" : 127.94120036093216,
+                "95.0" : 127.94120036093216,
+                "99.0" : 127.94120036093216,
+                "99.9" : 127.94120036093216,
+                "99.99" : 127.94120036093216,
+                "99.999" : 127.94120036093216,
+                "99.9999" : 127.94120036093216,
+                "100.0" : 127.94120036093216
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    126.9463162308929,
+                    127.25763772673346,
+                    125.67912300100137
+                ],
+                [
+                    126.28571242598183,
+                    127.94120036093216,
+                    127.91412996541293
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06268073203589754,
+            "scoreError" : 0.003700029288247111,
+            "scoreConfidence" : [
+                0.058980702747650424,
+                0.06638076132414465
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061232817180400946,
+                "50.0" : 0.06269012126393023,
+                "90.0" : 0.0641280117352828,
+                "95.0" : 0.0641280117352828,
+                "99.0" : 0.0641280117352828,
+                "99.9" : 0.0641280117352828,
+                "99.99" : 0.0641280117352828,
+                "99.999" : 0.0641280117352828,
+                "99.9999" : 0.0641280117352828,
+                "100.0" : 0.0641280117352828
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06372717844647943,
+                    0.06375852783657647,
+                    0.0641280117352828
+                ],
+                [
+                    0.06158479293526456,
+                    0.061653064081381014,
+                    0.061232817180400946
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8280119366502526E-4,
+            "scoreError" : 3.0480001996942524E-5,
+            "scoreConfidence" : [
+                3.523211916680827E-4,
+                4.132811956619678E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.7329504900318855E-4,
+                "50.0" : 3.7911445388843785E-4,
+                "90.0" : 3.970141959056498E-4,
+                "95.0" : 3.970141959056498E-4,
+                "99.0" : 3.970141959056498E-4,
+                "99.9" : 3.970141959056498E-4,
+                "99.99" : 3.970141959056498E-4,
+                "99.999" : 3.970141959056498E-4,
+                "99.9999" : 3.970141959056498E-4,
+                "100.0" : 3.970141959056498E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.970141959056498E-4,
+                    3.9467336405284056E-4,
+                    3.8388284910425674E-4
+                ],
+                [
+                    3.7329504900318855E-4,
+                    3.735956452515969E-4,
+                    3.74346058672619E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1545623122792685,
+            "scoreError" : 0.04397439311393211,
+            "scoreConfidence" : [
+                2.1105879191653365,
+                2.1985367053932006
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.115000035736942,
+                "50.0" : 2.156519738903428,
+                "90.0" : 2.1942001895448136,
+                "95.0" : 2.194996456760316,
+                "99.0" : 2.194996456760316,
+                "99.9" : 2.194996456760316,
+                "99.99" : 2.194996456760316,
+                "99.999" : 2.194996456760316,
+                "99.9999" : 2.194996456760316,
+                "100.0" : 2.194996456760316
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.181547220113438,
+                    2.187033784605292,
+                    2.1200451023955904,
+                    2.115000035736942,
+                    2.1551368942038356
+                ],
+                [
+                    2.194996456760316,
+                    2.1579025836030206,
+                    2.119310301546938,
+                    2.1665601314991334,
+                    2.1480906123281787
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013533795334650147,
+            "scoreError" : 4.376711077704879E-4,
+            "scoreConfidence" : [
+                0.01309612422687966,
+                0.013971466442420635
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013385251733369028,
+                "50.0" : 0.013531282128812286,
+                "90.0" : 0.013686044293047973,
+                "95.0" : 0.013686044293047973,
+                "99.0" : 0.013686044293047973,
+                "99.9" : 0.013686044293047973,
+                "99.99" : 0.013686044293047973,
+                "99.999" : 0.013686044293047973,
+                "99.9999" : 0.013686044293047973,
+                "100.0" : 0.013686044293047973
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013686044293047973,
+                    0.01367636230542206,
+                    0.013665944604485648
+                ],
+                [
+                    0.013385251733369028,
+                    0.013396619653138923,
+                    0.013392549418437247
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0958791247494002,
+            "scoreError" : 0.24251643318145702,
+            "scoreConfidence" : [
+                0.8533626915679432,
+                1.3383955579308573
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0166877100447336,
+                "50.0" : 1.094310457814241,
+                "90.0" : 1.1809353683278223,
+                "95.0" : 1.1809353683278223,
+                "99.0" : 1.1809353683278223,
+                "99.9" : 1.1809353683278223,
+                "99.99" : 1.1809353683278223,
+                "99.999" : 1.1809353683278223,
+                "99.9999" : 1.1809353683278223,
+                "100.0" : 1.1809353683278223
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0175687946682948,
+                    1.0166877100447336,
+                    1.0167204639080927
+                ],
+                [
+                    1.1710521209601874,
+                    1.17231029058727,
+                    1.1809353683278223
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010535642707325758,
+            "scoreError" : 4.976715517746036E-4,
+            "scoreConfidence" : [
+                0.010037971155551155,
+                0.011033314259100362
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01037131295762378,
+                "50.0" : 0.010532263357590253,
+                "90.0" : 0.010711622672430783,
+                "95.0" : 0.010711622672430783,
+                "99.0" : 0.010711622672430783,
+                "99.9" : 0.010711622672430783,
+                "99.99" : 0.010711622672430783,
+                "99.999" : 0.010711622672430783,
+                "99.9999" : 0.010711622672430783,
+                "100.0" : 0.010711622672430783
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01037131295762378,
+                    0.010376280671864331,
+                    0.010373796946447689
+                ],
+                [
+                    0.010688246043316176,
+                    0.010711622672430783,
+                    0.01069259695227179
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0364923366434353,
+            "scoreError" : 0.13362122988523303,
+            "scoreConfidence" : [
+                2.9028711067582025,
+                3.170113566528668
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9919416638755982,
+                "50.0" : 3.0337962213694443,
+                "90.0" : 3.093835299319728,
+                "95.0" : 3.093835299319728,
+                "99.0" : 3.093835299319728,
+                "99.9" : 3.093835299319728,
+                "99.99" : 3.093835299319728,
+                "99.999" : 3.093835299319728,
+                "99.9999" : 3.093835299319728,
+                "100.0" : 3.093835299319728
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0725691830466832,
+                    3.093835299319728,
+                    3.0717014373464373
+                ],
+                [
+                    2.9919416638755982,
+                    2.995891005392451,
+                    2.9930154308797126
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.749571518386386,
+            "scoreError" : 0.10045475902123358,
+            "scoreConfidence" : [
+                2.6491167593651523,
+                2.8500262774076193
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.706724850879567,
+                "50.0" : 2.751656389345449,
+                "90.0" : 2.7843501597995544,
+                "95.0" : 2.7843501597995544,
+                "99.0" : 2.7843501597995544,
+                "99.9" : 2.7843501597995544,
+                "99.99" : 2.7843501597995544,
+                "99.999" : 2.7843501597995544,
+                "99.9999" : 2.7843501597995544,
+                "100.0" : 2.7843501597995544
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.706724850879567,
+                    2.7234786252723313,
+                    2.7217983654421767
+                ],
+                [
+                    2.7843501597995544,
+                    2.781242955506118,
+                    2.779834153418566
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18004705349076178,
+            "scoreError" : 0.011845230510646076,
+            "scoreConfidence" : [
+                0.1682018229801157,
+                0.19189228400140784
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17611660263815998,
+                "50.0" : 0.17996036974831753,
+                "90.0" : 0.18410712222017672,
+                "95.0" : 0.18410712222017672,
+                "99.0" : 0.18410712222017672,
+                "99.9" : 0.18410712222017672,
+                "99.99" : 0.18410712222017672,
+                "99.999" : 0.18410712222017672,
+                "99.9999" : 0.18410712222017672,
+                "100.0" : 0.18410712222017672
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17625822481316977,
+                    0.17611660263815998,
+                    0.1762052676510493
+                ],
+                [
+                    0.18410712222017672,
+                    0.18393258893854955,
+                    0.18366251468346526
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.37939456932395094,
+            "scoreError" : 0.010013216658163935,
+            "scoreConfidence" : [
+                0.369381352665787,
+                0.3894077859821149
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3759904840771516,
+                "50.0" : 0.37937216298795273,
+                "90.0" : 0.3828628354517611,
+                "95.0" : 0.3828628354517611,
+                "99.0" : 0.3828628354517611,
+                "99.9" : 0.3828628354517611,
+                "99.99" : 0.3828628354517611,
+                "99.999" : 0.3828628354517611,
+                "99.9999" : 0.3828628354517611,
+                "100.0" : 0.3828628354517611
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.382728877530713,
+                    0.38235301655515197,
+                    0.3828628354517611
+                ],
+                [
+                    0.3759904840771516,
+                    0.3763913094207535,
+                    0.3760408929081748
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1627636579779944,
+            "scoreError" : 0.003191696954656168,
+            "scoreConfidence" : [
+                0.15957196102333823,
+                0.1659553549326506
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.16161750651302606,
+                "50.0" : 0.1628233782154303,
+                "90.0" : 0.163875942792062,
+                "95.0" : 0.163875942792062,
+                "99.0" : 0.163875942792062,
+                "99.9" : 0.163875942792062,
+                "99.99" : 0.163875942792062,
+                "99.999" : 0.163875942792062,
+                "99.9999" : 0.163875942792062,
+                "100.0" : 0.163875942792062
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16377950818061218,
+                    0.163875942792062,
+                    0.1637383429118774
+                ],
+                [
+                    0.16190841351898325,
+                    0.1616622339514056,
+                    0.16161750651302606
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40282161427366764,
+            "scoreError" : 0.00797877615523263,
+            "scoreConfidence" : [
+                0.394842838118435,
+                0.41080039042890026
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40001821364,
+                "50.0" : 0.4026423225678982,
+                "90.0" : 0.40655230429303196,
+                "95.0" : 0.40655230429303196,
+                "99.0" : 0.40655230429303196,
+                "99.9" : 0.40655230429303196,
+                "99.99" : 0.40655230429303196,
+                "99.999" : 0.40655230429303196,
+                "99.9999" : 0.40655230429303196,
+                "100.0" : 0.40655230429303196
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40655230429303196,
+                    0.40467345229038526,
+                    0.404798324886658
+                ],
+                [
+                    0.4002761976865194,
+                    0.40001821364,
+                    0.4006111928454112
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1490509508435018,
+            "scoreError" : 0.01661934744948804,
+            "scoreConfidence" : [
+                0.13243160339401377,
+                0.16567029829298985
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14356836878903165,
+                "50.0" : 0.14898865456343693,
+                "90.0" : 0.1550104546370499,
+                "95.0" : 0.1550104546370499,
+                "99.0" : 0.1550104546370499,
+                "99.9" : 0.1550104546370499,
+                "99.99" : 0.1550104546370499,
+                "99.999" : 0.1550104546370499,
+                "99.9999" : 0.1550104546370499,
+                "100.0" : 0.1550104546370499
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1550104546370499,
+                    0.15417570320064136,
+                    0.15417423193500146
+                ],
+                [
+                    0.143573869307414,
+                    0.1438030771918724,
+                    0.14356836878903165
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.042663799699856925,
+            "scoreError" : 0.0016955233567465412,
+            "scoreConfidence" : [
+                0.040968276343110385,
+                0.044359323056603464
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04210209162558258,
+                "50.0" : 0.042628492163274,
+                "90.0" : 0.04339011821877807,
+                "95.0" : 0.04339011821877807,
+                "99.0" : 0.04339011821877807,
+                "99.9" : 0.04339011821877807,
+                "99.99" : 0.04339011821877807,
+                "99.999" : 0.04339011821877807,
+                "99.9999" : 0.04339011821877807,
+                "100.0" : 0.04339011821877807
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.042104669453952935,
+                    0.04210209162558258,
+                    0.04215235009420879
+                ],
+                [
+                    0.04339011821877807,
+                    0.04312893457427997,
+                    0.04310463423233921
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8005766.748810445,
+            "scoreError" : 101677.54846982654,
+            "scoreConfidence" : [
+                7904089.200340618,
+                8107444.297280272
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7970285.149003984,
+                "50.0" : 8000199.65918971,
+                "90.0" : 8059948.660757454,
+                "95.0" : 8059948.660757454,
+                "99.0" : 8059948.660757454,
+                "99.9" : 8059948.660757454,
+                "99.99" : 8059948.660757454,
+                "99.999" : 8059948.660757454,
+                "99.9999" : 8059948.660757454,
+                "100.0" : 8059948.660757454
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8021808.892542101,
+                    8059948.660757454,
+                    8028007.670144462
+                ],
+                [
+                    7975959.694577352,
+                    7978590.42583732,
+                    7970285.149003984
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-04T21-25-43Z-5273839fbc070918673ee83e07b92285afb9d0f7-jdk17.json
+++ b/performance-results/2026-03-04T21-25-43Z-5273839fbc070918673ee83e07b92285afb9d0f7-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3454774516290544,
+            "scoreError" : 0.062045046774146226,
+            "scoreConfidence" : [
+                3.283432404854908,
+                3.4075224984032007
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.331171141341107,
+                "50.0" : 3.349738441655875,
+                "90.0" : 3.3512617818633603,
+                "95.0" : 3.3512617818633603,
+                "99.0" : 3.3512617818633603,
+                "99.9" : 3.3512617818633603,
+                "99.99" : 3.3512617818633603,
+                "99.999" : 3.3512617818633603,
+                "99.9999" : 3.3512617818633603,
+                "100.0" : 3.3512617818633603
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.331171141341107,
+                    3.3507698556502072
+                ],
+                [
+                    3.3512617818633603,
+                    3.348707027661543
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6798289438229275,
+            "scoreError" : 0.03275306951300093,
+            "scoreConfidence" : [
+                1.6470758743099265,
+                1.7125820133359284
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6728780015114262,
+                "50.0" : 1.681412434728157,
+                "90.0" : 1.6836129043239694,
+                "95.0" : 1.6836129043239694,
+                "99.0" : 1.6836129043239694,
+                "99.9" : 1.6836129043239694,
+                "99.99" : 1.6836129043239694,
+                "99.999" : 1.6836129043239694,
+                "99.9999" : 1.6836129043239694,
+                "100.0" : 1.6836129043239694
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6728780015114262,
+                    1.6792418959730537
+                ],
+                [
+                    1.6836129043239694,
+                    1.6835829734832604
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8491798224389326,
+            "scoreError" : 0.022897004638376114,
+            "scoreConfidence" : [
+                0.8262828178005566,
+                0.8720768270773087
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8451575119299037,
+                "50.0" : 0.848896432378765,
+                "90.0" : 0.8537689130682966,
+                "95.0" : 0.8537689130682966,
+                "99.0" : 0.8537689130682966,
+                "99.9" : 0.8537689130682966,
+                "99.99" : 0.8537689130682966,
+                "99.999" : 0.8537689130682966,
+                "99.9999" : 0.8537689130682966,
+                "100.0" : 0.8537689130682966
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8451575119299037,
+                    0.8537689130682966
+                ],
+                [
+                    0.848531498941031,
+                    0.849261365816499
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 15.833517412961909,
+            "scoreError" : 0.27406638072836786,
+            "scoreConfidence" : [
+                15.559451032233541,
+                16.107583793690278
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.672807453291313,
+                "50.0" : 15.846732992323378,
+                "90.0" : 15.932434503504677,
+                "95.0" : 15.932434503504677,
+                "99.0" : 15.932434503504677,
+                "99.9" : 15.932434503504677,
+                "99.99" : 15.932434503504677,
+                "99.999" : 15.932434503504677,
+                "99.9999" : 15.932434503504677,
+                "100.0" : 15.932434503504677
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    15.925829268865344,
+                    15.850855267549926,
+                    15.932434503504677
+                ],
+                [
+                    15.672807453291313,
+                    15.776567267463358,
+                    15.842610717096829
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2556.1895341005506,
+            "scoreError" : 90.29003157347033,
+            "scoreConfidence" : [
+                2465.89950252708,
+                2646.479565674021
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2522.3962288460484,
+                "50.0" : 2549.5278316854847,
+                "90.0" : 2611.7314582496915,
+                "95.0" : 2611.7314582496915,
+                "99.0" : 2611.7314582496915,
+                "99.9" : 2611.7314582496915,
+                "99.99" : 2611.7314582496915,
+                "99.999" : 2611.7314582496915,
+                "99.9999" : 2611.7314582496915,
+                "100.0" : 2611.7314582496915
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2560.768479764823,
+                    2569.00345319039,
+                    2611.7314582496915
+                ],
+                [
+                    2534.9504009462075,
+                    2538.2871836061468,
+                    2522.3962288460484
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 72287.11929759082,
+            "scoreError" : 586.6069878258224,
+            "scoreConfidence" : [
+                71700.51230976499,
+                72873.72628541665
+            ],
+            "scorePercentiles" : {
+                "0.0" : 71910.0279236032,
+                "50.0" : 72301.02681367786,
+                "90.0" : 72519.86889329454,
+                "95.0" : 72519.86889329454,
+                "99.0" : 72519.86889329454,
+                "99.9" : 72519.86889329454,
+                "99.99" : 72519.86889329454,
+                "99.999" : 72519.86889329454,
+                "99.9999" : 72519.86889329454,
+                "100.0" : 72519.86889329454
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72320.96947501415,
+                    71910.0279236032,
+                    72260.35361337475
+                ],
+                [
+                    72430.41172791665,
+                    72519.86889329454,
+                    72281.08415234157
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 340.25302840179216,
+            "scoreError" : 13.72962440058768,
+            "scoreConfidence" : [
+                326.5234040012045,
+                353.98265280237985
+            ],
+            "scorePercentiles" : {
+                "0.0" : 333.81986824310957,
+                "50.0" : 339.3177817701063,
+                "90.0" : 348.37507630642835,
+                "95.0" : 348.37507630642835,
+                "99.0" : 348.37507630642835,
+                "99.9" : 348.37507630642835,
+                "99.99" : 348.37507630642835,
+                "99.999" : 348.37507630642835,
+                "99.9999" : 348.37507630642835,
+                "100.0" : 348.37507630642835
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    342.5859303384269,
+                    348.37507630642835,
+                    333.81986824310957
+                ],
+                [
+                    339.9037352852935,
+                    338.1017319825757,
+                    338.7318282549191
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 124.43575260401998,
+            "scoreError" : 2.118654284892131,
+            "scoreConfidence" : [
+                122.31709831912785,
+                126.55440688891211
+            ],
+            "scorePercentiles" : {
+                "0.0" : 123.6105339711908,
+                "50.0" : 124.29081019422699,
+                "90.0" : 125.81882509115947,
+                "95.0" : 125.81882509115947,
+                "99.0" : 125.81882509115947,
+                "99.9" : 125.81882509115947,
+                "99.99" : 125.81882509115947,
+                "99.999" : 125.81882509115947,
+                "99.9999" : 125.81882509115947,
+                "100.0" : 125.81882509115947
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    125.81882509115947,
+                    124.57458266171832,
+                    124.16139649598598
+                ],
+                [
+                    124.02895351159736,
+                    124.420223892468,
+                    123.6105339711908
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.064036977754783,
+            "scoreError" : 0.0010112457344274215,
+            "scoreConfidence" : [
+                0.06302573202035558,
+                0.06504822348921041
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06338861021805274,
+                "50.0" : 0.06417419174641792,
+                "90.0" : 0.06437008630611378,
+                "95.0" : 0.06437008630611378,
+                "99.0" : 0.06437008630611378,
+                "99.9" : 0.06437008630611378,
+                "99.99" : 0.06437008630611378,
+                "99.999" : 0.06437008630611378,
+                "99.9999" : 0.06437008630611378,
+                "100.0" : 0.06437008630611378
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06437008630611378,
+                    0.06385768844387966,
+                    0.06338861021805274
+                ],
+                [
+                    0.06415631610552248,
+                    0.06419206738731337,
+                    0.064257098067816
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8257187546425524E-4,
+            "scoreError" : 3.784360937725032E-5,
+            "scoreConfidence" : [
+                3.4472826608700495E-4,
+                4.2041548484150553E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6592740544622265E-4,
+                "50.0" : 3.834776838546149E-4,
+                "90.0" : 3.970996877054341E-4,
+                "95.0" : 3.970996877054341E-4,
+                "99.0" : 3.970996877054341E-4,
+                "99.9" : 3.970996877054341E-4,
+                "99.99" : 3.970996877054341E-4,
+                "99.999" : 3.970996877054341E-4,
+                "99.9999" : 3.970996877054341E-4,
+                "100.0" : 3.970996877054341E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.9355601118756594E-4,
+                    3.970996877054341E-4,
+                    3.931264539633519E-4
+                ],
+                [
+                    3.718927807370789E-4,
+                    3.7382891374587783E-4,
+                    3.6592740544622265E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.258632004919533,
+            "scoreError" : 0.06149222027687432,
+            "scoreConfidence" : [
+                2.197139784642659,
+                2.3201242251964076
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.204892957010582,
+                "50.0" : 2.2452970820209117,
+                "90.0" : 2.325787194351612,
+                "95.0" : 2.3270846151698463,
+                "99.0" : 2.3270846151698463,
+                "99.9" : 2.3270846151698463,
+                "99.99" : 2.3270846151698463,
+                "99.999" : 2.3270846151698463,
+                "99.9999" : 2.3270846151698463,
+                "100.0" : 2.3270846151698463
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.3270846151698463,
+                    2.273829294906776,
+                    2.2318933409953137,
+                    2.2373520263982103,
+                    2.2245513890124555
+                ],
+                [
+                    2.314110406987506,
+                    2.2883686977116704,
+                    2.2532421376436136,
+                    2.2309951833593575,
+                    2.204892957010582
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.0137244411135555,
+            "scoreError" : 2.307046383123077E-4,
+            "scoreConfidence" : [
+                0.013493736475243193,
+                0.013955145751867808
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013623631129875155,
+                "50.0" : 0.013722222284498788,
+                "90.0" : 0.01383504927395077,
+                "95.0" : 0.01383504927395077,
+                "99.0" : 0.01383504927395077,
+                "99.9" : 0.01383504927395077,
+                "99.99" : 0.01383504927395077,
+                "99.999" : 0.01383504927395077,
+                "99.9999" : 0.01383504927395077,
+                "100.0" : 0.01383504927395077
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01383504927395077,
+                    0.013733381020458332,
+                    0.013796503509074479
+                ],
+                [
+                    0.013623631129875155,
+                    0.013711063548539243,
+                    0.013647018199435021
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0965433351949259,
+            "scoreError" : 0.18683940548803118,
+            "scoreConfidence" : [
+                0.9097039297068947,
+                1.283382740682957
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0324207569939094,
+                "50.0" : 1.098384846314473,
+                "90.0" : 1.1592396682508403,
+                "95.0" : 1.1592396682508403,
+                "99.0" : 1.1592396682508403,
+                "99.9" : 1.1592396682508403,
+                "99.99" : 1.1592396682508403,
+                "99.999" : 1.1592396682508403,
+                "99.9999" : 1.1592396682508403,
+                "100.0" : 1.1592396682508403
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0344326311543235,
+                    1.0404737512484394,
+                    1.0324207569939094
+                ],
+                [
+                    1.1562959413805065,
+                    1.1592396682508403,
+                    1.1563972621415357
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01077565114744188,
+            "scoreError" : 0.001264086579903994,
+            "scoreConfidence" : [
+                0.009511564567537887,
+                0.012039737727345875
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.01030554157864255,
+                "50.0" : 0.010796156186777588,
+                "90.0" : 0.011233953104393445,
+                "95.0" : 0.011233953104393445,
+                "99.0" : 0.011233953104393445,
+                "99.9" : 0.011233953104393445,
+                "99.99" : 0.011233953104393445,
+                "99.999" : 0.011233953104393445,
+                "99.9999" : 0.011233953104393445,
+                "100.0" : 0.011233953104393445
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01030554157864255,
+                    0.010343040032765928,
+                    0.010453912049658794
+                ],
+                [
+                    0.011233953104393445,
+                    0.011179059795294181,
+                    0.01113840032389638
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1581530397384223,
+            "scoreError" : 0.13293037759441256,
+            "scoreConfidence" : [
+                3.0252226621440097,
+                3.291083417332835
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0760383173431736,
+                "50.0" : 3.1729717349096838,
+                "90.0" : 3.2028245966709346,
+                "95.0" : 3.2028245966709346,
+                "99.0" : 3.2028245966709346,
+                "99.9" : 3.2028245966709346,
+                "99.99" : 3.2028245966709346,
+                "99.999" : 3.2028245966709346,
+                "99.9999" : 3.2028245966709346,
+                "100.0" : 3.2028245966709346
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.15695583270202,
+                    3.1345353013784463,
+                    3.0760383173431736
+                ],
+                [
+                    3.2028245966709346,
+                    3.1895765532186107,
+                    3.188987637117347
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.841811986563956,
+            "scoreError" : 0.09462301573331446,
+            "scoreConfidence" : [
+                2.7471889708306416,
+                2.9364350022972707
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.797578299020979,
+                "50.0" : 2.8469178231681886,
+                "90.0" : 2.8770144680667435,
+                "95.0" : 2.8770144680667435,
+                "99.0" : 2.8770144680667435,
+                "99.9" : 2.8770144680667435,
+                "99.99" : 2.8770144680667435,
+                "99.999" : 2.8770144680667435,
+                "99.9999" : 2.8770144680667435,
+                "100.0" : 2.8770144680667435
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.8770144680667435,
+                    2.861964185407725,
+                    2.8727784964090777
+                ],
+                [
+                    2.831871460928652,
+                    2.809665009550562,
+                    2.797578299020979
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18164785368834502,
+            "scoreError" : 0.011839759360402519,
+            "scoreConfidence" : [
+                0.1698080943279425,
+                0.19348761304874754
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17765414409308936,
+                "50.0" : 0.18146026702987045,
+                "90.0" : 0.18639047737269812,
+                "95.0" : 0.18639047737269812,
+                "99.0" : 0.18639047737269812,
+                "99.9" : 0.18639047737269812,
+                "99.99" : 0.18639047737269812,
+                "99.999" : 0.18639047737269812,
+                "99.9999" : 0.18639047737269812,
+                "100.0" : 0.18639047737269812
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18639047737269812,
+                    0.1851993654209415,
+                    0.18482183482728667
+                ],
+                [
+                    0.1780986992324542,
+                    0.1777226011836002,
+                    0.17765414409308936
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3930405924018829,
+            "scoreError" : 0.01941585473097306,
+            "scoreConfidence" : [
+                0.3736247376709098,
+                0.41245644713285595
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3852435071458839,
+                "50.0" : 0.39235075046578916,
+                "90.0" : 0.40246257437218286,
+                "95.0" : 0.40246257437218286,
+                "99.0" : 0.40246257437218286,
+                "99.9" : 0.40246257437218286,
+                "99.99" : 0.40246257437218286,
+                "99.999" : 0.40246257437218286,
+                "99.9999" : 0.40246257437218286,
+                "100.0" : 0.40246257437218286
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40246257437218286,
+                    0.39850082745566845,
+                    0.3960123266146596
+                ],
+                [
+                    0.38868917431691863,
+                    0.38733514450598394,
+                    0.3852435071458839
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16372046720739225,
+            "scoreError" : 0.002647918056906621,
+            "scoreConfidence" : [
+                0.16107254915048563,
+                0.16636838526429887
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1624310966442517,
+                "50.0" : 0.16352811668930944,
+                "90.0" : 0.16483776311668616,
+                "95.0" : 0.16483776311668616,
+                "99.0" : 0.16483776311668616,
+                "99.9" : 0.16483776311668616,
+                "99.99" : 0.16483776311668616,
+                "99.999" : 0.16483776311668616,
+                "99.9999" : 0.16483776311668616,
+                "100.0" : 0.16483776311668616
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1633066800463772,
+                    0.16477999726469814,
+                    0.1637495533322417
+                ],
+                [
+                    0.1624310966442517,
+                    0.1632177128400986,
+                    0.16483776311668616
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.41377315722008134,
+            "scoreError" : 0.010274766357650279,
+            "scoreConfidence" : [
+                0.40349839086243106,
+                0.42404792357773163
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4089676148529833,
+                "50.0" : 0.41500586673089884,
+                "90.0" : 0.41829617676831055,
+                "95.0" : 0.41829617676831055,
+                "99.0" : 0.41829617676831055,
+                "99.9" : 0.41829617676831055,
+                "99.99" : 0.41829617676831055,
+                "99.999" : 0.41829617676831055,
+                "99.9999" : 0.41829617676831055,
+                "100.0" : 0.41829617676831055
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41829617676831055,
+                    0.4149927522615985,
+                    0.4156945553477158
+                ],
+                [
+                    0.4150189812001992,
+                    0.4096688628896809,
+                    0.4089676148529833
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14360266883865327,
+            "scoreError" : 0.010553173078695771,
+            "scoreConfidence" : [
+                0.1330494957599575,
+                0.15415584191734905
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1399398054883083,
+                "50.0" : 0.14370942718808621,
+                "90.0" : 0.14716337412623431,
+                "95.0" : 0.14716337412623431,
+                "99.0" : 0.14716337412623431,
+                "99.9" : 0.14716337412623431,
+                "99.99" : 0.14716337412623431,
+                "99.999" : 0.14716337412623431,
+                "99.9999" : 0.14716337412623431,
+                "100.0" : 0.14716337412623431
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14703971203187718,
+                    0.14716337412623431,
+                    0.14689471413672553
+                ],
+                [
+                    0.1405241402394469,
+                    0.14005426700932747,
+                    0.1399398054883083
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04420447712380449,
+            "scoreError" : 3.603511475929286E-4,
+            "scoreConfidence" : [
+                0.04384412597621157,
+                0.04456482827139742
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04407632242168871,
+                "50.0" : 0.04417324530044407,
+                "90.0" : 0.04445172891135144,
+                "95.0" : 0.04445172891135144,
+                "99.0" : 0.04445172891135144,
+                "99.9" : 0.04445172891135144,
+                "99.99" : 0.04445172891135144,
+                "99.999" : 0.04445172891135144,
+                "99.9999" : 0.04445172891135144,
+                "100.0" : 0.04445172891135144
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.044202865666232015,
+                    0.04407632242168871,
+                    0.044149455142666674
+                ],
+                [
+                    0.04445172891135144,
+                    0.04417707508702797,
+                    0.04416941551386018
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8162851.225340809,
+            "scoreError" : 148583.69153890046,
+            "scoreConfidence" : [
+                8014267.533801909,
+                8311434.916879709
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8085910.259498787,
+                "50.0" : 8170338.326734001,
+                "90.0" : 8228682.123355263,
+                "95.0" : 8228682.123355263,
+                "99.0" : 8228682.123355263,
+                "99.9" : 8228682.123355263,
+                "99.99" : 8228682.123355263,
+                "99.999" : 8228682.123355263,
+                "99.9999" : 8228682.123355263,
+                "100.0" : 8228682.123355263
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8156044.892420538,
+                    8085910.259498787,
+                    8120570.818181818
+                ],
+                [
+                    8184631.761047463,
+                    8228682.123355263,
+                    8201267.497540983
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-04T23-59-12Z-3924d865b0206b34f09bcc8dd0288ab5427043e6-jdk17.json
+++ b/performance-results/2026-03-04T23-59-12Z-3924d865b0206b34f09bcc8dd0288ab5427043e6-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.376492147449713,
+            "scoreError" : 0.05094749348916878,
+            "scoreConfidence" : [
+                3.325544653960544,
+                3.427439640938882
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3659645892648853,
+                "50.0" : 3.37789716446981,
+                "90.0" : 3.3842096715943466,
+                "95.0" : 3.3842096715943466,
+                "99.0" : 3.3842096715943466,
+                "99.9" : 3.3842096715943466,
+                "99.99" : 3.3842096715943466,
+                "99.999" : 3.3842096715943466,
+                "99.9999" : 3.3842096715943466,
+                "100.0" : 3.3842096715943466
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.380361218529725,
+                    3.3842096715943466
+                ],
+                [
+                    3.3659645892648853,
+                    3.3754331104098956
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7055408060903154,
+            "scoreError" : 0.01752459326777718,
+            "scoreConfidence" : [
+                1.6880162128225382,
+                1.7230653993580927
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.701893382644625,
+                "50.0" : 1.705964646556044,
+                "90.0" : 1.7083405486045482,
+                "95.0" : 1.7083405486045482,
+                "99.0" : 1.7083405486045482,
+                "99.9" : 1.7083405486045482,
+                "99.99" : 1.7083405486045482,
+                "99.999" : 1.7083405486045482,
+                "99.9999" : 1.7083405486045482,
+                "100.0" : 1.7083405486045482
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7064949692655345,
+                    1.7083405486045482
+                ],
+                [
+                    1.7054343238465537,
+                    1.701893382644625
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8561540463818129,
+            "scoreError" : 0.02489855615601785,
+            "scoreConfidence" : [
+                0.831255490225795,
+                0.8810526025378308
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8521012327008262,
+                "50.0" : 0.8555995536820946,
+                "90.0" : 0.8613158454622363,
+                "95.0" : 0.8613158454622363,
+                "99.0" : 0.8613158454622363,
+                "99.9" : 0.8613158454622363,
+                "99.99" : 0.8613158454622363,
+                "99.999" : 0.8613158454622363,
+                "99.9999" : 0.8613158454622363,
+                "100.0" : 0.8613158454622363
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8521012327008262,
+                    0.8562531068436384
+                ],
+                [
+                    0.8549460005205509,
+                    0.8613158454622363
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.443187770698795,
+            "scoreError" : 0.39416273318576833,
+            "scoreConfidence" : [
+                16.049025037513026,
+                16.837350503884565
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.200860959536715,
+                "50.0" : 16.447807961714037,
+                "90.0" : 16.587917187623493,
+                "95.0" : 16.587917187623493,
+                "99.0" : 16.587917187623493,
+                "99.9" : 16.587917187623493,
+                "99.99" : 16.587917187623493,
+                "99.999" : 16.587917187623493,
+                "99.9999" : 16.587917187623493,
+                "100.0" : 16.587917187623493
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.57066779854627,
+                    16.587917187623493,
+                    16.47325743622623
+                ],
+                [
+                    16.40406475505822,
+                    16.200860959536715,
+                    16.422358487201844
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2753.840408708272,
+            "scoreError" : 44.00145834966014,
+            "scoreConfidence" : [
+                2709.8389503586122,
+                2797.841867057932
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2736.87550691603,
+                "50.0" : 2752.826772391782,
+                "90.0" : 2777.8574491950512,
+                "95.0" : 2777.8574491950512,
+                "99.0" : 2777.8574491950512,
+                "99.9" : 2777.8574491950512,
+                "99.99" : 2777.8574491950512,
+                "99.999" : 2777.8574491950512,
+                "99.9999" : 2777.8574491950512,
+                "100.0" : 2777.8574491950512
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2761.426932341516,
+                    2777.8574491950512,
+                    2761.4235111645885
+                ],
+                [
+                    2736.87550691603,
+                    2744.2300336189755,
+                    2741.2290190134686
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74127.11567388859,
+            "scoreError" : 2212.8847705269845,
+            "scoreConfidence" : [
+                71914.2309033616,
+                76340.00044441558
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73375.98989331923,
+                "50.0" : 74126.84841220698,
+                "90.0" : 74866.64634741787,
+                "95.0" : 74866.64634741787,
+                "99.0" : 74866.64634741787,
+                "99.9" : 74866.64634741787,
+                "99.99" : 74866.64634741787,
+                "99.999" : 74866.64634741787,
+                "99.9999" : 74866.64634741787,
+                "100.0" : 74866.64634741787
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74831.02970345334,
+                    74866.64634741787,
+                    74844.08360986017
+                ],
+                [
+                    73422.66712096063,
+                    73375.98989331923,
+                    73422.27736832036
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 363.3904927738427,
+            "scoreError" : 11.028168439093706,
+            "scoreConfidence" : [
+                352.362324334749,
+                374.4186612129364
+            ],
+            "scorePercentiles" : {
+                "0.0" : 359.5007413060743,
+                "50.0" : 363.2028825658643,
+                "90.0" : 367.53319191131357,
+                "95.0" : 367.53319191131357,
+                "99.0" : 367.53319191131357,
+                "99.9" : 367.53319191131357,
+                "99.99" : 367.53319191131357,
+                "99.999" : 367.53319191131357,
+                "99.9999" : 367.53319191131357,
+                "100.0" : 367.53319191131357
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    359.5007413060743,
+                    359.9296153318063,
+                    360.0284928328874
+                ],
+                [
+                    366.37727229884115,
+                    367.53319191131357,
+                    366.9736429621336
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 127.70584558027565,
+            "scoreError" : 1.1201375476431685,
+            "scoreConfidence" : [
+                126.58570803263248,
+                128.82598312791882
+            ],
+            "scorePercentiles" : {
+                "0.0" : 127.215397740496,
+                "50.0" : 127.68836184353589,
+                "90.0" : 128.21140171608022,
+                "95.0" : 128.21140171608022,
+                "99.0" : 128.21140171608022,
+                "99.9" : 128.21140171608022,
+                "99.99" : 128.21140171608022,
+                "99.999" : 128.21140171608022,
+                "99.9999" : 128.21140171608022,
+                "100.0" : 128.21140171608022
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    128.0995608620253,
+                    127.74444793799299,
+                    128.21140171608022
+                ],
+                [
+                    127.215397740496,
+                    127.33198947598069,
+                    127.6322757490788
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06137116158485209,
+            "scoreError" : 0.0012738410716123711,
+            "scoreConfidence" : [
+                0.06009732051323972,
+                0.06264500265646446
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06091998244919343,
+                "50.0" : 0.06132362491478177,
+                "90.0" : 0.06190099923863052,
+                "95.0" : 0.06190099923863052,
+                "99.0" : 0.06190099923863052,
+                "99.9" : 0.06190099923863052,
+                "99.99" : 0.06190099923863052,
+                "99.999" : 0.06190099923863052,
+                "99.9999" : 0.06190099923863052,
+                "100.0" : 0.06190099923863052
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06183403643817321,
+                    0.06190099923863052,
+                    0.06157797623123437
+                ],
+                [
+                    0.06091998244919343,
+                    0.06106927359832917,
+                    0.06092470155355185
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.638752235941099E-4,
+            "scoreError" : 2.3146449379879325E-5,
+            "scoreConfidence" : [
+                3.407287742142306E-4,
+                3.8702167297398923E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.550607407324824E-4,
+                "50.0" : 3.63840768857834E-4,
+                "90.0" : 3.727181530756232E-4,
+                "95.0" : 3.727181530756232E-4,
+                "99.0" : 3.727181530756232E-4,
+                "99.9" : 3.727181530756232E-4,
+                "99.99" : 3.727181530756232E-4,
+                "99.999" : 3.727181530756232E-4,
+                "99.9999" : 3.727181530756232E-4,
+                "100.0" : 3.727181530756232E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.7056378327493566E-4,
+                    3.707645672032328E-4,
+                    3.727181530756232E-4
+                ],
+                [
+                    3.5711775444073233E-4,
+                    3.5702634283765354E-4,
+                    3.550607407324824E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.14558103448013,
+            "scoreError" : 0.05117758444539929,
+            "scoreConfidence" : [
+                2.0944034500347306,
+                2.196758618925529
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.105240550199958,
+                "50.0" : 2.1371188885944683,
+                "90.0" : 2.2065305915153046,
+                "95.0" : 2.20825891874586,
+                "99.0" : 2.20825891874586,
+                "99.9" : 2.20825891874586,
+                "99.99" : 2.20825891874586,
+                "99.999" : 2.20825891874586,
+                "99.9999" : 2.20825891874586,
+                "100.0" : 2.20825891874586
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.20825891874586,
+                    2.165810838891295,
+                    2.144320771226415,
+                    2.129765762563884,
+                    2.1206478195504666
+                ],
+                [
+                    2.1909756464403065,
+                    2.1492733597678915,
+                    2.1299170059625214,
+                    2.105240550199958,
+                    2.1115996714527028
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013769412852857224,
+            "scoreError" : 5.649323253645858E-4,
+            "scoreConfidence" : [
+                0.013204480527492637,
+                0.01433434517822181
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013529451806153097,
+                "50.0" : 0.013784505759801915,
+                "90.0" : 0.013952709216177073,
+                "95.0" : 0.013952709216177073,
+                "99.0" : 0.013952709216177073,
+                "99.9" : 0.013952709216177073,
+                "99.99" : 0.013952709216177073,
+                "99.999" : 0.013952709216177073,
+                "99.9999" : 0.013952709216177073,
+                "100.0" : 0.013952709216177073
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013529451806153097,
+                    0.013618923712078705,
+                    0.013615153878200633
+                ],
+                [
+                    0.013950087807525123,
+                    0.013950150697008714,
+                    0.013952709216177073
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.9700631839396436,
+            "scoreError" : 0.052773381055182825,
+            "scoreConfidence" : [
+                0.9172898028844608,
+                1.0228365649948266
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9526372075633454,
+                "50.0" : 0.9698597576861107,
+                "90.0" : 0.9876879595061728,
+                "95.0" : 0.9876879595061728,
+                "99.0" : 0.9876879595061728,
+                "99.9" : 0.9876879595061728,
+                "99.99" : 0.9876879595061728,
+                "99.999" : 0.9876879595061728,
+                "99.9999" : 0.9876879595061728,
+                "100.0" : 0.9876879595061728
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.9527734919969513,
+                    0.9532558049756934,
+                    0.9526372075633454
+                ],
+                [
+                    0.9876879595061728,
+                    0.9875609291991705,
+                    0.9864637103965279
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01086280065839717,
+            "scoreError" : 4.478691217014188E-4,
+            "scoreConfidence" : [
+                0.010414931536695753,
+                0.011310669780098589
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010710724475937914,
+                "50.0" : 0.010864596860357872,
+                "90.0" : 0.011019957796858952,
+                "95.0" : 0.011019957796858952,
+                "99.0" : 0.011019957796858952,
+                "99.9" : 0.011019957796858952,
+                "99.99" : 0.011019957796858952,
+                "99.999" : 0.011019957796858952,
+                "99.9999" : 0.011019957796858952,
+                "100.0" : 0.011019957796858952
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.011019957796858952,
+                    0.011000887986359386,
+                    0.011004277861530302
+                ],
+                [
+                    0.01072830573435636,
+                    0.010710724475937914,
+                    0.010712650095340118
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.007336946467659,
+            "scoreError" : 0.15203550543059569,
+            "scoreConfidence" : [
+                2.855301441037063,
+                3.1593724518982547
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.953875252215003,
+                "50.0" : 3.006015916551888,
+                "90.0" : 3.066343888412017,
+                "95.0" : 3.066343888412017,
+                "99.0" : 3.066343888412017,
+                "99.9" : 3.066343888412017,
+                "99.99" : 3.066343888412017,
+                "99.999" : 3.066343888412017,
+                "99.9999" : 3.066343888412017,
+                "100.0" : 3.066343888412017
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0474102705667274,
+                    3.066343888412017,
+                    3.0554985088576663
+                ],
+                [
+                    2.956272196217494,
+                    2.9646215625370482,
+                    2.953875252215003
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.756158882178697,
+            "scoreError" : 0.008021334526026632,
+            "scoreConfidence" : [
+                2.74813754765267,
+                2.7641802167047236
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.752682275529865,
+                "50.0" : 2.7556557948153415,
+                "90.0" : 2.7606152544852334,
+                "95.0" : 2.7606152544852334,
+                "99.0" : 2.7606152544852334,
+                "99.9" : 2.7606152544852334,
+                "99.99" : 2.7606152544852334,
+                "99.999" : 2.7606152544852334,
+                "99.9999" : 2.7606152544852334,
+                "100.0" : 2.7606152544852334
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.754780939961443,
+                    2.7543108311759847,
+                    2.7606152544852334
+                ],
+                [
+                    2.7580333422504135,
+                    2.752682275529865,
+                    2.7565306496692394
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17800210544407705,
+            "scoreError" : 0.004894610613265909,
+            "scoreConfidence" : [
+                0.17310749483081114,
+                0.18289671605734295
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1747372763585532,
+                "50.0" : 0.17860545456867824,
+                "90.0" : 0.17927810467721983,
+                "95.0" : 0.17927810467721983,
+                "99.0" : 0.17927810467721983,
+                "99.9" : 0.17927810467721983,
+                "99.99" : 0.17927810467721983,
+                "99.999" : 0.17927810467721983,
+                "99.9999" : 0.17927810467721983,
+                "100.0" : 0.17927810467721983
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17927810467721983,
+                    0.1792382212463929,
+                    0.17909729713272562
+                ],
+                [
+                    0.17811361200463086,
+                    0.17754812124494,
+                    0.1747372763585532
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3894712356918219,
+            "scoreError" : 0.010291267311623203,
+            "scoreConfidence" : [
+                0.3791799683801987,
+                0.3997625030034451
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3833229430027981,
+                "50.0" : 0.39098339795965187,
+                "90.0" : 0.39333474370673377,
+                "95.0" : 0.39333474370673377,
+                "99.0" : 0.39333474370673377,
+                "99.9" : 0.39333474370673377,
+                "99.99" : 0.39333474370673377,
+                "99.999" : 0.39333474370673377,
+                "99.9999" : 0.39333474370673377,
+                "100.0" : 0.39333474370673377
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3833229430027981,
+                    0.3869071623786126,
+                    0.3912464158450704
+                ],
+                [
+                    0.39333474370673377,
+                    0.3912957691434832,
+                    0.39072038007423326
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15854160083315447,
+            "scoreError" : 0.008437690598357146,
+            "scoreConfidence" : [
+                0.15010391023479733,
+                0.1669792914315116
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15684021710763632,
+                "50.0" : 0.15738840899845663,
+                "90.0" : 0.16457972459761036,
+                "95.0" : 0.16457972459761036,
+                "99.0" : 0.16457972459761036,
+                "99.9" : 0.16457972459761036,
+                "99.99" : 0.16457972459761036,
+                "99.999" : 0.16457972459761036,
+                "99.9999" : 0.16457972459761036,
+                "100.0" : 0.16457972459761036
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15702039991835195,
+                    0.15684021710763632,
+                    0.15684676421782365
+                ],
+                [
+                    0.16457972459761036,
+                    0.1582060810789432,
+                    0.15775641807856128
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.41004238815059324,
+            "scoreError" : 0.012858629792687893,
+            "scoreConfidence" : [
+                0.39718375835790537,
+                0.4229010179432811
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4049357584224166,
+                "50.0" : 0.40939485414876,
+                "90.0" : 0.417397815351225,
+                "95.0" : 0.417397815351225,
+                "99.0" : 0.417397815351225,
+                "99.9" : 0.417397815351225,
+                "99.99" : 0.417397815351225,
+                "99.999" : 0.417397815351225,
+                "99.9999" : 0.417397815351225,
+                "100.0" : 0.417397815351225
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.417397815351225,
+                    0.4107690101458205,
+                    0.4049357584224166
+                ],
+                [
+                    0.4127186631861329,
+                    0.4080206981516994,
+                    0.40641238364626514
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1435427353422858,
+            "scoreError" : 0.007757036651051057,
+            "scoreConfidence" : [
+                0.13578569869123472,
+                0.15129977199333686
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14100405188872125,
+                "50.0" : 0.14350015808974909,
+                "90.0" : 0.1462356886844876,
+                "95.0" : 0.1462356886844876,
+                "99.0" : 0.1462356886844876,
+                "99.9" : 0.1462356886844876,
+                "99.99" : 0.1462356886844876,
+                "99.999" : 0.1462356886844876,
+                "99.9999" : 0.1462356886844876,
+                "100.0" : 0.1462356886844876
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1462356886844876,
+                    0.14599091721047022,
+                    0.14597294352401943
+                ],
+                [
+                    0.14102737265547877,
+                    0.14100405188872125,
+                    0.1410254380905373
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04307918280609777,
+            "scoreError" : 0.003165898184609988,
+            "scoreConfidence" : [
+                0.039913284621487785,
+                0.04624508099070776
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0419566798002895,
+                "50.0" : 0.04310518774400178,
+                "90.0" : 0.04435562857611752,
+                "95.0" : 0.04435562857611752,
+                "99.0" : 0.04435562857611752,
+                "99.9" : 0.04435562857611752,
+                "99.99" : 0.04435562857611752,
+                "99.999" : 0.04435562857611752,
+                "99.9999" : 0.04435562857611752,
+                "100.0" : 0.04435562857611752
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04225177260436032,
+                    0.041975065295226266,
+                    0.0419566798002895
+                ],
+                [
+                    0.04435562857611752,
+                    0.0439773476769498,
+                    0.043958602883643234
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7789492.364220176,
+            "scoreError" : 66559.2593896299,
+            "scoreConfidence" : [
+                7722933.104830546,
+                7856051.6236098055
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7746575.491092176,
+                "50.0" : 7795003.585394599,
+                "90.0" : 7813439.68203125,
+                "95.0" : 7813439.68203125,
+                "99.0" : 7813439.68203125,
+                "99.9" : 7813439.68203125,
+                "99.99" : 7813439.68203125,
+                "99.999" : 7813439.68203125,
+                "99.9999" : 7813439.68203125,
+                "100.0" : 7813439.68203125
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7813439.68203125,
+                    7783159.438132295,
+                    7801960.8213728545
+                ],
+                [
+                    7803772.4032761315,
+                    7746575.491092176,
+                    7788046.349416343
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-05T00-28-34Z-c8a9d1801e76543899dfbe3ee50966532d6e6eb3-jdk17.json
+++ b/performance-results/2026-03-05T00-28-34Z-c8a9d1801e76543899dfbe3ee50966532d6e6eb3-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3747101735663185,
+            "scoreError" : 0.024789103535115143,
+            "scoreConfidence" : [
+                3.349921070031203,
+                3.399499277101434
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.371314504702127,
+                "50.0" : 3.3737442473971244,
+                "90.0" : 3.3800376947688964,
+                "95.0" : 3.3800376947688964,
+                "99.0" : 3.3800376947688964,
+                "99.9" : 3.3800376947688964,
+                "99.99" : 3.3800376947688964,
+                "99.999" : 3.3800376947688964,
+                "99.9999" : 3.3800376947688964,
+                "100.0" : 3.3800376947688964
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.374832563129261,
+                    3.3800376947688964
+                ],
+                [
+                    3.371314504702127,
+                    3.3726559316649882
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6929066119777887,
+            "scoreError" : 0.022213018357343493,
+            "scoreConfidence" : [
+                1.6706935936204452,
+                1.7151196303351322
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6879997741297432,
+                "50.0" : 1.6939720301353947,
+                "90.0" : 1.6956826135106227,
+                "95.0" : 1.6956826135106227,
+                "99.0" : 1.6956826135106227,
+                "99.9" : 1.6956826135106227,
+                "99.99" : 1.6956826135106227,
+                "99.999" : 1.6956826135106227,
+                "99.9999" : 1.6956826135106227,
+                "100.0" : 1.6956826135106227
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6948073509393655,
+                    1.6879997741297432
+                ],
+                [
+                    1.693136709331424,
+                    1.6956826135106227
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8572855795633322,
+            "scoreError" : 0.02810980931948441,
+            "scoreConfidence" : [
+                0.8291757702438478,
+                0.8853953888828165
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8509944822267593,
+                "50.0" : 0.8585755798231132,
+                "90.0" : 0.8609966763803428,
+                "95.0" : 0.8609966763803428,
+                "99.0" : 0.8609966763803428,
+                "99.9" : 0.8609966763803428,
+                "99.99" : 0.8609966763803428,
+                "99.999" : 0.8609966763803428,
+                "99.9999" : 0.8609966763803428,
+                "100.0" : 0.8609966763803428
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8583637041605832,
+                    0.8587874554856433
+                ],
+                [
+                    0.8509944822267593,
+                    0.8609966763803428
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.45543425114488,
+            "scoreError" : 0.22712327662885776,
+            "scoreConfidence" : [
+                16.22831097451602,
+                16.68255752777374
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.375069882780444,
+                "50.0" : 16.44763677443853,
+                "90.0" : 16.543332995568452,
+                "95.0" : 16.543332995568452,
+                "99.0" : 16.543332995568452,
+                "99.9" : 16.543332995568452,
+                "99.99" : 16.543332995568452,
+                "99.999" : 16.543332995568452,
+                "99.9999" : 16.543332995568452,
+                "100.0" : 16.543332995568452
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.393372804246304,
+                    16.375069882780444,
+                    16.38017848593228
+                ],
+                [
+                    16.53875059371104,
+                    16.501900744630756,
+                    16.543332995568452
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2800.3697748001996,
+            "scoreError" : 32.25394600059049,
+            "scoreConfidence" : [
+                2768.115828799609,
+                2832.62372080079
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2789.1707305103873,
+                "50.0" : 2800.2571856405807,
+                "90.0" : 2811.4050333260816,
+                "95.0" : 2811.4050333260816,
+                "99.0" : 2811.4050333260816,
+                "99.9" : 2811.4050333260816,
+                "99.99" : 2811.4050333260816,
+                "99.999" : 2811.4050333260816,
+                "99.9999" : 2811.4050333260816,
+                "100.0" : 2811.4050333260816
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2790.556935286529,
+                    2789.1707305103873,
+                    2789.93407370064
+                ],
+                [
+                    2811.4050333260816,
+                    2811.194439982929,
+                    2809.9574359946323
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74100.35375377994,
+            "scoreError" : 4263.430829910265,
+            "scoreConfidence" : [
+                69836.92292386967,
+                78363.78458369021
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72620.29441040465,
+                "50.0" : 74163.7498487639,
+                "90.0" : 75541.45851347703,
+                "95.0" : 75541.45851347703,
+                "99.0" : 75541.45851347703,
+                "99.9" : 75541.45851347703,
+                "99.99" : 75541.45851347703,
+                "99.999" : 75541.45851347703,
+                "99.9999" : 75541.45851347703,
+                "100.0" : 75541.45851347703
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    75459.49900710782,
+                    75541.45851347703,
+                    75456.2962599397
+                ],
+                [
+                    72620.29441040465,
+                    72653.37089416233,
+                    72871.2034375881
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 364.6802236811845,
+            "scoreError" : 12.477311580131344,
+            "scoreConfidence" : [
+                352.20291210105313,
+                377.15753526131584
+            ],
+            "scorePercentiles" : {
+                "0.0" : 360.4632190180115,
+                "50.0" : 364.74025080022705,
+                "90.0" : 369.0232983598266,
+                "95.0" : 369.0232983598266,
+                "99.0" : 369.0232983598266,
+                "99.9" : 369.0232983598266,
+                "99.99" : 369.0232983598266,
+                "99.999" : 369.0232983598266,
+                "99.9999" : 369.0232983598266,
+                "100.0" : 369.0232983598266
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    360.4776075635913,
+                    360.9308465521277,
+                    360.4632190180115
+                ],
+                [
+                    368.6367155452236,
+                    368.5496550483264,
+                    369.0232983598266
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 130.53138810407364,
+            "scoreError" : 4.173435316674878,
+            "scoreConfidence" : [
+                126.35795278739876,
+                134.7048234207485
+            ],
+            "scorePercentiles" : {
+                "0.0" : 129.02823448307768,
+                "50.0" : 130.55026666740702,
+                "90.0" : 131.9861638640449,
+                "95.0" : 131.9861638640449,
+                "99.0" : 131.9861638640449,
+                "99.9" : 131.9861638640449,
+                "99.99" : 131.9861638640449,
+                "99.999" : 131.9861638640449,
+                "99.9999" : 131.9861638640449,
+                "100.0" : 131.9861638640449
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    129.20813780764067,
+                    129.02823448307768,
+                    129.2916493497393
+                ],
+                [
+                    131.86525913486452,
+                    131.80888398507477,
+                    131.9861638640449
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06162023223846568,
+            "scoreError" : 0.0018616020484154806,
+            "scoreConfidence" : [
+                0.0597586301900502,
+                0.06348183428688116
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06096908684306792,
+                "50.0" : 0.061616768744869245,
+                "90.0" : 0.062250469155399515,
+                "95.0" : 0.062250469155399515,
+                "99.0" : 0.062250469155399515,
+                "99.9" : 0.062250469155399515,
+                "99.99" : 0.062250469155399515,
+                "99.999" : 0.062250469155399515,
+                "99.9999" : 0.062250469155399515,
+                "100.0" : 0.062250469155399515
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0622361561708457,
+                    0.06218998857629691,
+                    0.062250469155399515
+                ],
+                [
+                    0.06104354891344158,
+                    0.061032143771742445,
+                    0.06096908684306792
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.5932140649834286E-4,
+            "scoreError" : 5.2691503059261856E-6,
+            "scoreConfidence" : [
+                3.5405225619241666E-4,
+                3.6459055680426906E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5743784021563486E-4,
+                "50.0" : 3.592700392686536E-4,
+                "90.0" : 3.6116379477845774E-4,
+                "95.0" : 3.6116379477845774E-4,
+                "99.0" : 3.6116379477845774E-4,
+                "99.9" : 3.6116379477845774E-4,
+                "99.99" : 3.6116379477845774E-4,
+                "99.999" : 3.6116379477845774E-4,
+                "99.9999" : 3.6116379477845774E-4,
+                "100.0" : 3.6116379477845774E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.607658254005567E-4,
+                    3.611570467627866E-4,
+                    3.6116379477845774E-4
+                ],
+                [
+                    3.5777425313675054E-4,
+                    3.5743784021563486E-4,
+                    3.576296786958708E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.118052151751435,
+            "scoreError" : 0.04771304654361869,
+            "scoreConfidence" : [
+                2.0703391052078164,
+                2.1657651982950537
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.0888569605263156,
+                "50.0" : 2.100201869657932,
+                "90.0" : 2.161843420892237,
+                "95.0" : 2.162344268324324,
+                "99.0" : 2.162344268324324,
+                "99.9" : 2.162344268324324,
+                "99.99" : 2.162344268324324,
+                "99.999" : 2.162344268324324,
+                "99.9999" : 2.162344268324324,
+                "100.0" : 2.162344268324324
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.162344268324324,
+                    2.152852626560482,
+                    2.0967174412997904,
+                    2.101627806682076,
+                    2.0987759326337883
+                ],
+                [
+                    2.157335794003451,
+                    2.143433669309901,
+                    2.0893808815542094,
+                    2.0891961366200125,
+                    2.0888569605263156
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.01346693599512938,
+            "scoreError" : 2.684795022655732E-4,
+            "scoreConfidence" : [
+                0.013198456492863806,
+                0.013735415497394952
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013373564254506502,
+                "50.0" : 0.013466393018706207,
+                "90.0" : 0.01355761801079715,
+                "95.0" : 0.01355761801079715,
+                "99.0" : 0.01355761801079715,
+                "99.9" : 0.01355761801079715,
+                "99.99" : 0.01355761801079715,
+                "99.999" : 0.01355761801079715,
+                "99.9999" : 0.01355761801079715,
+                "100.0" : 0.01355761801079715
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013373564254506502,
+                    0.013381878331036145,
+                    0.013383432952534923
+                ],
+                [
+                    0.013555769337024064,
+                    0.013549353084877489,
+                    0.01355761801079715
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1265072938198248,
+            "scoreError" : 0.4335884213319381,
+            "scoreConfidence" : [
+                0.6929188724878868,
+                1.560095715151763
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9851605104915772,
+                "50.0" : 1.1264568407057767,
+                "90.0" : 1.2679346984911881,
+                "95.0" : 1.2679346984911881,
+                "99.0" : 1.2679346984911881,
+                "99.9" : 1.2679346984911881,
+                "99.99" : 1.2679346984911881,
+                "99.999" : 1.2679346984911881,
+                "99.9999" : 1.2679346984911881,
+                "100.0" : 1.2679346984911881
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.2677977219827585,
+                    1.2672379647744552,
+                    1.2679346984911881
+                ],
+                [
+                    0.9851605104915772,
+                    0.9856757166370984,
+                    0.9852371505418719
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010346622476077325,
+            "scoreError" : 7.796241870506553E-4,
+            "scoreConfidence" : [
+                0.009566998289026669,
+                0.01112624666312798
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010090961524179324,
+                "50.0" : 0.010345858518150754,
+                "90.0" : 0.010605452808459738,
+                "95.0" : 0.010605452808459738,
+                "99.0" : 0.010605452808459738,
+                "99.9" : 0.010605452808459738,
+                "99.99" : 0.010605452808459738,
+                "99.999" : 0.010605452808459738,
+                "99.9999" : 0.010605452808459738,
+                "100.0" : 0.010605452808459738
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010599765610955651,
+                    0.010605452808459738,
+                    0.010595984776048555
+                ],
+                [
+                    0.010095732260252952,
+                    0.01009183787656773,
+                    0.010090961524179324
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0512466484840783,
+            "scoreError" : 0.13383752276938254,
+            "scoreConfidence" : [
+                2.9174091257146957,
+                3.185084171253461
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0044948732732735,
+                "50.0" : 3.0509937496377613,
+                "90.0" : 3.098554986369269,
+                "95.0" : 3.098554986369269,
+                "99.0" : 3.098554986369269,
+                "99.9" : 3.098554986369269,
+                "99.99" : 3.098554986369269,
+                "99.999" : 3.098554986369269,
+                "99.9999" : 3.098554986369269,
+                "100.0" : 3.098554986369269
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0044948732732735,
+                    3.0092595950661853,
+                    3.009495614921781
+                ],
+                [
+                    3.098554986369269,
+                    3.093182936920223,
+                    3.0924918843537417
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.740463784841904,
+            "scoreError" : 0.14146445041876096,
+            "scoreConfidence" : [
+                2.598999334423143,
+                2.881928235260665
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6926872393645667,
+                "50.0" : 2.740324643932707,
+                "90.0" : 2.7909188992745535,
+                "95.0" : 2.7909188992745535,
+                "99.0" : 2.7909188992745535,
+                "99.9" : 2.7909188992745535,
+                "99.99" : 2.7909188992745535,
+                "99.999" : 2.7909188992745535,
+                "99.9999" : 2.7909188992745535,
+                "100.0" : 2.7909188992745535
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.6926872393645667,
+                    2.6969784147788567,
+                    2.69378965364934
+                ],
+                [
+                    2.7909188992745535,
+                    2.7847376288975503,
+                    2.783670873086557
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1761333399841211,
+            "scoreError" : 4.998706309250967E-4,
+            "scoreConfidence" : [
+                0.175633469353196,
+                0.1766332106150462
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17596567978180538,
+                "50.0" : 0.17609073256521934,
+                "90.0" : 0.17646251133736832,
+                "95.0" : 0.17646251133736832,
+                "99.0" : 0.17646251133736832,
+                "99.9" : 0.17646251133736832,
+                "99.99" : 0.17646251133736832,
+                "99.999" : 0.17646251133736832,
+                "99.9999" : 0.17646251133736832,
+                "100.0" : 0.17646251133736832
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17604229739816216,
+                    0.17613916773227653,
+                    0.17602041286325312
+                ],
+                [
+                    0.17616997079186117,
+                    0.17646251133736832,
+                    0.17596567978180538
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.37874651685559885,
+            "scoreError" : 0.00681259213732608,
+            "scoreConfidence" : [
+                0.37193392471827275,
+                0.38555910899292495
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3758424291566446,
+                "50.0" : 0.3790385114876039,
+                "90.0" : 0.38100133828628036,
+                "95.0" : 0.38100133828628036,
+                "99.0" : 0.38100133828628036,
+                "99.9" : 0.38100133828628036,
+                "99.99" : 0.38100133828628036,
+                "99.999" : 0.38100133828628036,
+                "99.9999" : 0.38100133828628036,
+                "100.0" : 0.38100133828628036
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.38087115340671057,
+                    0.38091258520606386,
+                    0.38100133828628036
+                ],
+                [
+                    0.376645725509397,
+                    0.3772058695684973,
+                    0.3758424291566446
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15735470607441573,
+            "scoreError" : 0.0024591268239564142,
+            "scoreConfidence" : [
+                0.15489557925045933,
+                0.15981383289837214
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15644259270673633,
+                "50.0" : 0.15732886236639235,
+                "90.0" : 0.1583003022493787,
+                "95.0" : 0.1583003022493787,
+                "99.0" : 0.1583003022493787,
+                "99.9" : 0.1583003022493787,
+                "99.99" : 0.1583003022493787,
+                "99.999" : 0.1583003022493787,
+                "99.9999" : 0.1583003022493787,
+                "100.0" : 0.1583003022493787
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1566081560097095,
+                    0.1566304476239702,
+                    0.15644259270673633
+                ],
+                [
+                    0.1583003022493787,
+                    0.1580272771088145,
+                    0.15811946074788522
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4097613249033934,
+            "scoreError" : 0.0068051965724600216,
+            "scoreConfidence" : [
+                0.40295612833093336,
+                0.41656652147585344
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40733346185491426,
+                "50.0" : 0.4094986959789449,
+                "90.0" : 0.41348719148232377,
+                "95.0" : 0.41348719148232377,
+                "99.0" : 0.41348719148232377,
+                "99.9" : 0.41348719148232377,
+                "99.99" : 0.41348719148232377,
+                "99.999" : 0.41348719148232377,
+                "99.9999" : 0.41348719148232377,
+                "100.0" : 0.41348719148232377
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41348719148232377,
+                    0.41111543704008224,
+                    0.4082387225669497
+                ],
+                [
+                    0.4107586693909401,
+                    0.40733346185491426,
+                    0.4076344670851506
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14202787218976398,
+            "scoreError" : 0.009043015184246161,
+            "scoreConfidence" : [
+                0.13298485700551782,
+                0.15107088737401014
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.13891374700301434,
+                "50.0" : 0.14197938295030527,
+                "90.0" : 0.14532062540143864,
+                "95.0" : 0.14532062540143864,
+                "99.0" : 0.14532062540143864,
+                "99.9" : 0.14532062540143864,
+                "99.99" : 0.14532062540143864,
+                "99.999" : 0.14532062540143864,
+                "99.9999" : 0.14532062540143864,
+                "100.0" : 0.14532062540143864
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.13891374700301434,
+                    0.13922032045106503,
+                    0.13913883417742653
+                ],
+                [
+                    0.14532062540143864,
+                    0.14483526065609384,
+                    0.14473844544954553
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04299641167324906,
+            "scoreError" : 0.0015432735565010527,
+            "scoreConfidence" : [
+                0.04145313811674801,
+                0.04453968522975011
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04249876884370857,
+                "50.0" : 0.04293744622249102,
+                "90.0" : 0.04375497110904007,
+                "95.0" : 0.04375497110904007,
+                "99.0" : 0.04375497110904007,
+                "99.9" : 0.04375497110904007,
+                "99.99" : 0.04375497110904007,
+                "99.999" : 0.04375497110904007,
+                "99.9999" : 0.04375497110904007,
+                "100.0" : 0.04375497110904007
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04375497110904007,
+                    0.04334824966947415,
+                    0.04333478088531623
+                ],
+                [
+                    0.04254011155966581,
+                    0.04249876884370857,
+                    0.04250158797228951
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7750418.525839704,
+            "scoreError" : 156363.9217816154,
+            "scoreConfidence" : [
+                7594054.604058089,
+                7906782.447621319
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7694861.798461539,
+                "50.0" : 7749104.855707798,
+                "90.0" : 7811039.234192037,
+                "95.0" : 7811039.234192037,
+                "99.0" : 7811039.234192037,
+                "99.9" : 7811039.234192037,
+                "99.99" : 7811039.234192037,
+                "99.999" : 7811039.234192037,
+                "99.9999" : 7811039.234192037,
+                "100.0" : 7811039.234192037
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7811039.234192037,
+                    7798703.365549494,
+                    7793135.6012461055
+                ],
+                [
+                    7705074.110169492,
+                    7699697.045419553,
+                    7694861.798461539
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-05T11-26-19Z-471b67613c7265bd8267f238637a96ef7368c4d6-jdk17.json
+++ b/performance-results/2026-03-05T11-26-19Z-471b67613c7265bd8267f238637a96ef7368c4d6-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3801049686092317,
+            "scoreError" : 0.02449770777777562,
+            "scoreConfidence" : [
+                3.355607260831456,
+                3.4046026763870074
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3766417722530457,
+                "50.0" : 3.379963456370365,
+                "90.0" : 3.3838511894431504,
+                "95.0" : 3.3838511894431504,
+                "99.0" : 3.3838511894431504,
+                "99.9" : 3.3838511894431504,
+                "99.99" : 3.3838511894431504,
+                "99.999" : 3.3838511894431504,
+                "99.9999" : 3.3838511894431504,
+                "100.0" : 3.3838511894431504
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3766417722530457,
+                    3.3828830599486652
+                ],
+                [
+                    3.377043852792065,
+                    3.3838511894431504
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7056720688327807,
+            "scoreError" : 0.022914576705867152,
+            "scoreConfidence" : [
+                1.6827574921269135,
+                1.7285866455386478
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.7021993763327592,
+                "50.0" : 1.7050568691319312,
+                "90.0" : 1.7103751607345012,
+                "95.0" : 1.7103751607345012,
+                "99.0" : 1.7103751607345012,
+                "99.9" : 1.7103751607345012,
+                "99.99" : 1.7103751607345012,
+                "99.999" : 1.7103751607345012,
+                "99.9999" : 1.7103751607345012,
+                "100.0" : 1.7103751607345012
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7038762053718306,
+                    1.706237532892032
+                ],
+                [
+                    1.7021993763327592,
+                    1.7103751607345012
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8589195457831135,
+            "scoreError" : 0.014333738156759595,
+            "scoreConfidence" : [
+                0.8445858076263538,
+                0.8732532839398731
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.856065578918892,
+                "50.0" : 0.8594477757357801,
+                "90.0" : 0.860717052742002,
+                "95.0" : 0.860717052742002,
+                "99.0" : 0.860717052742002,
+                "99.9" : 0.860717052742002,
+                "99.99" : 0.860717052742002,
+                "99.999" : 0.860717052742002,
+                "99.9999" : 0.860717052742002,
+                "100.0" : 0.860717052742002
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8582589708667585,
+                    0.860717052742002
+                ],
+                [
+                    0.856065578918892,
+                    0.8606365806048016
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.501258072819763,
+            "scoreError" : 0.33546184129093737,
+            "scoreConfidence" : [
+                16.165796231528827,
+                16.8367199141107
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.386079449925035,
+                "50.0" : 16.495912939153655,
+                "90.0" : 16.62205303286045,
+                "95.0" : 16.62205303286045,
+                "99.0" : 16.62205303286045,
+                "99.9" : 16.62205303286045,
+                "99.99" : 16.62205303286045,
+                "99.999" : 16.62205303286045,
+                "99.9999" : 16.62205303286045,
+                "100.0" : 16.62205303286045
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.390255534421627,
+                    16.386079449925035,
+                    16.401452871108866
+                ],
+                [
+                    16.62205303286045,
+                    16.59037300719844,
+                    16.61733454140417
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2756.355441161814,
+            "scoreError" : 52.59123181097361,
+            "scoreConfidence" : [
+                2703.7642093508402,
+                2808.9466729727874
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2737.411278560427,
+                "50.0" : 2753.4293396826392,
+                "90.0" : 2779.037818270726,
+                "95.0" : 2779.037818270726,
+                "99.0" : 2779.037818270726,
+                "99.9" : 2779.037818270726,
+                "99.99" : 2779.037818270726,
+                "99.999" : 2779.037818270726,
+                "99.9999" : 2779.037818270726,
+                "100.0" : 2779.037818270726
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2765.65530600357,
+                    2779.037818270726,
+                    2774.249673643934
+                ],
+                [
+                    2737.411278560427,
+                    2740.5751971305194,
+                    2741.2033733617086
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73450.68930448781,
+            "scoreError" : 2783.13023498166,
+            "scoreConfidence" : [
+                70667.55906950615,
+                76233.81953946946
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72426.35768053222,
+                "50.0" : 73486.50478494974,
+                "90.0" : 74366.5133943401,
+                "95.0" : 74366.5133943401,
+                "99.0" : 74366.5133943401,
+                "99.9" : 74366.5133943401,
+                "99.99" : 74366.5133943401,
+                "99.999" : 74366.5133943401,
+                "99.9999" : 74366.5133943401,
+                "100.0" : 74366.5133943401
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72587.01173821995,
+                    72426.35768053222,
+                    72626.9405908521
+                ],
+                [
+                    74346.06897904738,
+                    74351.24344393503,
+                    74366.5133943401
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 358.7806204383337,
+            "scoreError" : 7.035669373474187,
+            "scoreConfidence" : [
+                351.7449510648595,
+                365.8162898118079
+            ],
+            "scorePercentiles" : {
+                "0.0" : 355.3926847035959,
+                "50.0" : 358.9034767005918,
+                "90.0" : 361.42334004946247,
+                "95.0" : 361.42334004946247,
+                "99.0" : 361.42334004946247,
+                "99.9" : 361.42334004946247,
+                "99.99" : 361.42334004946247,
+                "99.999" : 361.42334004946247,
+                "99.9999" : 361.42334004946247,
+                "100.0" : 361.42334004946247
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    360.45626047111875,
+                    361.0348423812352,
+                    361.42334004946247
+                ],
+                [
+                    355.3926847035959,
+                    357.35069293006484,
+                    357.0259020945249
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 128.60336969811695,
+            "scoreError" : 4.184069371870374,
+            "scoreConfidence" : [
+                124.41930032624657,
+                132.78743906998733
+            ],
+            "scorePercentiles" : {
+                "0.0" : 126.92746600489136,
+                "50.0" : 128.58208551021005,
+                "90.0" : 130.13216613589051,
+                "95.0" : 130.13216613589051,
+                "99.0" : 130.13216613589051,
+                "99.9" : 130.13216613589051,
+                "99.99" : 130.13216613589051,
+                "99.999" : 130.13216613589051,
+                "99.9999" : 130.13216613589051,
+                "100.0" : 130.13216613589051
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    129.72462447988065,
+                    130.13216613589051,
+                    129.99357397566024
+                ],
+                [
+                    127.43954654053942,
+                    127.40284105183949,
+                    126.92746600489136
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.061065224754088564,
+            "scoreError" : 0.001812906156932062,
+            "scoreConfidence" : [
+                0.0592523185971565,
+                0.06287813091102062
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06042660289559075,
+                "50.0" : 0.06109081163233476,
+                "90.0" : 0.061687615440133244,
+                "95.0" : 0.061687615440133244,
+                "99.0" : 0.061687615440133244,
+                "99.9" : 0.061687615440133244,
+                "99.99" : 0.061687615440133244,
+                "99.999" : 0.061687615440133244,
+                "99.9999" : 0.061687615440133244,
+                "100.0" : 0.061687615440133244
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06043206646240867,
+                    0.06042660289559075,
+                    0.060573829486946514
+                ],
+                [
+                    0.06160779377772302,
+                    0.061687615440133244,
+                    0.06166344046172914
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.5527110682472495E-4,
+            "scoreError" : 4.408923602780612E-5,
+            "scoreConfidence" : [
+                3.1118187079691884E-4,
+                3.9936034285253106E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.4036996247566084E-4,
+                "50.0" : 3.5508163404218674E-4,
+                "90.0" : 3.7024051189342433E-4,
+                "95.0" : 3.7024051189342433E-4,
+                "99.0" : 3.7024051189342433E-4,
+                "99.9" : 3.7024051189342433E-4,
+                "99.99" : 3.7024051189342433E-4,
+                "99.999" : 3.7024051189342433E-4,
+                "99.9999" : 3.7024051189342433E-4,
+                "100.0" : 3.7024051189342433E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.4036996247566084E-4,
+                    3.410840971872852E-4,
+                    3.413274591846831E-4
+                ],
+                [
+                    3.697688013076058E-4,
+                    3.688358088996904E-4,
+                    3.7024051189342433E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.154860014891997,
+            "scoreError" : 0.05352625436260718,
+            "scoreConfidence" : [
+                2.10133376052939,
+                2.2083862692546044
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.11634730787135,
+                "50.0" : 2.1431513839972065,
+                "90.0" : 2.2179488521602195,
+                "95.0" : 2.2203104622557728,
+                "99.0" : 2.2203104622557728,
+                "99.9" : 2.2203104622557728,
+                "99.99" : 2.2203104622557728,
+                "99.999" : 2.2203104622557728,
+                "99.9999" : 2.2203104622557728,
+                "100.0" : 2.2203104622557728
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.1966943613002416,
+                    2.171840921606949,
+                    2.1341985674349124,
+                    2.129935264267462,
+                    2.1317480115089515
+                ],
+                [
+                    2.177573551055955,
+                    2.2203104622557728,
+                    2.1521042005595006,
+                    2.11634730787135,
+                    2.1178475010588733
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013527667003088611,
+            "scoreError" : 4.5111167990399435E-4,
+            "scoreConfidence" : [
+                0.013076555323184616,
+                0.013978778682992606
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013376696715259144,
+                "50.0" : 0.01353046662851717,
+                "90.0" : 0.01367611031836228,
+                "95.0" : 0.01367611031836228,
+                "99.0" : 0.01367611031836228,
+                "99.9" : 0.01367611031836228,
+                "99.99" : 0.01367611031836228,
+                "99.999" : 0.01367611031836228,
+                "99.9999" : 0.01367611031836228,
+                "100.0" : 0.01367611031836228
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013376696715259144,
+                    0.013388033453511427,
+                    0.013377849434459509
+                ],
+                [
+                    0.0136744122934164,
+                    0.013672899803522915,
+                    0.01367611031836228
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.017245360821067,
+            "scoreError" : 0.0044606703733244945,
+            "scoreConfidence" : [
+                1.0127846904477424,
+                1.0217060311943915
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0154899703493094,
+                "50.0" : 1.017048171658471,
+                "90.0" : 1.0197529294381564,
+                "95.0" : 1.0197529294381564,
+                "99.0" : 1.0197529294381564,
+                "99.9" : 1.0197529294381564,
+                "99.99" : 1.0197529294381564,
+                "99.999" : 1.0197529294381564,
+                "99.9999" : 1.0197529294381564,
+                "100.0" : 1.0197529294381564
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0176493246158542,
+                    1.0181660235186316,
+                    1.0197529294381564
+                ],
+                [
+                    1.0159668983033627,
+                    1.0164470187010874,
+                    1.0154899703493094
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.0106658203966682,
+            "scoreError" : 6.269317742882272E-5,
+            "scoreConfidence" : [
+                0.010603127219239377,
+                0.010728513574097022
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010640268593352997,
+                "50.0" : 0.010670306344228725,
+                "90.0" : 0.010687700495038923,
+                "95.0" : 0.010687700495038923,
+                "99.0" : 0.010687700495038923,
+                "99.9" : 0.010687700495038923,
+                "99.99" : 0.010687700495038923,
+                "99.999" : 0.010687700495038923,
+                "99.9999" : 0.010687700495038923,
+                "100.0" : 0.010687700495038923
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010657278970533384,
+                    0.010640268593352997,
+                    0.010641104224836558
+                ],
+                [
+                    0.010685236378323278,
+                    0.010687700495038923,
+                    0.010683333717924065
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.990024911267692,
+            "scoreError" : 0.17873053436695954,
+            "scoreConfidence" : [
+                2.8112943769007326,
+                3.1687554456346514
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.924363154385965,
+                "50.0" : 2.9903363963588707,
+                "90.0" : 3.0549677025045816,
+                "95.0" : 3.0549677025045816,
+                "99.0" : 3.0549677025045816,
+                "99.9" : 3.0549677025045816,
+                "99.99" : 3.0549677025045816,
+                "99.999" : 3.0549677025045816,
+                "99.9999" : 3.0549677025045816,
+                "100.0" : 3.0549677025045816
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.933623029325513,
+                    2.9383285305522913,
+                    2.924363154385965
+                ],
+                [
+                    3.04234426216545,
+                    3.0549677025045816,
+                    3.046522788672351
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.733588292272015,
+            "scoreError" : 0.03390502962726724,
+            "scoreConfidence" : [
+                2.699683262644748,
+                2.7674933218992823
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.721684209795918,
+                "50.0" : 2.7321054783338896,
+                "90.0" : 2.7480130593406593,
+                "95.0" : 2.7480130593406593,
+                "99.0" : 2.7480130593406593,
+                "99.9" : 2.7480130593406593,
+                "99.99" : 2.7480130593406593,
+                "99.999" : 2.7480130593406593,
+                "99.9999" : 2.7480130593406593,
+                "100.0" : 2.7480130593406593
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.724595210296922,
+                    2.722324713663582,
+                    2.721684209795918
+                ],
+                [
+                    2.7452968141641505,
+                    2.7480130593406593,
+                    2.7396157463708573
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18177129025718552,
+            "scoreError" : 0.007485260879005773,
+            "scoreConfidence" : [
+                0.17428602937817975,
+                0.1892565511361913
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1792332352582715,
+                "50.0" : 0.18177173724972745,
+                "90.0" : 0.18425752556519817,
+                "95.0" : 0.18425752556519817,
+                "99.0" : 0.18425752556519817,
+                "99.9" : 0.18425752556519817,
+                "99.99" : 0.18425752556519817,
+                "99.999" : 0.18425752556519817,
+                "99.9999" : 0.18425752556519817,
+                "100.0" : 0.18425752556519817
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18425594079929247,
+                    0.18410697264258624,
+                    0.18425752556519817
+                ],
+                [
+                    0.17943650185686863,
+                    0.17933756542089596,
+                    0.1792332352582715
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3896353026707744,
+            "scoreError" : 0.020952897303030217,
+            "scoreConfidence" : [
+                0.36868240536774416,
+                0.41058819997380464
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.37774037984437564,
+                "50.0" : 0.3923164804348421,
+                "90.0" : 0.3967555403689744,
+                "95.0" : 0.3967555403689744,
+                "99.0" : 0.3967555403689744,
+                "99.9" : 0.3967555403689744,
+                "99.99" : 0.3967555403689744,
+                "99.999" : 0.3967555403689744,
+                "99.9999" : 0.3967555403689744,
+                "100.0" : 0.3967555403689744
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3967555403689744,
+                    0.39520993463484033,
+                    0.3936467812942844
+                ],
+                [
+                    0.3909861795753998,
+                    0.383473000306772,
+                    0.37774037984437564
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16305423639014496,
+            "scoreError" : 0.011039475958628206,
+            "scoreConfidence" : [
+                0.15201476043151677,
+                0.17409371234877316
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15581064871770903,
+                "50.0" : 0.16472685769751927,
+                "90.0" : 0.16667953512675635,
+                "95.0" : 0.16667953512675635,
+                "99.0" : 0.16667953512675635,
+                "99.9" : 0.16667953512675635,
+                "99.99" : 0.16667953512675635,
+                "99.999" : 0.16667953512675635,
+                "99.9999" : 0.16667953512675635,
+                "100.0" : 0.16667953512675635
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16667953512675635,
+                    0.1648181841975146,
+                    0.16495565117775138
+                ],
+                [
+                    0.16463553119752394,
+                    0.16142586792361457,
+                    0.15581064871770903
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40386491647370315,
+            "scoreError" : 0.014208942402313393,
+            "scoreConfidence" : [
+                0.38965597407138974,
+                0.41807385887601656
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39860644036989795,
+                "50.0" : 0.40345100799343636,
+                "90.0" : 0.4114478966467805,
+                "95.0" : 0.4114478966467805,
+                "99.0" : 0.4114478966467805,
+                "99.9" : 0.4114478966467805,
+                "99.99" : 0.4114478966467805,
+                "99.999" : 0.4114478966467805,
+                "99.9999" : 0.4114478966467805,
+                "100.0" : 0.4114478966467805
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4018982683358116,
+                    0.39860644036989795,
+                    0.3988190779661017
+                ],
+                [
+                    0.4114478966467805,
+                    0.4074140678725658,
+                    0.40500374765106106
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14732520029938725,
+            "scoreError" : 0.002892223938849004,
+            "scoreConfidence" : [
+                0.14443297636053826,
+                0.15021742423823625
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14609618583178716,
+                "50.0" : 0.14762102640641603,
+                "90.0" : 0.14830718813863472,
+                "95.0" : 0.14830718813863472,
+                "99.0" : 0.14830718813863472,
+                "99.9" : 0.14830718813863472,
+                "99.99" : 0.14830718813863472,
+                "99.999" : 0.14830718813863472,
+                "99.9999" : 0.14830718813863472,
+                "100.0" : 0.14830718813863472
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14711549903641044,
+                    0.1461285400824152,
+                    0.14609618583178716
+                ],
+                [
+                    0.14812655377642162,
+                    0.14830718813863472,
+                    0.14817723493065435
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04228522113552948,
+            "scoreError" : 5.661857222361192E-4,
+            "scoreConfidence" : [
+                0.04171903541329336,
+                0.0428514068577656
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.042077059597243144,
+                "50.0" : 0.04229963969416038,
+                "90.0" : 0.04248010828858832,
+                "95.0" : 0.04248010828858832,
+                "99.0" : 0.04248010828858832,
+                "99.9" : 0.04248010828858832,
+                "99.99" : 0.04248010828858832,
+                "99.999" : 0.04248010828858832,
+                "99.9999" : 0.04248010828858832,
+                "100.0" : 0.04248010828858832
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04246247156960574,
+                    0.04246312121340796,
+                    0.04248010828858832
+                ],
+                [
+                    0.042136807818715025,
+                    0.042077059597243144,
+                    0.04209175832561664
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7712222.8230571225,
+            "scoreError" : 340626.1401297226,
+            "scoreConfidence" : [
+                7371596.6829274,
+                8052848.963186845
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7573608.292959879,
+                "50.0" : 7721332.148981294,
+                "90.0" : 7848369.9215686275,
+                "95.0" : 7848369.9215686275,
+                "99.0" : 7848369.9215686275,
+                "99.9" : 7848369.9215686275,
+                "99.99" : 7848369.9215686275,
+                "99.999" : 7848369.9215686275,
+                "99.9999" : 7848369.9215686275,
+                "100.0" : 7848369.9215686275
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7636073.0106870225,
+                    7601397.670972644,
+                    7573608.292959879
+                ],
+                [
+                    7806591.287275566,
+                    7807296.754879001,
+                    7848369.9215686275
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-05T12-37-32Z-0b8d2ae656823aaf90cf56b255573c2c1f1ef3b8-jdk17.json
+++ b/performance-results/2026-03-05T12-37-32Z-0b8d2ae656823aaf90cf56b255573c2c1f1ef3b8-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3787541659577203,
+            "scoreError" : 0.025694818624276652,
+            "scoreConfidence" : [
+                3.353059347333444,
+                3.4044489845819967
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3754060083911277,
+                "50.0" : 3.377702429309048,
+                "90.0" : 3.384205796821657,
+                "95.0" : 3.384205796821657,
+                "99.0" : 3.384205796821657,
+                "99.9" : 3.384205796821657,
+                "99.99" : 3.384205796821657,
+                "99.999" : 3.384205796821657,
+                "99.9999" : 3.384205796821657,
+                "100.0" : 3.384205796821657
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3754060083911277,
+                    3.3762378157586186
+                ],
+                [
+                    3.3791670428594776,
+                    3.384205796821657
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7028014779332556,
+            "scoreError" : 0.01990126995155184,
+            "scoreConfidence" : [
+                1.6829002079817037,
+                1.7227027478848076
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6986392370935568,
+                "50.0" : 1.7035149589387353,
+                "90.0" : 1.7055367567619952,
+                "95.0" : 1.7055367567619952,
+                "99.0" : 1.7055367567619952,
+                "99.9" : 1.7055367567619952,
+                "99.99" : 1.7055367567619952,
+                "99.999" : 1.7055367567619952,
+                "99.9999" : 1.7055367567619952,
+                "100.0" : 1.7055367567619952
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6986392370935568,
+                    1.7046617701073663
+                ],
+                [
+                    1.702368147770104,
+                    1.7055367567619952
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8589138317947154,
+            "scoreError" : 0.008132710840953006,
+            "scoreConfidence" : [
+                0.8507811209537623,
+                0.8670465426356684
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8578300204101409,
+                "50.0" : 0.858571391988503,
+                "90.0" : 0.860682522791715,
+                "95.0" : 0.860682522791715,
+                "99.0" : 0.860682522791715,
+                "99.9" : 0.860682522791715,
+                "99.99" : 0.860682522791715,
+                "99.999" : 0.860682522791715,
+                "99.9999" : 0.860682522791715,
+                "100.0" : 0.860682522791715
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8578300204101409,
+                    0.860682522791715
+                ],
+                [
+                    0.8582440014433265,
+                    0.8588987825336794
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.31725568958695,
+            "scoreError" : 0.09787957732076744,
+            "scoreConfidence" : [
+                16.219376112266183,
+                16.41513526690772
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.25438370941773,
+                "50.0" : 16.328676769047675,
+                "90.0" : 16.34581097704186,
+                "95.0" : 16.34581097704186,
+                "99.0" : 16.34581097704186,
+                "99.9" : 16.34581097704186,
+                "99.99" : 16.34581097704186,
+                "99.999" : 16.34581097704186,
+                "99.9999" : 16.34581097704186,
+                "100.0" : 16.34581097704186
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.34486602978073,
+                    16.30111988318604,
+                    16.25438370941773
+                ],
+                [
+                    16.324212589877362,
+                    16.34581097704186,
+                    16.33314094821799
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2743.0600678230803,
+            "scoreError" : 18.743290284618272,
+            "scoreConfidence" : [
+                2724.3167775384622,
+                2761.8033581076984
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2735.49093569293,
+                "50.0" : 2743.750738671018,
+                "90.0" : 2749.993028788905,
+                "95.0" : 2749.993028788905,
+                "99.0" : 2749.993028788905,
+                "99.9" : 2749.993028788905,
+                "99.99" : 2749.993028788905,
+                "99.999" : 2749.993028788905,
+                "99.9999" : 2749.993028788905,
+                "100.0" : 2749.993028788905
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2735.49093569293,
+                    2736.3880111367994,
+                    2739.424901757458
+                ],
+                [
+                    2749.993028788905,
+                    2748.9869539778115,
+                    2748.076575584578
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73658.67158938335,
+            "scoreError" : 235.23179025069066,
+            "scoreConfidence" : [
+                73423.43979913266,
+                73893.90337963404
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73538.3330565916,
+                "50.0" : 73685.4141381442,
+                "90.0" : 73744.13699301644,
+                "95.0" : 73744.13699301644,
+                "99.0" : 73744.13699301644,
+                "99.9" : 73744.13699301644,
+                "99.99" : 73744.13699301644,
+                "99.999" : 73744.13699301644,
+                "99.9999" : 73744.13699301644,
+                "100.0" : 73744.13699301644
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73538.3330565916,
+                    73573.75915638955,
+                    73671.95416998358
+                ],
+                [
+                    73698.87410630482,
+                    73744.13699301644,
+                    73724.97205401411
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 359.9215039048331,
+            "scoreError" : 4.245304225800666,
+            "scoreConfidence" : [
+                355.67619967903244,
+                364.1668081306338
+            ],
+            "scorePercentiles" : {
+                "0.0" : 358.34475628233037,
+                "50.0" : 360.0583472260397,
+                "90.0" : 361.4450922977169,
+                "95.0" : 361.4450922977169,
+                "99.0" : 361.4450922977169,
+                "99.9" : 361.4450922977169,
+                "99.99" : 361.4450922977169,
+                "99.999" : 361.4450922977169,
+                "99.9999" : 361.4450922977169,
+                "100.0" : 361.4450922977169
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    358.92800449800336,
+                    358.3908279902519,
+                    358.34475628233037
+                ],
+                [
+                    361.188689954076,
+                    361.23165240661996,
+                    361.4450922977169
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 127.00046697829903,
+            "scoreError" : 2.783601654541683,
+            "scoreConfidence" : [
+                124.21686532375735,
+                129.7840686328407
+            ],
+            "scorePercentiles" : {
+                "0.0" : 125.9327158248399,
+                "50.0" : 126.93434176756242,
+                "90.0" : 128.43665968884855,
+                "95.0" : 128.43665968884855,
+                "99.0" : 128.43665968884855,
+                "99.9" : 128.43665968884855,
+                "99.99" : 128.43665968884855,
+                "99.999" : 128.43665968884855,
+                "99.9999" : 128.43665968884855,
+                "100.0" : 128.43665968884855
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    125.9327158248399,
+                    126.31137611128563,
+                    126.20734977101078
+                ],
+                [
+                    127.5573074238392,
+                    127.55739304997014,
+                    128.43665968884855
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06066012396297027,
+            "scoreError" : 0.0012370305744918524,
+            "scoreConfidence" : [
+                0.05942309338847842,
+                0.06189715453746212
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06018711377602302,
+                "50.0" : 0.060706402057915346,
+                "90.0" : 0.06108253005204134,
+                "95.0" : 0.06108253005204134,
+                "99.0" : 0.06108253005204134,
+                "99.9" : 0.06108253005204134,
+                "99.99" : 0.06108253005204134,
+                "99.999" : 0.06108253005204134,
+                "99.9999" : 0.06108253005204134,
+                "100.0" : 0.06108253005204134
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06108253005204134,
+                    0.06107974089773581,
+                    0.061004257849626355
+                ],
+                [
+                    0.0601985549361907,
+                    0.060408546266204344,
+                    0.06018711377602302
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.590630405993531E-4,
+            "scoreError" : 1.1815278771285637E-5,
+            "scoreConfidence" : [
+                3.4724776182806745E-4,
+                3.7087831937063876E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5505772440249007E-4,
+                "50.0" : 3.590132812043437E-4,
+                "90.0" : 3.630893546477859E-4,
+                "95.0" : 3.630893546477859E-4,
+                "99.0" : 3.630893546477859E-4,
+                "99.9" : 3.630893546477859E-4,
+                "99.99" : 3.630893546477859E-4,
+                "99.999" : 3.630893546477859E-4,
+                "99.9999" : 3.630893546477859E-4,
+                "100.0" : 3.630893546477859E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.630893546477859E-4,
+                    3.625434894112974E-4,
+                    3.630758976531317E-4
+                ],
+                [
+                    3.551287044840237E-4,
+                    3.5548307299738995E-4,
+                    3.5505772440249007E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.114955410894848,
+            "scoreError" : 0.053208532851904376,
+            "scoreConfidence" : [
+                2.0617468780429435,
+                2.1681639437467526
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.0740675613853172,
+                "50.0" : 2.110124494534846,
+                "90.0" : 2.167416411055245,
+                "95.0" : 2.167567978543563,
+                "99.0" : 2.167567978543563,
+                "99.9" : 2.167567978543563,
+                "99.99" : 2.167567978543563,
+                "99.999" : 2.167567978543563,
+                "99.9999" : 2.167567978543563,
+                "100.0" : 2.167567978543563
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.1660523036603854,
+                    2.167567978543563,
+                    2.110283190335514,
+                    2.1099657987341773,
+                    2.108633560404807
+                ],
+                [
+                    2.140247323132891,
+                    2.123938697175621,
+                    2.074645068450529,
+                    2.074152627125674,
+                    2.0740675613853172
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013786500475902344,
+            "scoreError" : 7.656075360321748E-4,
+            "scoreConfidence" : [
+                0.013020892939870169,
+                0.014552108011934519
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013534248927421996,
+                "50.0" : 0.013784090303675101,
+                "90.0" : 0.014046370853559871,
+                "95.0" : 0.014046370853559871,
+                "99.0" : 0.014046370853559871,
+                "99.9" : 0.014046370853559871,
+                "99.99" : 0.014046370853559871,
+                "99.999" : 0.014046370853559871,
+                "99.9999" : 0.014046370853559871,
+                "100.0" : 0.014046370853559871
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013534248927421996,
+                    0.013539970557691084,
+                    0.013537775574908317
+                ],
+                [
+                    0.01402821004965912,
+                    0.014032426892173674,
+                    0.014046370853559871
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0045113521301223,
+            "scoreError" : 0.02552461861533763,
+            "scoreConfidence" : [
+                0.9789867335147847,
+                1.03003597074546
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9955061420465857,
+                "50.0" : 1.0041551128299813,
+                "90.0" : 1.0140109731291826,
+                "95.0" : 1.0140109731291826,
+                "99.0" : 1.0140109731291826,
+                "99.9" : 1.0140109731291826,
+                "99.99" : 1.0140109731291826,
+                "99.999" : 1.0140109731291826,
+                "99.9999" : 1.0140109731291826,
+                "100.0" : 1.0140109731291826
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.9965953287493772,
+                    0.9955061420465857,
+                    0.9966104356751371
+                ],
+                [
+                    1.0140109731291826,
+                    1.0116997899848255,
+                    1.0126454431956258
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010328985363969428,
+            "scoreError" : 4.8407439926211575E-4,
+            "scoreConfidence" : [
+                0.009844910964707312,
+                0.010813059763231544
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010168271822132563,
+                "50.0" : 0.010329480323800686,
+                "90.0" : 0.01049058901000235,
+                "95.0" : 0.01049058901000235,
+                "99.0" : 0.01049058901000235,
+                "99.9" : 0.01049058901000235,
+                "99.99" : 0.01049058901000235,
+                "99.999" : 0.01049058901000235,
+                "99.9999" : 0.01049058901000235,
+                "100.0" : 0.01049058901000235
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010168271822132563,
+                    0.010177057027890117,
+                    0.010169008535657777
+                ],
+                [
+                    0.01048708216842251,
+                    0.010481903619711254,
+                    0.01049058901000235
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.111578777438081,
+            "scoreError" : 0.03202084608624682,
+            "scoreConfidence" : [
+                3.079557931351834,
+                3.143599623524328
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0977134055727555,
+                "50.0" : 3.109862903005422,
+                "90.0" : 3.128717082551595,
+                "95.0" : 3.128717082551595,
+                "99.0" : 3.128717082551595,
+                "99.9" : 3.128717082551595,
+                "99.99" : 3.128717082551595,
+                "99.999" : 3.128717082551595,
+                "99.9999" : 3.128717082551595,
+                "100.0" : 3.128717082551595
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.128717082551595,
+                    3.11974313724267,
+                    3.113694169364882
+                ],
+                [
+                    3.106031636645963,
+                    3.0977134055727555,
+                    3.1035732332506205
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.730341221398518,
+            "scoreError" : 0.11974921534507287,
+            "scoreConfidence" : [
+                2.610592006053445,
+                2.850090436743591
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.689776746100054,
+                "50.0" : 2.7305678972323326,
+                "90.0" : 2.7707557,
+                "95.0" : 2.7707557,
+                "99.0" : 2.7707557,
+                "99.9" : 2.7707557,
+                "99.99" : 2.7707557,
+                "99.999" : 2.7707557,
+                "99.9999" : 2.7707557,
+                "100.0" : 2.7707557
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7707557,
+                    2.766769732503458,
+                    2.7703015049861497
+                ],
+                [
+                    2.689776746100054,
+                    2.6900775828402366,
+                    2.694366061961207
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17953882095721052,
+            "scoreError" : 0.002465713434828934,
+            "scoreConfidence" : [
+                0.1770731075223816,
+                0.18200453439203945
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17868538553764785,
+                "50.0" : 0.17940513482459475,
+                "90.0" : 0.18122131753193801,
+                "95.0" : 0.18122131753193801,
+                "99.0" : 0.18122131753193801,
+                "99.9" : 0.18122131753193801,
+                "99.99" : 0.18122131753193801,
+                "99.999" : 0.18122131753193801,
+                "99.9999" : 0.18122131753193801,
+                "100.0" : 0.18122131753193801
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1794954655466408,
+                    0.17939139590284506,
+                    0.17941887374634444
+                ],
+                [
+                    0.18122131753193801,
+                    0.1790204874778468,
+                    0.17868538553764785
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.379670557739547,
+            "scoreError" : 0.004344763007926486,
+            "scoreConfidence" : [
+                0.37532579473162053,
+                0.38401532074747347
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.37765543293051357,
+                "50.0" : 0.38022386783406625,
+                "90.0" : 0.38120092178089504,
+                "95.0" : 0.38120092178089504,
+                "99.0" : 0.38120092178089504,
+                "99.9" : 0.38120092178089504,
+                "99.99" : 0.38120092178089504,
+                "99.999" : 0.38120092178089504,
+                "99.9999" : 0.38120092178089504,
+                "100.0" : 0.38120092178089504
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3796645733485194,
+                    0.3779158590431562,
+                    0.37765543293051357
+                ],
+                [
+                    0.3807831623196131,
+                    0.38120092178089504,
+                    0.3808033970145844
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15675150438499263,
+            "scoreError" : 0.0032352168330599773,
+            "scoreConfidence" : [
+                0.15351628755193267,
+                0.1599867212180526
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1556778305649392,
+                "50.0" : 0.15642954837591358,
+                "90.0" : 0.15869279389361432,
+                "95.0" : 0.15869279389361432,
+                "99.0" : 0.15869279389361432,
+                "99.9" : 0.15869279389361432,
+                "99.99" : 0.15869279389361432,
+                "99.999" : 0.15869279389361432,
+                "99.9999" : 0.15869279389361432,
+                "100.0" : 0.15869279389361432
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1573594200878035,
+                    0.15869279389361432,
+                    0.15691192989283081
+                ],
+                [
+                    0.15594716685899634,
+                    0.15591988501177168,
+                    0.1556778305649392
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.405657893449259,
+            "scoreError" : 0.0058299541718155315,
+            "scoreConfidence" : [
+                0.3998279392774435,
+                0.41148784762107454
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4024355259959759,
+                "50.0" : 0.40556880178643245,
+                "90.0" : 0.4081371437025549,
+                "95.0" : 0.4081371437025549,
+                "99.0" : 0.4081371437025549,
+                "99.9" : 0.4081371437025549,
+                "99.99" : 0.4081371437025549,
+                "99.999" : 0.4081371437025549,
+                "99.9999" : 0.4081371437025549,
+                "100.0" : 0.4081371437025549
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4081371437025549,
+                    0.4049656908560784,
+                    0.4047197077583067
+                ],
+                [
+                    0.40751737966585166,
+                    0.4061719127167865,
+                    0.4024355259959759
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14831947064597426,
+            "scoreError" : 0.018919415412754857,
+            "scoreConfidence" : [
+                0.1294000552332194,
+                0.1672388860587291
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14246219800555596,
+                "50.0" : 0.1459206967814798,
+                "90.0" : 0.15665175129233372,
+                "95.0" : 0.15665175129233372,
+                "99.0" : 0.15665175129233372,
+                "99.9" : 0.15665175129233372,
+                "99.99" : 0.15665175129233372,
+                "99.999" : 0.15665175129233372,
+                "99.9999" : 0.15665175129233372,
+                "100.0" : 0.15665175129233372
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1484991708294972,
+                    0.1564220196618229,
+                    0.15665175129233372
+                ],
+                [
+                    0.14334222273346234,
+                    0.1425394613531734,
+                    0.14246219800555596
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.043754769245308744,
+            "scoreError" : 0.0022198135132841385,
+            "scoreConfidence" : [
+                0.041534955732024606,
+                0.04597458275859288
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04285406554447554,
+                "50.0" : 0.043848057633628174,
+                "90.0" : 0.044482659797162045,
+                "95.0" : 0.044482659797162045,
+                "99.0" : 0.044482659797162045,
+                "99.9" : 0.044482659797162045,
+                "99.99" : 0.044482659797162045,
+                "99.999" : 0.044482659797162045,
+                "99.9999" : 0.044482659797162045,
+                "100.0" : 0.044482659797162045
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04325324959342561,
+                    0.04301746902571118,
+                    0.04285406554447554
+                ],
+                [
+                    0.04444286567383073,
+                    0.044482659797162045,
+                    0.044478305837247364
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7822183.322835714,
+            "scoreError" : 108171.72356993645,
+            "scoreConfidence" : [
+                7714011.5992657775,
+                7930355.04640565
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7789362.835669782,
+                "50.0" : 7803024.420046803,
+                "90.0" : 7872305.723839496,
+                "95.0" : 7872305.723839496,
+                "99.0" : 7872305.723839496,
+                "99.9" : 7872305.723839496,
+                "99.99" : 7872305.723839496,
+                "99.999" : 7872305.723839496,
+                "99.9999" : 7872305.723839496,
+                "100.0" : 7872305.723839496
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7800534.334633386,
+                    7794721.662509743,
+                    7789362.835669782
+                ],
+                [
+                    7805514.5054602185,
+                    7872305.723839496,
+                    7870660.874901652
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-06T20-35-15Z-ec31e0b578ed9066068cd6a88b1627cfc609e231-jdk17.json
+++ b/performance-results/2026-03-06T20-35-15Z-ec31e0b578ed9066068cd6a88b1627cfc609e231-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.371102673634682,
+            "scoreError" : 0.04333930051056839,
+            "scoreConfidence" : [
+                3.3277633731241134,
+                3.4144419741452503
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.362352168111208,
+                "50.0" : 3.3718026888086152,
+                "90.0" : 3.378453148810288,
+                "95.0" : 3.378453148810288,
+                "99.0" : 3.378453148810288,
+                "99.9" : 3.378453148810288,
+                "99.99" : 3.378453148810288,
+                "99.999" : 3.378453148810288,
+                "99.9999" : 3.378453148810288,
+                "100.0" : 3.378453148810288
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3705059979713092,
+                    3.378453148810288
+                ],
+                [
+                    3.362352168111208,
+                    3.3730993796459217
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7009091766137656,
+            "scoreError" : 0.025993420619223294,
+            "scoreConfidence" : [
+                1.6749157559945422,
+                1.726902597232989
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6969448222389858,
+                "50.0" : 1.7002613951026708,
+                "90.0" : 1.7061690940107352,
+                "95.0" : 1.7061690940107352,
+                "99.0" : 1.7061690940107352,
+                "99.9" : 1.7061690940107352,
+                "99.99" : 1.7061690940107352,
+                "99.999" : 1.7061690940107352,
+                "99.9999" : 1.7061690940107352,
+                "100.0" : 1.7061690940107352
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7017310373227494,
+                    1.7061690940107352
+                ],
+                [
+                    1.6987917528825924,
+                    1.6969448222389858
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8549650973262872,
+            "scoreError" : 0.033622698018498876,
+            "scoreConfidence" : [
+                0.8213423993077884,
+                0.888587795344786
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.851258996307247,
+                "50.0" : 0.8530297055550864,
+                "90.0" : 0.8625419818877293,
+                "95.0" : 0.8625419818877293,
+                "99.0" : 0.8625419818877293,
+                "99.9" : 0.8625419818877293,
+                "99.99" : 0.8625419818877293,
+                "99.999" : 0.8625419818877293,
+                "99.9999" : 0.8625419818877293,
+                "100.0" : 0.8625419818877293
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.851258996307247,
+                    0.8518933837472328
+                ],
+                [
+                    0.8541660273629399,
+                    0.8625419818877293
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.434125595823406,
+            "scoreError" : 0.3007461366156466,
+            "scoreConfidence" : [
+                16.13337945920776,
+                16.734871732439053
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.332760494766827,
+                "50.0" : 16.431993799806314,
+                "90.0" : 16.5405453599498,
+                "95.0" : 16.5405453599498,
+                "99.0" : 16.5405453599498,
+                "99.9" : 16.5405453599498,
+                "99.99" : 16.5405453599498,
+                "99.999" : 16.5405453599498,
+                "99.9999" : 16.5405453599498,
+                "100.0" : 16.5405453599498
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.335033471059873,
+                    16.332760494766827,
+                    16.341384137386008
+                ],
+                [
+                    16.53242664955129,
+                    16.5405453599498,
+                    16.522603462226623
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2839.874973294129,
+            "scoreError" : 168.0384309609412,
+            "scoreConfidence" : [
+                2671.836542333188,
+                3007.9134042550704
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2782.704956464049,
+                "50.0" : 2841.5332045474597,
+                "90.0" : 2894.9175163423183,
+                "95.0" : 2894.9175163423183,
+                "99.0" : 2894.9175163423183,
+                "99.9" : 2894.9175163423183,
+                "99.99" : 2894.9175163423183,
+                "99.999" : 2894.9175163423183,
+                "99.9999" : 2894.9175163423183,
+                "100.0" : 2894.9175163423183
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2782.704956464049,
+                    2784.1032991416055,
+                    2788.801991331866
+                ],
+                [
+                    2894.2644177630536,
+                    2894.457658721883,
+                    2894.9175163423183
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74632.20458235241,
+            "scoreError" : 1244.25627483343,
+            "scoreConfidence" : [
+                73387.94830751898,
+                75876.46085718584
+            ],
+            "scorePercentiles" : {
+                "0.0" : 74197.25361533301,
+                "50.0" : 74643.76396201643,
+                "90.0" : 75068.38539071674,
+                "95.0" : 75068.38539071674,
+                "99.0" : 75068.38539071674,
+                "99.9" : 75068.38539071674,
+                "99.99" : 75068.38539071674,
+                "99.999" : 75068.38539071674,
+                "99.9999" : 75068.38539071674,
+                "100.0" : 75068.38539071674
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    75028.95073371532,
+                    75011.17244445204,
+                    75068.38539071674
+                ],
+                [
+                    74211.10983031648,
+                    74197.25361533301,
+                    74276.35547958082
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 360.2407205713967,
+            "scoreError" : 7.799367219296496,
+            "scoreConfidence" : [
+                352.44135335210024,
+                368.0400877906932
+            ],
+            "scorePercentiles" : {
+                "0.0" : 357.282424348612,
+                "50.0" : 360.13924953643823,
+                "90.0" : 363.0745087928898,
+                "95.0" : 363.0745087928898,
+                "99.0" : 363.0745087928898,
+                "99.9" : 363.0745087928898,
+                "99.99" : 363.0745087928898,
+                "99.999" : 363.0745087928898,
+                "99.9999" : 363.0745087928898,
+                "100.0" : 363.0745087928898
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    362.25835228023925,
+                    362.9383851117624,
+                    363.0745087928898
+                ],
+                [
+                    357.282424348612,
+                    357.8705061022396,
+                    358.0201467926372
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 126.54026170317015,
+            "scoreError" : 7.099185429896253,
+            "scoreConfidence" : [
+                119.4410762732739,
+                133.6394471330664
+            ],
+            "scorePercentiles" : {
+                "0.0" : 123.73267654338876,
+                "50.0" : 126.89463574469957,
+                "90.0" : 129.10684011916155,
+                "95.0" : 129.10684011916155,
+                "99.0" : 129.10684011916155,
+                "99.9" : 129.10684011916155,
+                "99.99" : 129.10684011916155,
+                "99.999" : 129.10684011916155,
+                "99.9999" : 129.10684011916155,
+                "100.0" : 129.10684011916155
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    125.14954340852417,
+                    123.73267654338876,
+                    123.9479120798484
+                ],
+                [
+                    129.10684011916155,
+                    128.639728080875,
+                    128.66486998722303
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06096465541210897,
+            "scoreError" : 5.384267799050281E-4,
+            "scoreConfidence" : [
+                0.06042622863220394,
+                0.061503082192014
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.060688722742113635,
+                "50.0" : 0.06100386871364233,
+                "90.0" : 0.06113239411056296,
+                "95.0" : 0.06113239411056296,
+                "99.0" : 0.06113239411056296,
+                "99.9" : 0.06113239411056296,
+                "99.99" : 0.06113239411056296,
+                "99.999" : 0.06113239411056296,
+                "99.9999" : 0.06113239411056296,
+                "100.0" : 0.06113239411056296
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06112680685464893,
+                    0.06113171432850602,
+                    0.06113239411056296
+                ],
+                [
+                    0.060688722742113635,
+                    0.06088093057263573,
+                    0.060827363864186565
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.626254887971702E-4,
+            "scoreError" : 4.1221638145355525E-5,
+            "scoreConfidence" : [
+                3.2140385065181467E-4,
+                4.0384712694252576E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.490411057351661E-4,
+                "50.0" : 3.626403072353203E-4,
+                "90.0" : 3.7613495360726794E-4,
+                "95.0" : 3.7613495360726794E-4,
+                "99.0" : 3.7613495360726794E-4,
+                "99.9" : 3.7613495360726794E-4,
+                "99.99" : 3.7613495360726794E-4,
+                "99.999" : 3.7613495360726794E-4,
+                "99.9999" : 3.7613495360726794E-4,
+                "100.0" : 3.7613495360726794E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.7613495360726794E-4,
+                    3.7593260931446156E-4,
+                    3.76065314961875E-4
+                ],
+                [
+                    3.49348005156179E-4,
+                    3.490411057351661E-4,
+                    3.4923094400807187E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.159387029211144,
+            "scoreError" : 0.054775691424238604,
+            "scoreConfidence" : [
+                2.1046113377869053,
+                2.2141627206353824
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.113339231403212,
+                "50.0" : 2.163625629756414,
+                "90.0" : 2.218813151295289,
+                "95.0" : 2.2220478495889804,
+                "99.0" : 2.2220478495889804,
+                "99.9" : 2.2220478495889804,
+                "99.99" : 2.2220478495889804,
+                "99.999" : 2.2220478495889804,
+                "99.9999" : 2.2220478495889804,
+                "100.0" : 2.2220478495889804
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.1798738034001746,
+                    2.1737584227341884,
+                    2.1180493752647185,
+                    2.1146131786469344,
+                    2.113339231403212
+                ],
+                [
+                    2.2220478495889804,
+                    2.189700866652069,
+                    2.1790157579520697,
+                    2.149978969690456,
+                    2.1534928367786392
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013797140805444854,
+            "scoreError" : 7.482017908253753E-4,
+            "scoreConfidence" : [
+                0.013048939014619478,
+                0.01454534259627023
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013545807509702064,
+                "50.0" : 0.01379265967296717,
+                "90.0" : 0.014048627501499671,
+                "95.0" : 0.014048627501499671,
+                "99.0" : 0.014048627501499671,
+                "99.9" : 0.014048627501499671,
+                "99.99" : 0.014048627501499671,
+                "99.999" : 0.014048627501499671,
+                "99.9999" : 0.014048627501499671,
+                "100.0" : 0.014048627501499671
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013557155427215726,
+                    0.013558130253872487,
+                    0.013545807509702064
+                ],
+                [
+                    0.014045935048317321,
+                    0.014048627501499671,
+                    0.014027189092061854
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0791461827155764,
+            "scoreError" : 0.12134062639219405,
+            "scoreConfidence" : [
+                0.9578055563233824,
+                1.2004868091077705
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0389110095574485,
+                "50.0" : 1.0793449910935096,
+                "90.0" : 1.1186736722595079,
+                "95.0" : 1.1186736722595079,
+                "99.0" : 1.1186736722595079,
+                "99.9" : 1.1186736722595079,
+                "99.99" : 1.1186736722595079,
+                "99.999" : 1.1186736722595079,
+                "99.9999" : 1.1186736722595079,
+                "100.0" : 1.1186736722595079
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0389110095574485,
+                    1.0400942092563703,
+                    1.0399354126026827
+                ],
+                [
+                    1.1185957729306488,
+                    1.118667019686801,
+                    1.1186736722595079
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01021655966588624,
+            "scoreError" : 8.936106779817446E-5,
+            "scoreConfidence" : [
+                0.010127198598088066,
+                0.010305920733684415
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010183116388097454,
+                "50.0" : 0.010217106120366422,
+                "90.0" : 0.01025493800235037,
+                "95.0" : 0.01025493800235037,
+                "99.0" : 0.01025493800235037,
+                "99.9" : 0.01025493800235037,
+                "99.99" : 0.01025493800235037,
+                "99.999" : 0.01025493800235037,
+                "99.9999" : 0.01025493800235037,
+                "100.0" : 0.01025493800235037
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010183116388097454,
+                    0.01019802206381742,
+                    0.01018405825539334
+                ],
+                [
+                    0.010236190176915424,
+                    0.01025493800235037,
+                    0.010243033108743436
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.990572469131692,
+            "scoreError" : 0.03781692598961958,
+            "scoreConfidence" : [
+                2.9527555431420724,
+                3.0283893951213114
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.97349266646849,
+                "50.0" : 2.991435736781935,
+                "90.0" : 3.0058021646634616,
+                "95.0" : 3.0058021646634616,
+                "99.0" : 3.0058021646634616,
+                "99.9" : 3.0058021646634616,
+                "99.99" : 3.0058021646634616,
+                "99.999" : 3.0058021646634616,
+                "99.9999" : 3.0058021646634616,
+                "100.0" : 3.0058021646634616
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.97349266646849,
+                    2.984256761933174,
+                    2.978778706372841
+                ],
+                [
+                    2.9986147116306956,
+                    3.0024898037214887,
+                    3.0058021646634616
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7298434653348784,
+            "scoreError" : 0.04341183074746325,
+            "scoreConfidence" : [
+                2.6864316345874153,
+                2.7732552960823416
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7149521294788275,
+                "50.0" : 2.7296943295710285,
+                "90.0" : 2.745197931100741,
+                "95.0" : 2.745197931100741,
+                "99.0" : 2.745197931100741,
+                "99.9" : 2.745197931100741,
+                "99.99" : 2.745197931100741,
+                "99.999" : 2.745197931100741,
+                "99.9999" : 2.745197931100741,
+                "100.0" : 2.745197931100741
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.745197931100741,
+                    2.743017693362589,
+                    2.743648532510288
+                ],
+                [
+                    2.7163709657794675,
+                    2.7158735397773555,
+                    2.7149521294788275
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17823520295776554,
+            "scoreError" : 0.003797382164395344,
+            "scoreConfidence" : [
+                0.1744378207933702,
+                0.1820325851221609
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17691545155241042,
+                "50.0" : 0.1782689903629942,
+                "90.0" : 0.179506476180219,
+                "95.0" : 0.179506476180219,
+                "99.0" : 0.179506476180219,
+                "99.9" : 0.179506476180219,
+                "99.99" : 0.179506476180219,
+                "99.999" : 0.179506476180219,
+                "99.9999" : 0.179506476180219,
+                "100.0" : 0.179506476180219
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1769976980831519,
+                    0.17708726296683253,
+                    0.17691545155241042
+                ],
+                [
+                    0.17945071775915591,
+                    0.179506476180219,
+                    0.1794536112048236
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3803643283420228,
+            "scoreError" : 9.444714956738467E-4,
+            "scoreConfidence" : [
+                0.37941985684634894,
+                0.3813087998376966
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3799503789513678,
+                "50.0" : 0.380313769049776,
+                "90.0" : 0.3808194387281036,
+                "95.0" : 0.3808194387281036,
+                "99.0" : 0.3808194387281036,
+                "99.9" : 0.3808194387281036,
+                "99.99" : 0.3808194387281036,
+                "99.999" : 0.3808194387281036,
+                "99.9999" : 0.3808194387281036,
+                "100.0" : 0.3808194387281036
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.38022857507319113,
+                    0.3806835227835091,
+                    0.3808194387281036
+                ],
+                [
+                    0.3801050914896043,
+                    0.3799503789513678,
+                    0.38039896302636084
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15898521915177835,
+            "scoreError" : 0.01808932212573613,
+            "scoreConfidence" : [
+                0.14089589702604222,
+                0.17707454127751449
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15300788417461023,
+                "50.0" : 0.15877062740602843,
+                "90.0" : 0.1652097313277494,
+                "95.0" : 0.1652097313277494,
+                "99.0" : 0.1652097313277494,
+                "99.9" : 0.1652097313277494,
+                "99.99" : 0.1652097313277494,
+                "99.999" : 0.1652097313277494,
+                "99.9999" : 0.1652097313277494,
+                "100.0" : 0.1652097313277494
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15309888877661937,
+                    0.1532016492837993,
+                    0.15300788417461023
+                ],
+                [
+                    0.16505355581963424,
+                    0.1652097313277494,
+                    0.16433960552825755
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4132514902775291,
+            "scoreError" : 0.0046810399161132145,
+            "scoreConfidence" : [
+                0.40857045036141587,
+                0.41793253019364235
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.41084669857442174,
+                "50.0" : 0.41351690428376164,
+                "90.0" : 0.41481946100879374,
+                "95.0" : 0.41481946100879374,
+                "99.0" : 0.41481946100879374,
+                "99.9" : 0.41481946100879374,
+                "99.99" : 0.41481946100879374,
+                "99.999" : 0.41481946100879374,
+                "99.9999" : 0.41481946100879374,
+                "100.0" : 0.41481946100879374
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41481946100879374,
+                    0.4146906046444122,
+                    0.41456462065248934
+                ],
+                [
+                    0.4121183688700239,
+                    0.412469187915034,
+                    0.41084669857442174
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14469884224383336,
+            "scoreError" : 4.423865327150245E-4,
+            "scoreConfidence" : [
+                0.14425645571111834,
+                0.1451412287765484
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14455587324187977,
+                "50.0" : 0.14467760478377722,
+                "90.0" : 0.14492945672463767,
+                "95.0" : 0.14492945672463767,
+                "99.0" : 0.14492945672463767,
+                "99.9" : 0.14492945672463767,
+                "99.99" : 0.14492945672463767,
+                "99.999" : 0.14492945672463767,
+                "99.9999" : 0.14492945672463767,
+                "100.0" : 0.14492945672463767
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14492945672463767,
+                    0.14478054331050658,
+                    0.144793946977485
+                ],
+                [
+                    0.14455587324187977,
+                    0.1445585669514434,
+                    0.14457466625704785
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04254810373033416,
+            "scoreError" : 4.607713551242798E-4,
+            "scoreConfidence" : [
+                0.042087332375209875,
+                0.04300887508545844
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0423597298169665,
+                "50.0" : 0.042565297309611796,
+                "90.0" : 0.042710449931237134,
+                "95.0" : 0.042710449931237134,
+                "99.0" : 0.042710449931237134,
+                "99.9" : 0.042710449931237134,
+                "99.99" : 0.042710449931237134,
+                "99.999" : 0.042710449931237134,
+                "99.9999" : 0.042710449931237134,
+                "100.0" : 0.042710449931237134
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.042710449931237134,
+                    0.042693794636872465,
+                    0.04268278840326092
+                ],
+                [
+                    0.042394053377705236,
+                    0.0423597298169665,
+                    0.04244780621596268
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8033997.172305193,
+            "scoreError" : 87564.03017134608,
+            "scoreConfidence" : [
+                7946433.142133847,
+                8121561.202476539
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7994801.417266187,
+                "50.0" : 8043477.222912908,
+                "90.0" : 8062573.165189363,
+                "95.0" : 8062573.165189363,
+                "99.0" : 8062573.165189363,
+                "99.9" : 8062573.165189363,
+                "99.99" : 8062573.165189363,
+                "99.999" : 8062573.165189363,
+                "99.9999" : 8062573.165189363,
+                "100.0" : 8062573.165189363
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8062422.094278808,
+                    8062573.165189363,
+                    8053044.684380032
+                ],
+                [
+                    7997231.9112709835,
+                    7994801.417266187,
+                    8033909.761445783
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-07T15-05-04Z-f679e89ae9d091240dbdb9cf995b3a8d1c1bdfe7-jdk17.json
+++ b/performance-results/2026-03-07T15-05-04Z-f679e89ae9d091240dbdb9cf995b3a8d1c1bdfe7-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3713108231031335,
+            "scoreError" : 0.03933975858993324,
+            "scoreConfidence" : [
+                3.3319710645132004,
+                3.4106505816930666
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.363131111861754,
+                "50.0" : 3.3722078247439917,
+                "90.0" : 3.3776965310627958,
+                "95.0" : 3.3776965310627958,
+                "99.0" : 3.3776965310627958,
+                "99.9" : 3.3776965310627958,
+                "99.99" : 3.3776965310627958,
+                "99.999" : 3.3776965310627958,
+                "99.9999" : 3.3776965310627958,
+                "100.0" : 3.3776965310627958
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.363131111861754,
+                    3.37123510669946
+                ],
+                [
+                    3.373180542788523,
+                    3.3776965310627958
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6955554656679186,
+            "scoreError" : 0.011042862935379054,
+            "scoreConfidence" : [
+                1.6845126027325394,
+                1.7065983286032977
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6945108104919486,
+                "50.0" : 1.694800854645974,
+                "90.0" : 1.698109342887777,
+                "95.0" : 1.698109342887777,
+                "99.0" : 1.698109342887777,
+                "99.9" : 1.698109342887777,
+                "99.99" : 1.698109342887777,
+                "99.999" : 1.698109342887777,
+                "99.9999" : 1.698109342887777,
+                "100.0" : 1.698109342887777
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6945108104919486,
+                    1.694866047358625
+                ],
+                [
+                    1.6947356619333231,
+                    1.698109342887777
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8557519298198919,
+            "scoreError" : 0.025940346224308335,
+            "scoreConfidence" : [
+                0.8298115835955836,
+                0.8816922760442002
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8521484638527282,
+                "50.0" : 0.8546934858854944,
+                "90.0" : 0.8614722836558502,
+                "95.0" : 0.8614722836558502,
+                "99.0" : 0.8614722836558502,
+                "99.9" : 0.8614722836558502,
+                "99.99" : 0.8614722836558502,
+                "99.999" : 0.8614722836558502,
+                "99.9999" : 0.8614722836558502,
+                "100.0" : 0.8614722836558502
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8542486678629864,
+                    0.8551383039080026
+                ],
+                [
+                    0.8521484638527282,
+                    0.8614722836558502
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.363246558475804,
+            "scoreError" : 0.24292658903005035,
+            "scoreConfidence" : [
+                16.120319969445752,
+                16.606173147505856
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.23289859181219,
+                "50.0" : 16.37785836851245,
+                "90.0" : 16.4443444976418,
+                "95.0" : 16.4443444976418,
+                "99.0" : 16.4443444976418,
+                "99.9" : 16.4443444976418,
+                "99.99" : 16.4443444976418,
+                "99.999" : 16.4443444976418,
+                "99.9999" : 16.4443444976418,
+                "100.0" : 16.4443444976418
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.3359906738827,
+                    16.30317789202567,
+                    16.23289859181219
+                ],
+                [
+                    16.4197260631422,
+                    16.4443444976418,
+                    16.44334163235027
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2649.8924582954974,
+            "scoreError" : 141.1110411390673,
+            "scoreConfidence" : [
+                2508.78141715643,
+                2791.0034994345647
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2603.562472711917,
+                "50.0" : 2649.18008213035,
+                "90.0" : 2698.9345834687697,
+                "95.0" : 2698.9345834687697,
+                "99.0" : 2698.9345834687697,
+                "99.9" : 2698.9345834687697,
+                "99.99" : 2698.9345834687697,
+                "99.999" : 2698.9345834687697,
+                "99.9999" : 2698.9345834687697,
+                "100.0" : 2698.9345834687697
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2603.562472711917,
+                    2603.7853940669766,
+                    2604.6042034792017
+                ],
+                [
+                    2693.7559607814983,
+                    2698.9345834687697,
+                    2694.7121352646186
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74053.00909624076,
+            "scoreError" : 474.91774001353696,
+            "scoreConfidence" : [
+                73578.09135622722,
+                74527.9268362543
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73878.41537064346,
+                "50.0" : 74058.8242138667,
+                "90.0" : 74227.13251613207,
+                "95.0" : 74227.13251613207,
+                "99.0" : 74227.13251613207,
+                "99.9" : 74227.13251613207,
+                "99.99" : 74227.13251613207,
+                "99.999" : 74227.13251613207,
+                "99.9999" : 74227.13251613207,
+                "100.0" : 74227.13251613207
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74195.71056310179,
+                    74227.13251613207,
+                    74197.44058668407
+                ],
+                [
+                    73878.41537064346,
+                    73921.93786463159,
+                    73897.41767625148
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 367.93805492164057,
+            "scoreError" : 30.24885263687533,
+            "scoreConfidence" : [
+                337.68920228476526,
+                398.1869075585159
+            ],
+            "scorePercentiles" : {
+                "0.0" : 357.68832072518285,
+                "50.0" : 367.7687975924211,
+                "90.0" : 379.27839603706684,
+                "95.0" : 379.27839603706684,
+                "99.0" : 379.27839603706684,
+                "99.9" : 379.27839603706684,
+                "99.99" : 379.27839603706684,
+                "99.999" : 379.27839603706684,
+                "99.9999" : 379.27839603706684,
+                "100.0" : 379.27839603706684
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    379.27839603706684,
+                    376.9564079316827,
+                    377.02180398125614
+                ],
+                [
+                    357.68832072518285,
+                    358.5811872531595,
+                    358.1022136014954
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 126.96522711874864,
+            "scoreError" : 0.9300581047944155,
+            "scoreConfidence" : [
+                126.03516901395423,
+                127.89528522354306
+            ],
+            "scorePercentiles" : {
+                "0.0" : 126.50572741325816,
+                "50.0" : 126.88818334810696,
+                "90.0" : 127.44697145628616,
+                "95.0" : 127.44697145628616,
+                "99.0" : 127.44697145628616,
+                "99.9" : 127.44697145628616,
+                "99.99" : 127.44697145628616,
+                "99.999" : 127.44697145628616,
+                "99.9999" : 127.44697145628616,
+                "100.0" : 127.44697145628616
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    127.23491205192498,
+                    127.44697145628616,
+                    126.92816953378801
+                ],
+                [
+                    126.82738509480862,
+                    126.84819716242592,
+                    126.50572741325816
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06076468212150141,
+            "scoreError" : 4.897018256486785E-4,
+            "scoreConfidence" : [
+                0.06027498029585273,
+                0.06125438394715008
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06059693782835536,
+                "50.0" : 0.06076381217593246,
+                "90.0" : 0.060936258585809346,
+                "95.0" : 0.060936258585809346,
+                "99.0" : 0.060936258585809346,
+                "99.9" : 0.060936258585809346,
+                "99.99" : 0.060936258585809346,
+                "99.999" : 0.060936258585809346,
+                "99.9999" : 0.060936258585809346,
+                "100.0" : 0.060936258585809346
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.060919106978160886,
+                    0.060916389304467536,
+                    0.060936258585809346
+                ],
+                [
+                    0.06060816498481791,
+                    0.06059693782835536,
+                    0.060611235047397384
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.639666939538463E-4,
+            "scoreError" : 4.527331590314624E-5,
+            "scoreConfidence" : [
+                3.1869337805070006E-4,
+                4.092400098569925E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.491149545573846E-4,
+                "50.0" : 3.639276614792352E-4,
+                "90.0" : 3.78852114135422E-4,
+                "95.0" : 3.78852114135422E-4,
+                "99.0" : 3.78852114135422E-4,
+                "99.9" : 3.78852114135422E-4,
+                "99.99" : 3.78852114135422E-4,
+                "99.999" : 3.78852114135422E-4,
+                "99.9999" : 3.78852114135422E-4,
+                "100.0" : 3.78852114135422E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.785153466280818E-4,
+                    3.78852114135422E-4,
+                    3.7874581707516696E-4
+                ],
+                [
+                    3.493399763303886E-4,
+                    3.492319549966338E-4,
+                    3.491149545573846E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.147247863627668,
+            "scoreError" : 0.04998158722956877,
+            "scoreConfidence" : [
+                2.0972662763980994,
+                2.197229450857237
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.114758163459505,
+                "50.0" : 2.1378949081650767,
+                "90.0" : 2.2079072674584403,
+                "95.0" : 2.210136578563536,
+                "99.0" : 2.210136578563536,
+                "99.9" : 2.210136578563536,
+                "99.99" : 2.210136578563536,
+                "99.999" : 2.210136578563536,
+                "99.9999" : 2.210136578563536,
+                "100.0" : 2.210136578563536
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.210136578563536,
+                    2.165477622780424,
+                    2.147931585266323,
+                    2.1271876826882177,
+                    2.1278582310638297
+                ],
+                [
+                    2.1878434675125793,
+                    2.1589251092164905,
+                    2.116226351248413,
+                    2.116133844477359,
+                    2.114758163459505
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.01364610313901852,
+            "scoreError" : 6.112518337074264E-4,
+            "scoreConfidence" : [
+                0.013034851305311094,
+                0.014257354972725947
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013445508138334204,
+                "50.0" : 0.013633713068527394,
+                "90.0" : 0.013881980639089133,
+                "95.0" : 0.013881980639089133,
+                "99.0" : 0.013881980639089133,
+                "99.9" : 0.013881980639089133,
+                "99.99" : 0.013881980639089133,
+                "99.999" : 0.013881980639089133,
+                "99.9999" : 0.013881980639089133,
+                "100.0" : 0.013881980639089133
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013445508138334204,
+                    0.013448000138512724,
+                    0.013450750910602261
+                ],
+                [
+                    0.013816675226452529,
+                    0.013881980639089133,
+                    0.013833703781120267
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0148176184636615,
+            "scoreError" : 0.14828789346769114,
+            "scoreConfidence" : [
+                0.8665297249959704,
+                1.1631055119313527
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9647115629944047,
+                "50.0" : 1.0164445628192804,
+                "90.0" : 1.0639057352127659,
+                "95.0" : 1.0639057352127659,
+                "99.0" : 1.0639057352127659,
+                "99.9" : 1.0639057352127659,
+                "99.99" : 1.0639057352127659,
+                "99.999" : 1.0639057352127659,
+                "99.9999" : 1.0639057352127659,
+                "100.0" : 1.0639057352127659
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.9647115629944047,
+                    0.9702869739012322,
+                    0.9647463818251978
+                ],
+                [
+                    1.0639057352127659,
+                    1.0626529051110403,
+                    1.0626021517373287
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010573206345188685,
+            "scoreError" : 5.602223176117819E-4,
+            "scoreConfidence" : [
+                0.010012984027576903,
+                0.011133428662800466
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010389359581775831,
+                "50.0" : 0.0105733397312733,
+                "90.0" : 0.01075881415694991,
+                "95.0" : 0.01075881415694991,
+                "99.0" : 0.01075881415694991,
+                "99.9" : 0.01075881415694991,
+                "99.99" : 0.01075881415694991,
+                "99.999" : 0.01075881415694991,
+                "99.9999" : 0.01075881415694991,
+                "100.0" : 0.01075881415694991
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010754079989074117,
+                    0.010753816104042463,
+                    0.01075881415694991
+                ],
+                [
+                    0.010392863358504135,
+                    0.010390304880785647,
+                    0.010389359581775831
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1402865286175374,
+            "scoreError" : 0.35373955484474223,
+            "scoreConfidence" : [
+                2.7865469737727953,
+                3.4940260834622796
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0217190803625376,
+                "50.0" : 3.1383944627889058,
+                "90.0" : 3.2667513200522533,
+                "95.0" : 3.2667513200522533,
+                "99.0" : 3.2667513200522533,
+                "99.9" : 3.2667513200522533,
+                "99.99" : 3.2667513200522533,
+                "99.999" : 3.2667513200522533,
+                "99.9999" : 3.2667513200522533,
+                "100.0" : 3.2667513200522533
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.248454277272727,
+                    3.2667513200522533,
+                    3.2506392540610785
+                ],
+                [
+                    3.025820591651543,
+                    3.028334648305085,
+                    3.0217190803625376
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7118824458221056,
+            "scoreError" : 0.1627918552010962,
+            "scoreConfidence" : [
+                2.5490905906210095,
+                2.8746743010232017
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6567983612217794,
+                "50.0" : 2.7103322966748458,
+                "90.0" : 2.7695455486014953,
+                "95.0" : 2.7695455486014953,
+                "99.0" : 2.7695455486014953,
+                "99.9" : 2.7695455486014953,
+                "99.99" : 2.7695455486014953,
+                "99.999" : 2.7695455486014953,
+                "99.9999" : 2.7695455486014953,
+                "100.0" : 2.7695455486014953
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.6594230954533367,
+                    2.6567983612217794,
+                    2.660694553338654
+                ],
+                [
+                    2.7695455486014953,
+                    2.764863076306331,
+                    2.7599700400110376
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18085379825298767,
+            "scoreError" : 0.006249579857313403,
+            "scoreConfidence" : [
+                0.17460421839567428,
+                0.18710337811030106
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1787701870251524,
+                "50.0" : 0.1808609276264997,
+                "90.0" : 0.1829190374245473,
+                "95.0" : 0.1829190374245473,
+                "99.0" : 0.1829190374245473,
+                "99.9" : 0.1829190374245473,
+                "99.99" : 0.1829190374245473,
+                "99.999" : 0.1829190374245473,
+                "99.9999" : 0.1829190374245473,
+                "100.0" : 0.1829190374245473
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17889644244083078,
+                    0.17879315368661947,
+                    0.1787701870251524
+                ],
+                [
+                    0.1829185561286075,
+                    0.1829190374245473,
+                    0.18282541281216863
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.38549566792759316,
+            "scoreError" : 0.024271702545794638,
+            "scoreConfidence" : [
+                0.3612239653817985,
+                0.4097673704733878
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3772324437947944,
+                "50.0" : 0.3850460058867779,
+                "90.0" : 0.3947999253454402,
+                "95.0" : 0.3947999253454402,
+                "99.0" : 0.3947999253454402,
+                "99.9" : 0.3947999253454402,
+                "99.99" : 0.3947999253454402,
+                "99.999" : 0.3947999253454402,
+                "99.9999" : 0.3947999253454402,
+                "100.0" : 0.3947999253454402
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3947999253454402,
+                    0.3931815771408351,
+                    0.3920813134556575
+                ],
+                [
+                    0.3776680495109332,
+                    0.3772324437947944,
+                    0.3780106983178983
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15805962014298688,
+            "scoreError" : 9.027841848174971E-4,
+            "scoreConfidence" : [
+                0.1571568359581694,
+                0.15896240432780437
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15752034542017798,
+                "50.0" : 0.1581719252793165,
+                "90.0" : 0.1583475810333634,
+                "95.0" : 0.1583475810333634,
+                "99.0" : 0.1583475810333634,
+                "99.9" : 0.1583475810333634,
+                "99.99" : 0.1583475810333634,
+                "99.999" : 0.1583475810333634,
+                "99.9999" : 0.1583475810333634,
+                "100.0" : 0.1583475810333634
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15831602569420258,
+                    0.1583475810333634,
+                    0.1581524141797536
+                ],
+                [
+                    0.15819143637887945,
+                    0.15752034542017798,
+                    0.15782991815154432
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40221294342451386,
+            "scoreError" : 0.0036006943121873096,
+            "scoreConfidence" : [
+                0.39861224911232657,
+                0.40581363773670115
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.40085217520442523,
+                "50.0" : 0.4022073582260243,
+                "90.0" : 0.40362062929329623,
+                "95.0" : 0.40362062929329623,
+                "99.0" : 0.40362062929329623,
+                "99.9" : 0.40362062929329623,
+                "99.99" : 0.40362062929329623,
+                "99.999" : 0.40362062929329623,
+                "99.9999" : 0.40362062929329623,
+                "100.0" : 0.40362062929329623
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.40125032548248607,
+                    0.40105972215760977,
+                    0.40085217520442523
+                ],
+                [
+                    0.40362062929329623,
+                    0.4031643909695626,
+                    0.40333041743970316
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14685952467964,
+            "scoreError" : 0.011557039907105196,
+            "scoreConfidence" : [
+                0.13530248477253481,
+                0.1584165645867452
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14216919310491896,
+                "50.0" : 0.1474969539344625,
+                "90.0" : 0.15066119050847457,
+                "95.0" : 0.15066119050847457,
+                "99.0" : 0.15066119050847457,
+                "99.9" : 0.15066119050847457,
+                "99.99" : 0.15066119050847457,
+                "99.999" : 0.15066119050847457,
+                "99.9999" : 0.15066119050847457,
+                "100.0" : 0.15066119050847457
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14450239619097163,
+                    0.14281585226071805,
+                    0.14216919310491896
+                ],
+                [
+                    0.15066119050847457,
+                    0.15051700433480336,
+                    0.15049151167795335
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.043630849306519275,
+            "scoreError" : 3.754013412326387E-5,
+            "scoreConfidence" : [
+                0.04359330917239601,
+                0.04366838944064254
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04361312675540359,
+                "50.0" : 0.04363457336039274,
+                "90.0" : 0.04364888478594874,
+                "95.0" : 0.04364888478594874,
+                "99.0" : 0.04364888478594874,
+                "99.9" : 0.04364888478594874,
+                "99.99" : 0.04364888478594874,
+                "99.999" : 0.04364888478594874,
+                "99.9999" : 0.04364888478594874,
+                "100.0" : 0.04364888478594874
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04363387389553326,
+                    0.04361312675540359,
+                    0.04361702187358247
+                ],
+                [
+                    0.04363691570339534,
+                    0.04364888478594874,
+                    0.04363527282525221
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7902169.661756433,
+            "scoreError" : 172889.776578238,
+            "scoreConfidence" : [
+                7729279.885178194,
+                8075059.438334671
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7838674.807210031,
+                "50.0" : 7902351.026783686,
+                "90.0" : 7966771.933121019,
+                "95.0" : 7966771.933121019,
+                "99.0" : 7966771.933121019,
+                "99.9" : 7966771.933121019,
+                "99.99" : 7966771.933121019,
+                "99.999" : 7966771.933121019,
+                "99.9999" : 7966771.933121019,
+                "100.0" : 7966771.933121019
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7851355.6632653065,
+                    7848524.634509804,
+                    7838674.807210031
+                ],
+                [
+                    7966771.933121019,
+                    7953346.390302067,
+                    7954344.542130366
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-07T21-06-24Z-ef5b6f80af2c24e0660355bc524671d6324535e2-jdk17.json
+++ b/performance-results/2026-03-07T21-06-24Z-ef5b6f80af2c24e0660355bc524671d6324535e2-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3789368697686912,
+            "scoreError" : 0.027805454159511838,
+            "scoreConfidence" : [
+                3.3511314156091796,
+                3.406742323928203
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3749780561284313,
+                "50.0" : 3.3778964567069725,
+                "90.0" : 3.38497650953239,
+                "95.0" : 3.38497650953239,
+                "99.0" : 3.38497650953239,
+                "99.9" : 3.38497650953239,
+                "99.99" : 3.38497650953239,
+                "99.999" : 3.38497650953239,
+                "99.9999" : 3.38497650953239,
+                "100.0" : 3.38497650953239
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3749780561284313,
+                    3.37868103084897
+                ],
+                [
+                    3.377111882564975,
+                    3.38497650953239
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6979779554674161,
+            "scoreError" : 0.0189084505633384,
+            "scoreConfidence" : [
+                1.6790695049040778,
+                1.7168864060307545
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6941291820127706,
+                "50.0" : 1.6984604448923544,
+                "90.0" : 1.7008617500721859,
+                "95.0" : 1.7008617500721859,
+                "99.0" : 1.7008617500721859,
+                "99.9" : 1.7008617500721859,
+                "99.99" : 1.7008617500721859,
+                "99.999" : 1.7008617500721859,
+                "99.9999" : 1.7008617500721859,
+                "100.0" : 1.7008617500721859
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6994830218533563,
+                    1.6974378679313527
+                ],
+                [
+                    1.6941291820127706,
+                    1.7008617500721859
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.853081833602457,
+            "scoreError" : 0.050199866437230456,
+            "scoreConfidence" : [
+                0.8028819671652265,
+                0.9032817000396876
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.842221631275647,
+                "50.0" : 0.8548291176053784,
+                "90.0" : 0.8604474679234243,
+                "95.0" : 0.8604474679234243,
+                "99.0" : 0.8604474679234243,
+                "99.9" : 0.8604474679234243,
+                "99.99" : 0.8604474679234243,
+                "99.999" : 0.8604474679234243,
+                "99.9999" : 0.8604474679234243,
+                "100.0" : 0.8604474679234243
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.842221631275647,
+                    0.8560007631524528
+                ],
+                [
+                    0.8536574720583041,
+                    0.8604474679234243
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.479330573951117,
+            "scoreError" : 0.32969186716416987,
+            "scoreConfidence" : [
+                16.14963870678695,
+                16.809022441115285
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.363683146730494,
+                "50.0" : 16.465000614437464,
+                "90.0" : 16.63772143117054,
+                "95.0" : 16.63772143117054,
+                "99.0" : 16.63772143117054,
+                "99.9" : 16.63772143117054,
+                "99.99" : 16.63772143117054,
+                "99.999" : 16.63772143117054,
+                "99.9999" : 16.63772143117054,
+                "100.0" : 16.63772143117054
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.388187714889,
+                    16.37652153362784,
+                    16.363683146730494
+                ],
+                [
+                    16.63772143117054,
+                    16.541813513985932,
+                    16.568056103302908
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2695.8584526180434,
+            "scoreError" : 106.66354501488233,
+            "scoreConfidence" : [
+                2589.194907603161,
+                2802.521997632926
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2660.28056266597,
+                "50.0" : 2695.4208283218504,
+                "90.0" : 2735.233274636525,
+                "95.0" : 2735.233274636525,
+                "99.0" : 2735.233274636525,
+                "99.9" : 2735.233274636525,
+                "99.99" : 2735.233274636525,
+                "99.999" : 2735.233274636525,
+                "99.9999" : 2735.233274636525,
+                "100.0" : 2735.233274636525
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2728.1545221187002,
+                    2728.088005443576,
+                    2735.233274636525
+                ],
+                [
+                    2662.7536512001248,
+                    2660.640699643363,
+                    2660.28056266597
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73893.13812700276,
+            "scoreError" : 1330.5926610840572,
+            "scoreConfidence" : [
+                72562.54546591871,
+                75223.73078808682
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73437.18718310703,
+                "50.0" : 73903.4189304568,
+                "90.0" : 74331.47786969249,
+                "95.0" : 74331.47786969249,
+                "99.0" : 74331.47786969249,
+                "99.9" : 74331.47786969249,
+                "99.99" : 74331.47786969249,
+                "99.999" : 74331.47786969249,
+                "99.9999" : 74331.47786969249,
+                "100.0" : 74331.47786969249
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    74324.72667702907,
+                    74331.47786969249,
+                    74322.00245776951
+                ],
+                [
+                    73437.18718310703,
+                    73484.83540314407,
+                    73458.59917127441
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 367.9889551276624,
+            "scoreError" : 1.7302783967718165,
+            "scoreConfidence" : [
+                366.25867673089056,
+                369.71923352443423
+            ],
+            "scorePercentiles" : {
+                "0.0" : 367.41830520119146,
+                "50.0" : 367.71907242632824,
+                "90.0" : 369.0254794006179,
+                "95.0" : 369.0254794006179,
+                "99.0" : 369.0254794006179,
+                "99.9" : 369.0254794006179,
+                "99.99" : 369.0254794006179,
+                "99.999" : 369.0254794006179,
+                "99.9999" : 369.0254794006179,
+                "100.0" : 369.0254794006179
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    368.44719727948706,
+                    369.0254794006179,
+                    367.6046040320215
+                ],
+                [
+                    367.73015293024923,
+                    367.41830520119146,
+                    367.7079919224072
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 126.44620631696186,
+            "scoreError" : 2.1368734038010464,
+            "scoreConfidence" : [
+                124.30933291316082,
+                128.5830797207629
+            ],
+            "scorePercentiles" : {
+                "0.0" : 125.39867300674204,
+                "50.0" : 126.53170583418952,
+                "90.0" : 127.25921183186774,
+                "95.0" : 127.25921183186774,
+                "99.0" : 127.25921183186774,
+                "99.9" : 127.25921183186774,
+                "99.99" : 127.25921183186774,
+                "99.999" : 127.25921183186774,
+                "99.9999" : 127.25921183186774,
+                "100.0" : 127.25921183186774
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    126.44255595826813,
+                    125.73211274369325,
+                    125.39867300674204
+                ],
+                [
+                    126.6208557101109,
+                    127.22382865108908,
+                    127.25921183186774
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.05952185634625786,
+            "scoreError" : 0.0016963989726066935,
+            "scoreConfidence" : [
+                0.05782545737365117,
+                0.06121825531886455
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.05896299593752395,
+                "50.0" : 0.05948547773421163,
+                "90.0" : 0.0601417033684755,
+                "95.0" : 0.0601417033684755,
+                "99.0" : 0.0601417033684755,
+                "99.9" : 0.0601417033684755,
+                "99.99" : 0.0601417033684755,
+                "99.999" : 0.0601417033684755,
+                "99.9999" : 0.0601417033684755,
+                "100.0" : 0.0601417033684755
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06008986096022113,
+                    0.0601417033684755,
+                    0.059984791418734106
+                ],
+                [
+                    0.05896299593752395,
+                    0.058965622342903305,
+                    0.05898616404968915
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6242487195184306E-4,
+            "scoreError" : 2.646824663073717E-5,
+            "scoreConfidence" : [
+                3.3595662532110587E-4,
+                3.8889311858258024E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.5364385638285455E-4,
+                "50.0" : 3.62486743826806E-4,
+                "90.0" : 3.7108865323100574E-4,
+                "95.0" : 3.7108865323100574E-4,
+                "99.0" : 3.7108865323100574E-4,
+                "99.9" : 3.7108865323100574E-4,
+                "99.99" : 3.7108865323100574E-4,
+                "99.999" : 3.7108865323100574E-4,
+                "99.9999" : 3.7108865323100574E-4,
+                "100.0" : 3.7108865323100574E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.710407629722721E-4,
+                    3.709927227910452E-4,
+                    3.7108865323100574E-4
+                ],
+                [
+                    3.539807648625668E-4,
+                    3.5380247147131393E-4,
+                    3.5364385638285455E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1594054411091363,
+            "scoreError" : 0.050689062227013075,
+            "scoreConfidence" : [
+                2.1087163788821233,
+                2.2100945033361494
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1197293895718525,
+                "50.0" : 2.1578831250629804,
+                "90.0" : 2.218523436566899,
+                "95.0" : 2.221815017551655,
+                "99.0" : 2.221815017551655,
+                "99.9" : 2.221815017551655,
+                "99.99" : 2.221815017551655,
+                "99.999" : 2.221815017551655,
+                "99.9999" : 2.221815017551655,
+                "100.0" : 2.221815017551655
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.221815017551655,
+                    2.1888992077040927,
+                    2.1677190853922843,
+                    2.143881888102894,
+                    2.148047164733677
+                ],
+                [
+                    2.1871329803192654,
+                    2.168153758075005,
+                    2.1284613858267716,
+                    2.120214533813865,
+                    2.1197293895718525
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013500751519695452,
+            "scoreError" : 1.6469297175863775E-4,
+            "scoreConfidence" : [
+                0.013336058547936814,
+                0.01366544449145409
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013444332383728278,
+                "50.0" : 0.013500568398134526,
+                "90.0" : 0.013557435815084102,
+                "95.0" : 0.013557435815084102,
+                "99.0" : 0.013557435815084102,
+                "99.9" : 0.013557435815084102,
+                "99.99" : 0.013557435815084102,
+                "99.999" : 0.013557435815084102,
+                "99.9999" : 0.013557435815084102,
+                "100.0" : 0.013557435815084102
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013557435815084102,
+                    0.01355480304870445,
+                    0.013550659300603405
+                ],
+                [
+                    0.013446801074386833,
+                    0.013450477495665648,
+                    0.013444332383728278
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.011603110578772,
+            "scoreError" : 0.11523379907344881,
+            "scoreConfidence" : [
+                0.8963693115053232,
+                1.1268369096522208
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9740081436641668,
+                "50.0" : 1.0115263452552201,
+                "90.0" : 1.0494769722950992,
+                "95.0" : 1.0494769722950992,
+                "99.0" : 1.0494769722950992,
+                "99.9" : 1.0494769722950992,
+                "99.99" : 1.0494769722950992,
+                "99.999" : 1.0494769722950992,
+                "99.9999" : 1.0494769722950992,
+                "100.0" : 1.0494769722950992
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0488071740954379,
+                    1.049062559739851,
+                    1.0494769722950992
+                ],
+                [
+                    0.9742455164150025,
+                    0.9740081436641668,
+                    0.9740182972630759
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010562722613180047,
+            "scoreError" : 9.409989566525926E-4,
+            "scoreConfidence" : [
+                0.009621723656527454,
+                0.01150372156983264
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010249899871059261,
+                "50.0" : 0.010567272222845304,
+                "90.0" : 0.010872000071753325,
+                "95.0" : 0.010872000071753325,
+                "99.0" : 0.010872000071753325,
+                "99.9" : 0.010872000071753325,
+                "99.99" : 0.010872000071753325,
+                "99.999" : 0.010872000071753325,
+                "99.9999" : 0.010872000071753325,
+                "100.0" : 0.010872000071753325
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010868441444652868,
+                    0.010872000071753325,
+                    0.010866543837840305
+                ],
+                [
+                    0.010249899871059261,
+                    0.010268000607850304,
+                    0.010251449845924219
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.977295189195493,
+            "scoreError" : 0.03643354934096646,
+            "scoreConfidence" : [
+                2.940861639854526,
+                3.0137287385364595
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.958698725443787,
+                "50.0" : 2.976667060648681,
+                "90.0" : 2.9926706600837822,
+                "95.0" : 2.9926706600837822,
+                "99.0" : 2.9926706600837822,
+                "99.9" : 2.9926706600837822,
+                "99.99" : 2.9926706600837822,
+                "99.999" : 2.9926706600837822,
+                "99.9999" : 2.9926706600837822,
+                "100.0" : 2.9926706600837822
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9891250125523015,
+                    2.982455180679785,
+                    2.9926706600837822
+                ],
+                [
+                    2.958698725443787,
+                    2.970878940617577,
+                    2.9699426157957243
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.775516099798981,
+            "scoreError" : 0.012321340091388444,
+            "scoreConfidence" : [
+                2.7631947597075928,
+                2.7878374398903696
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7722491826496674,
+                "50.0" : 2.7734003723360754,
+                "90.0" : 2.783357185082104,
+                "95.0" : 2.783357185082104,
+                "99.0" : 2.783357185082104,
+                "99.9" : 2.783357185082104,
+                "99.99" : 2.783357185082104,
+                "99.999" : 2.783357185082104,
+                "99.9999" : 2.783357185082104,
+                "100.0" : 2.783357185082104
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7780914869444446,
+                    2.773028712226227,
+                    2.7725979994455225
+                ],
+                [
+                    2.783357185082104,
+                    2.7737720324459234,
+                    2.7722491826496674
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18481619850306955,
+            "scoreError" : 0.005274931005801397,
+            "scoreConfidence" : [
+                0.17954126749726815,
+                0.19009112950887094
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.18303877413745767,
+                "50.0" : 0.18481646550416797,
+                "90.0" : 0.1865785396727673,
+                "95.0" : 0.1865785396727673,
+                "99.0" : 0.1865785396727673,
+                "99.9" : 0.1865785396727673,
+                "99.99" : 0.1865785396727673,
+                "99.999" : 0.1865785396727673,
+                "99.9999" : 0.1865785396727673,
+                "100.0" : 0.1865785396727673
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18313249837932866,
+                    0.18312702970260766,
+                    0.18303877413745767
+                ],
+                [
+                    0.1865785396727673,
+                    0.18651991649724892,
+                    0.18650043262900728
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3818983943373419,
+            "scoreError" : 0.0051622306306402035,
+            "scoreConfidence" : [
+                0.3767361637067017,
+                0.3870606249679821
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3797428798131693,
+                "50.0" : 0.3819422790430944,
+                "90.0" : 0.3838913290978887,
+                "95.0" : 0.3838913290978887,
+                "99.0" : 0.3838913290978887,
+                "99.9" : 0.3838913290978887,
+                "99.99" : 0.3838913290978887,
+                "99.999" : 0.3838913290978887,
+                "99.9999" : 0.3838913290978887,
+                "100.0" : 0.3838913290978887
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3803849022441993,
+                    0.3806176396437543,
+                    0.3797428798131693
+                ],
+                [
+                    0.3834866967826054,
+                    0.3832669184424345,
+                    0.3838913290978887
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15603310786738514,
+            "scoreError" : 0.0013942192013645337,
+            "scoreConfidence" : [
+                0.1546388886660206,
+                0.15742732706874968
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15547051663505487,
+                "50.0" : 0.15601910158004448,
+                "90.0" : 0.15659412261004368,
+                "95.0" : 0.15659412261004368,
+                "99.0" : 0.15659412261004368,
+                "99.9" : 0.15659412261004368,
+                "99.99" : 0.15659412261004368,
+                "99.999" : 0.15659412261004368,
+                "99.9999" : 0.15659412261004368,
+                "100.0" : 0.15659412261004368
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15655740371970694,
+                    0.15659412261004368,
+                    0.15622494093295008
+                ],
+                [
+                    0.15553840107941644,
+                    0.15581326222713887,
+                    0.15547051663505487
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.403246775366812,
+            "scoreError" : 0.024472163453216168,
+            "scoreConfidence" : [
+                0.37877461191359585,
+                0.4277189388200282
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3933351723961611,
+                "50.0" : 0.40393470753371064,
+                "90.0" : 0.41256243985148516,
+                "95.0" : 0.41256243985148516,
+                "99.0" : 0.41256243985148516,
+                "99.9" : 0.41256243985148516,
+                "99.99" : 0.41256243985148516,
+                "99.999" : 0.41256243985148516,
+                "99.9999" : 0.41256243985148516,
+                "100.0" : 0.41256243985148516
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41177097245326527,
+                    0.41256243985148516,
+                    0.4081541169340027
+                ],
+                [
+                    0.3997152981334186,
+                    0.3933351723961611,
+                    0.3939426524325389
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14526036210607027,
+            "scoreError" : 0.003793158254497872,
+            "scoreConfidence" : [
+                0.1414672038515724,
+                0.14905352036056813
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14355362335276048,
+                "50.0" : 0.14553974132385625,
+                "90.0" : 0.1469843845023223,
+                "95.0" : 0.1469843845023223,
+                "99.0" : 0.1469843845023223,
+                "99.9" : 0.1469843845023223,
+                "99.99" : 0.1469843845023223,
+                "99.999" : 0.1469843845023223,
+                "99.9999" : 0.1469843845023223,
+                "100.0" : 0.1469843845023223
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1469843845023223,
+                    0.146098131587021,
+                    0.14599064904597148
+                ],
+                [
+                    0.14508883360174102,
+                    0.14355362335276048,
+                    0.1438465505466053
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04307044454820963,
+            "scoreError" : 0.0016927237747427664,
+            "scoreConfidence" : [
+                0.04137772077346687,
+                0.04476316832295239
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.042550638329830054,
+                "50.0" : 0.04296851879683129,
+                "90.0" : 0.04398727823279464,
+                "95.0" : 0.04398727823279464,
+                "99.0" : 0.04398727823279464,
+                "99.9" : 0.04398727823279464,
+                "99.99" : 0.04398727823279464,
+                "99.999" : 0.04398727823279464,
+                "99.9999" : 0.04398727823279464,
+                "100.0" : 0.04398727823279464
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04398727823279464,
+                    0.04337110499585811,
+                    0.043390717414131245
+                ],
+                [
+                    0.042550638329830054,
+                    0.04255699571883924,
+                    0.04256593259780448
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7835553.661074708,
+            "scoreError" : 75997.87061545908,
+            "scoreConfidence" : [
+                7759555.790459249,
+                7911551.531690167
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7784792.953307393,
+                "50.0" : 7843077.92492163,
+                "90.0" : 7863058.5149371065,
+                "95.0" : 7863058.5149371065,
+                "99.0" : 7863058.5149371065,
+                "99.9" : 7863058.5149371065,
+                "99.99" : 7863058.5149371065,
+                "99.999" : 7863058.5149371065,
+                "99.9999" : 7863058.5149371065,
+                "100.0" : 7863058.5149371065
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7784792.953307393,
+                    7830346.113458529,
+                    7863058.5149371065
+                ],
+                [
+                    7846160.4,
+                    7848968.534901961,
+                    7839995.44984326
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-07T21-07-52Z-ef5b6f80af2c24e0660355bc524671d6324535e2-jdk17.json
+++ b/performance-results/2026-03-07T21-07-52Z-ef5b6f80af2c24e0660355bc524671d6324535e2-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3458120373188516,
+            "scoreError" : 0.04925415066396217,
+            "scoreConfidence" : [
+                3.2965578866548895,
+                3.3950661879828137
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3377701877219668,
+                "50.0" : 3.3465030268417464,
+                "90.0" : 3.352471907869948,
+                "95.0" : 3.352471907869948,
+                "99.0" : 3.352471907869948,
+                "99.9" : 3.352471907869948,
+                "99.99" : 3.352471907869948,
+                "99.999" : 3.352471907869948,
+                "99.9999" : 3.352471907869948,
+                "100.0" : 3.352471907869948
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3377701877219668,
+                    3.352173593029641
+                ],
+                [
+                    3.3408324606538518,
+                    3.352471907869948
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6877210031072603,
+            "scoreError" : 0.055579751588574484,
+            "scoreConfidence" : [
+                1.6321412515186857,
+                1.7433007546958348
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6796372455507915,
+                "50.0" : 1.6880016216763134,
+                "90.0" : 1.6952435235256225,
+                "95.0" : 1.6952435235256225,
+                "99.0" : 1.6952435235256225,
+                "99.9" : 1.6952435235256225,
+                "99.99" : 1.6952435235256225,
+                "99.999" : 1.6952435235256225,
+                "99.9999" : 1.6952435235256225,
+                "100.0" : 1.6952435235256225
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6950670342237262,
+                    1.6952435235256225
+                ],
+                [
+                    1.6809362091289006,
+                    1.6796372455507915
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8497311271857032,
+            "scoreError" : 0.016460334472232555,
+            "scoreConfidence" : [
+                0.8332707927134706,
+                0.8661914616579358
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8464844976999853,
+                "50.0" : 0.849928498379301,
+                "90.0" : 0.8525830142842253,
+                "95.0" : 0.8525830142842253,
+                "99.0" : 0.8525830142842253,
+                "99.9" : 0.8525830142842253,
+                "99.99" : 0.8525830142842253,
+                "99.999" : 0.8525830142842253,
+                "99.9999" : 0.8525830142842253,
+                "100.0" : 0.8525830142842253
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8464844976999853,
+                    0.849331108228769
+                ],
+                [
+                    0.8505258885298329,
+                    0.8525830142842253
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.056730928082796,
+            "scoreError" : 0.1755160062459505,
+            "scoreConfidence" : [
+                15.881214921836845,
+                16.232246934328746
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.987141221628688,
+                "50.0" : 16.057800527060678,
+                "90.0" : 16.117168470428055,
+                "95.0" : 16.117168470428055,
+                "99.0" : 16.117168470428055,
+                "99.9" : 16.117168470428055,
+                "99.99" : 16.117168470428055,
+                "99.999" : 16.117168470428055,
+                "99.9999" : 16.117168470428055,
+                "100.0" : 16.117168470428055
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.11604222068147,
+                    16.106980408703993,
+                    16.117168470428055
+                ],
+                [
+                    15.987141221628688,
+                    16.008620645417363,
+                    16.004432601637202
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2534.6853004043332,
+            "scoreError" : 117.19183695071843,
+            "scoreConfidence" : [
+                2417.493463453615,
+                2651.8771373550517
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2489.956376463703,
+                "50.0" : 2535.791117361979,
+                "90.0" : 2577.000373579528,
+                "95.0" : 2577.000373579528,
+                "99.0" : 2577.000373579528,
+                "99.9" : 2577.000373579528,
+                "99.99" : 2577.000373579528,
+                "99.999" : 2577.000373579528,
+                "99.9999" : 2577.000373579528,
+                "100.0" : 2577.000373579528
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2505.4886508944865,
+                    2495.4001186749115,
+                    2489.956376463703
+                ],
+                [
+                    2566.0935838294718,
+                    2574.1726989839,
+                    2577.000373579528
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73029.61310651847,
+            "scoreError" : 407.36356742055955,
+            "scoreConfidence" : [
+                72622.24953909792,
+                73436.97667393903
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72857.70569631882,
+                "50.0" : 73052.23292173594,
+                "90.0" : 73167.19733867783,
+                "95.0" : 73167.19733867783,
+                "99.0" : 73167.19733867783,
+                "99.9" : 73167.19733867783,
+                "99.99" : 73167.19733867783,
+                "99.999" : 73167.19733867783,
+                "99.9999" : 73167.19733867783,
+                "100.0" : 73167.19733867783
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72857.70569631882,
+                    72957.36725198786,
+                    72886.39953927384
+                ],
+                [
+                    73167.19733867783,
+                    73147.098591484,
+                    73161.91022136851
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 350.5010586053857,
+            "scoreError" : 4.666847200785622,
+            "scoreConfidence" : [
+                345.83421140460007,
+                355.16790580617135
+            ],
+            "scorePercentiles" : {
+                "0.0" : 348.06913402975323,
+                "50.0" : 350.3671025763924,
+                "90.0" : 352.4218301244303,
+                "95.0" : 352.4218301244303,
+                "99.0" : 352.4218301244303,
+                "99.9" : 352.4218301244303,
+                "99.99" : 352.4218301244303,
+                "99.999" : 352.4218301244303,
+                "99.9999" : 352.4218301244303,
+                "100.0" : 352.4218301244303
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    348.06913402975323,
+                    349.7519846485395,
+                    349.6358405645674
+                ],
+                [
+                    350.9822205042453,
+                    352.4218301244303,
+                    352.1453417607786
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 124.25690228103373,
+            "scoreError" : 1.8258641733051466,
+            "scoreConfidence" : [
+                122.43103810772858,
+                126.08276645433888
+            ],
+            "scorePercentiles" : {
+                "0.0" : 123.54625662473607,
+                "50.0" : 124.25195489860054,
+                "90.0" : 125.06858466006902,
+                "95.0" : 125.06858466006902,
+                "99.0" : 125.06858466006902,
+                "99.9" : 125.06858466006902,
+                "99.99" : 125.06858466006902,
+                "99.999" : 125.06858466006902,
+                "99.9999" : 125.06858466006902,
+                "100.0" : 125.06858466006902
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    124.53874041480763,
+                    125.06858466006902,
+                    124.83872726759229
+                ],
+                [
+                    123.58393533660399,
+                    123.96516938239346,
+                    123.54625662473607
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06229556874595993,
+            "scoreError" : 8.785795259406243E-4,
+            "scoreConfidence" : [
+                0.06141698922001931,
+                0.06317414827190056
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.061977348149709025,
+                "50.0" : 0.0623110458964382,
+                "90.0" : 0.0625862029390044,
+                "95.0" : 0.0625862029390044,
+                "99.0" : 0.0625862029390044,
+                "99.9" : 0.0625862029390044,
+                "99.99" : 0.0625862029390044,
+                "99.999" : 0.0625862029390044,
+                "99.9999" : 0.0625862029390044,
+                "100.0" : 0.0625862029390044
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.0625759088155787,
+                    0.0625862029390044,
+                    0.06258049731221488
+                ],
+                [
+                    0.061977348149709025,
+                    0.062007272281954934,
+                    0.062046182977297686
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7214372974131714E-4,
+            "scoreError" : 1.6388953654563582E-5,
+            "scoreConfidence" : [
+                3.557547760867536E-4,
+                3.885326833958807E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6673244075160756E-4,
+                "50.0" : 3.718379751448532E-4,
+                "90.0" : 3.778832182966566E-4,
+                "95.0" : 3.778832182966566E-4,
+                "99.0" : 3.778832182966566E-4,
+                "99.9" : 3.778832182966566E-4,
+                "99.99" : 3.778832182966566E-4,
+                "99.999" : 3.778832182966566E-4,
+                "99.9999" : 3.778832182966566E-4,
+                "100.0" : 3.778832182966566E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.6673244075160756E-4,
+                    3.6698391462892894E-4,
+                    3.6675303414770825E-4
+                ],
+                [
+                    3.778832182966566E-4,
+                    3.7781773496222386E-4,
+                    3.7669203566077737E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1482193109988037,
+            "scoreError" : 0.06780659051536272,
+            "scoreConfidence" : [
+                2.080412720483441,
+                2.2160259015141666
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.092720400920695,
+                "50.0" : 2.1553293670429303,
+                "90.0" : 2.2199103949765684,
+                "95.0" : 2.22085752508881,
+                "99.0" : 2.22085752508881,
+                "99.9" : 2.22085752508881,
+                "99.99" : 2.22085752508881,
+                "99.999" : 2.22085752508881,
+                "99.9999" : 2.22085752508881,
+                "100.0" : 2.22085752508881
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.22085752508881,
+                    2.211386223966394,
+                    2.1605277381723913,
+                    2.1544023274450668,
+                    2.1562564066407934
+                ],
+                [
+                    2.1580016627104013,
+                    2.132918294092557,
+                    2.102060144178226,
+                    2.0930623867727083,
+                    2.092720400920695
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013564547957026774,
+            "scoreError" : 1.5968051962505158E-4,
+            "scoreConfidence" : [
+                0.013404867437401722,
+                0.013724228476651825
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013503655631625143,
+                "50.0" : 0.01356099030829917,
+                "90.0" : 0.013626249168131464,
+                "95.0" : 0.013626249168131464,
+                "99.0" : 0.013626249168131464,
+                "99.9" : 0.013626249168131464,
+                "99.99" : 0.013626249168131464,
+                "99.999" : 0.013626249168131464,
+                "99.9999" : 0.013626249168131464,
+                "100.0" : 0.013626249168131464
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013597358978089487,
+                    0.01362250718578699,
+                    0.013626249168131464
+                ],
+                [
+                    0.013503655631625143,
+                    0.013512895140018702,
+                    0.013524621638508852
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0442053357424232,
+            "scoreError" : 0.046307314666196246,
+            "scoreConfidence" : [
+                0.997898021076227,
+                1.0905126504086196
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.027736207070188,
+                "50.0" : 1.0444497237580013,
+                "90.0" : 1.059755991946593,
+                "95.0" : 1.059755991946593,
+                "99.0" : 1.059755991946593,
+                "99.9" : 1.059755991946593,
+                "99.99" : 1.059755991946593,
+                "99.999" : 1.059755991946593,
+                "99.9999" : 1.059755991946593,
+                "100.0" : 1.059755991946593
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0591392453929251,
+                    1.059755991946593,
+                    1.0588880789919526
+                ],
+                [
+                    1.0297011225288304,
+                    1.027736207070188,
+                    1.03001136852405
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010572923416982896,
+            "scoreError" : 3.693687384740891E-4,
+            "scoreConfidence" : [
+                0.010203554678508807,
+                0.010942292155456985
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010434752160457113,
+                "50.0" : 0.01057501654206859,
+                "90.0" : 0.010699955320687855,
+                "95.0" : 0.010699955320687855,
+                "99.0" : 0.010699955320687855,
+                "99.9" : 0.010699955320687855,
+                "99.99" : 0.010699955320687855,
+                "99.999" : 0.010699955320687855,
+                "99.9999" : 0.010699955320687855,
+                "100.0" : 0.010699955320687855
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010463331714350287,
+                    0.010461197868067033,
+                    0.010434752160457113
+                ],
+                [
+                    0.010686701369786892,
+                    0.01069160206854819,
+                    0.010699955320687855
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.1138030001783803,
+            "scoreError" : 0.24249917354835154,
+            "scoreConfidence" : [
+                2.8713038266300286,
+                3.356302173726732
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.033436886597938,
+                "50.0" : 3.108220707694662,
+                "90.0" : 3.2057399288461537,
+                "95.0" : 3.2057399288461537,
+                "99.0" : 3.2057399288461537,
+                "99.9" : 3.2057399288461537,
+                "99.99" : 3.2057399288461537,
+                "99.999" : 3.2057399288461537,
+                "99.9999" : 3.2057399288461537,
+                "100.0" : 3.2057399288461537
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.191597226547543,
+                    3.2057399288461537,
+                    3.179813785759695
+                ],
+                [
+                    3.0356025436893206,
+                    3.033436886597938,
+                    3.0366276296296295
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.779542335984153,
+            "scoreError" : 0.012921827987613235,
+            "scoreConfidence" : [
+                2.76662050799654,
+                2.7924641639717662
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.773253815030505,
+                "50.0" : 2.780214239530215,
+                "90.0" : 2.7842234626948774,
+                "95.0" : 2.7842234626948774,
+                "99.0" : 2.7842234626948774,
+                "99.9" : 2.7842234626948774,
+                "99.99" : 2.7842234626948774,
+                "99.999" : 2.7842234626948774,
+                "99.9999" : 2.7842234626948774,
+                "100.0" : 2.7842234626948774
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7813920461624027,
+                    2.784201822104677,
+                    2.7790364328980273
+                ],
+                [
+                    2.7842234626948774,
+                    2.773253815030505,
+                    2.7751464370144285
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17928521978505554,
+            "scoreError" : 0.002596460914314687,
+            "scoreConfidence" : [
+                0.17668875887074087,
+                0.18188168069937022
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17840491857851357,
+                "50.0" : 0.17920949637626915,
+                "90.0" : 0.18032867626586843,
+                "95.0" : 0.18032867626586843,
+                "99.0" : 0.18032867626586843,
+                "99.9" : 0.18032867626586843,
+                "99.99" : 0.18032867626586843,
+                "99.999" : 0.18032867626586843,
+                "99.9999" : 0.18032867626586843,
+                "100.0" : 0.18032867626586843
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17845563533673578,
+                    0.17840491857851357,
+                    0.1784834331685377
+                ],
+                [
+                    0.18032867626586843,
+                    0.18010309577667719,
+                    0.17993555958400057
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3857231882997804,
+            "scoreError" : 0.015254168511424302,
+            "scoreConfidence" : [
+                0.3704690197883561,
+                0.4009773568112047
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3806651648966541,
+                "50.0" : 0.3856876973240106,
+                "90.0" : 0.39079884200242293,
+                "95.0" : 0.39079884200242293,
+                "99.0" : 0.39079884200242293,
+                "99.9" : 0.39079884200242293,
+                "99.99" : 0.39079884200242293,
+                "99.999" : 0.39079884200242293,
+                "99.9999" : 0.39079884200242293,
+                "100.0" : 0.39079884200242293
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3807163796779229,
+                    0.3808952822700438,
+                    0.3806651648966541
+                ],
+                [
+                    0.39048011237797736,
+                    0.39079884200242293,
+                    0.3907833485736616
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16033251463926115,
+            "scoreError" : 0.005746814475227824,
+            "scoreConfidence" : [
+                0.15458570016403334,
+                0.16607932911448897
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15832393149470417,
+                "50.0" : 0.16029717660665466,
+                "90.0" : 0.1623082555184055,
+                "95.0" : 0.1623082555184055,
+                "99.0" : 0.1623082555184055,
+                "99.9" : 0.1623082555184055,
+                "99.99" : 0.1623082555184055,
+                "99.999" : 0.1623082555184055,
+                "99.9999" : 0.1623082555184055,
+                "100.0" : 0.1623082555184055
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16200027461526,
+                    0.1622885683219734,
+                    0.1623082555184055
+                ],
+                [
+                    0.15847997928717453,
+                    0.15859407859804933,
+                    0.15832393149470417
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4109695724491573,
+            "scoreError" : 0.006405008687433801,
+            "scoreConfidence" : [
+                0.4045645637617235,
+                0.41737458113659115
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4087320965790657,
+                "50.0" : 0.41060712386386616,
+                "90.0" : 0.41466656458100093,
+                "95.0" : 0.41466656458100093,
+                "99.0" : 0.41466656458100093,
+                "99.9" : 0.41466656458100093,
+                "99.99" : 0.41466656458100093,
+                "99.999" : 0.41466656458100093,
+                "99.9999" : 0.41466656458100093,
+                "100.0" : 0.41466656458100093
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41466656458100093,
+                    0.4116275993414283,
+                    0.41215079854929115
+                ],
+                [
+                    0.4087320965790657,
+                    0.4090537272578534,
+                    0.40958664838630404
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14651887593438265,
+            "scoreError" : 0.006141587125707148,
+            "scoreConfidence" : [
+                0.1403772888086755,
+                0.1526604630600898
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1444595773347779,
+                "50.0" : 0.14637080794482982,
+                "90.0" : 0.14873396095783445,
+                "95.0" : 0.14873396095783445,
+                "99.0" : 0.14873396095783445,
+                "99.9" : 0.14873396095783445,
+                "99.99" : 0.14873396095783445,
+                "99.999" : 0.14873396095783445,
+                "99.9999" : 0.14873396095783445,
+                "100.0" : 0.14873396095783445
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1444595773347779,
+                    0.14462214318770156,
+                    0.14450733272159763
+                ],
+                [
+                    0.1481194727019581,
+                    0.14873396095783445,
+                    0.14867076870242626
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.0438738849514143,
+            "scoreError" : 0.0015066304504499526,
+            "scoreConfidence" : [
+                0.04236725450096435,
+                0.04538051540186425
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04327875441436139,
+                "50.0" : 0.04380068243512013,
+                "90.0" : 0.044787670346649947,
+                "95.0" : 0.044787670346649947,
+                "99.0" : 0.044787670346649947,
+                "99.9" : 0.044787670346649947,
+                "99.99" : 0.044787670346649947,
+                "99.999" : 0.044787670346649947,
+                "99.9999" : 0.044787670346649947,
+                "100.0" : 0.044787670346649947
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04357578375869867,
+                    0.04353532380649711,
+                    0.04327875441436139
+                ],
+                [
+                    0.044787670346649947,
+                    0.044025581111541576,
+                    0.04404019627073709
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 8026691.059003458,
+            "scoreError" : 344026.55887139327,
+            "scoreConfidence" : [
+                7682664.500132065,
+                8370717.617874851
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7891806.914037855,
+                "50.0" : 8029188.815774754,
+                "90.0" : 8164193.33877551,
+                "95.0" : 8164193.33877551,
+                "99.0" : 8164193.33877551,
+                "99.9" : 8164193.33877551,
+                "99.99" : 8164193.33877551,
+                "99.999" : 8164193.33877551,
+                "99.9999" : 8164193.33877551,
+                "100.0" : 8164193.33877551
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    8164193.33877551,
+                    8124670.349309504,
+                    8122443.633928572
+                ],
+                [
+                    7921098.120348377,
+                    7935933.997620936,
+                    7891806.914037855
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-07T23-40-42Z-b4972e334f16f773f8ca961713401c8d03ef76e7-jdk17.json
+++ b/performance-results/2026-03-07T23-40-42Z-b4972e334f16f773f8ca961713401c8d03ef76e7-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3637228368158674,
+            "scoreError" : 0.03234442657954227,
+            "scoreConfidence" : [
+                3.3313784102363253,
+                3.3960672633954094
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.356515365021912,
+                "50.0" : 3.3651354748540325,
+                "90.0" : 3.3681050325334927,
+                "95.0" : 3.3681050325334927,
+                "99.0" : 3.3681050325334927,
+                "99.9" : 3.3681050325334927,
+                "99.99" : 3.3681050325334927,
+                "99.999" : 3.3681050325334927,
+                "99.9999" : 3.3681050325334927,
+                "100.0" : 3.3681050325334927
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3650411920897856,
+                    3.3681050325334927
+                ],
+                [
+                    3.356515365021912,
+                    3.3652297576182795
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6910654388951292,
+            "scoreError" : 0.03215594992733229,
+            "scoreConfidence" : [
+                1.6589094889677969,
+                1.7232213888224615
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6843749540184214,
+                "50.0" : 1.6921391595910382,
+                "90.0" : 1.6956084823800177,
+                "95.0" : 1.6956084823800177,
+                "99.0" : 1.6956084823800177,
+                "99.9" : 1.6956084823800177,
+                "99.99" : 1.6956084823800177,
+                "99.999" : 1.6956084823800177,
+                "99.9999" : 1.6956084823800177,
+                "100.0" : 1.6956084823800177
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.69395288295565,
+                    1.6956084823800177
+                ],
+                [
+                    1.6843749540184214,
+                    1.6903254362264266
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8570316675859064,
+            "scoreError" : 0.01483383383315079,
+            "scoreConfidence" : [
+                0.8421978337527556,
+                0.8718655014190573
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8537075168742255,
+                "50.0" : 0.8577391133055157,
+                "90.0" : 0.858940926858369,
+                "95.0" : 0.858940926858369,
+                "99.0" : 0.858940926858369,
+                "99.9" : 0.858940926858369,
+                "99.99" : 0.858940926858369,
+                "99.999" : 0.858940926858369,
+                "99.9999" : 0.858940926858369,
+                "100.0" : 0.858940926858369
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8537075168742255,
+                    0.857976254583972
+                ],
+                [
+                    0.8575019720270595,
+                    0.858940926858369
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.069187587413143,
+            "scoreError" : 0.2544779827444566,
+            "scoreConfidence" : [
+                15.814709604668687,
+                16.3236655701576
+            ],
+            "scorePercentiles" : {
+                "0.0" : 15.97481744245572,
+                "50.0" : 16.07009610687887,
+                "90.0" : 16.157232218111833,
+                "95.0" : 16.157232218111833,
+                "99.0" : 16.157232218111833,
+                "99.9" : 16.157232218111833,
+                "99.99" : 16.157232218111833,
+                "99.999" : 16.157232218111833,
+                "99.9999" : 16.157232218111833,
+                "100.0" : 16.157232218111833
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.154902362539985,
+                    16.157232218111833,
+                    16.142816322193042
+                ],
+                [
+                    15.97481744245572,
+                    15.987981287613582,
+                    15.9973758915647
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2658.2262561766943,
+            "scoreError" : 6.884272876239396,
+            "scoreConfidence" : [
+                2651.341983300455,
+                2665.1105290529335
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2654.0822590580415,
+                "50.0" : 2659.03814194001,
+                "90.0" : 2661.088508321021,
+                "95.0" : 2661.088508321021,
+                "99.0" : 2661.088508321021,
+                "99.9" : 2661.088508321021,
+                "99.99" : 2661.088508321021,
+                "99.999" : 2661.088508321021,
+                "99.9999" : 2661.088508321021,
+                "100.0" : 2661.088508321021
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2658.9496734018594,
+                    2656.7557399932216,
+                    2661.088508321021
+                ],
+                [
+                    2659.354745807861,
+                    2659.1266104781607,
+                    2654.0822590580415
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 74052.33137854496,
+            "scoreError" : 1851.7862046035102,
+            "scoreConfidence" : [
+                72200.54517394144,
+                75904.11758314847
+            ],
+            "scorePercentiles" : {
+                "0.0" : 73435.78264754674,
+                "50.0" : 74009.26428882005,
+                "90.0" : 74708.03324486909,
+                "95.0" : 74708.03324486909,
+                "99.0" : 74708.03324486909,
+                "99.9" : 74708.03324486909,
+                "99.99" : 74708.03324486909,
+                "99.999" : 74708.03324486909,
+                "99.9999" : 74708.03324486909,
+                "100.0" : 74708.03324486909
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73453.07878821238,
+                    73466.17132362732,
+                    73435.78264754674
+                ],
+                [
+                    74698.56501300144,
+                    74552.35725401278,
+                    74708.03324486909
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 363.4540003181839,
+            "scoreError" : 6.655621433658082,
+            "scoreConfidence" : [
+                356.7983788845258,
+                370.109621751842
+            ],
+            "scorePercentiles" : {
+                "0.0" : 361.00269638012554,
+                "50.0" : 363.3060289197372,
+                "90.0" : 366.30020271856,
+                "95.0" : 366.30020271856,
+                "99.0" : 366.30020271856,
+                "99.9" : 366.30020271856,
+                "99.99" : 366.30020271856,
+                "99.999" : 366.30020271856,
+                "99.9999" : 366.30020271856,
+                "100.0" : 366.30020271856
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    361.00269638012554,
+                    362.0001445045393,
+                    361.1026301201986
+                ],
+                [
+                    366.30020271856,
+                    364.611913334935,
+                    365.7064148507443
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 126.96400372852814,
+            "scoreError" : 3.714455658986624,
+            "scoreConfidence" : [
+                123.24954806954152,
+                130.67845938751478
+            ],
+            "scorePercentiles" : {
+                "0.0" : 125.6789511258828,
+                "50.0" : 126.93979485006255,
+                "90.0" : 128.39391830107488,
+                "95.0" : 128.39391830107488,
+                "99.0" : 128.39391830107488,
+                "99.9" : 128.39391830107488,
+                "99.99" : 128.39391830107488,
+                "99.999" : 128.39391830107488,
+                "99.9999" : 128.39391830107488,
+                "100.0" : 128.39391830107488
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    125.86267123361871,
+                    125.74302039278724,
+                    125.6789511258828
+                ],
+                [
+                    128.39391830107488,
+                    128.0169184665064,
+                    128.0885428512987
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.060587569519971705,
+            "scoreError" : 0.003378832122707641,
+            "scoreConfidence" : [
+                0.057208737397264064,
+                0.06396640164267935
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.059421851400253134,
+                "50.0" : 0.06058984811034663,
+                "90.0" : 0.0618285631754668,
+                "95.0" : 0.0618285631754668,
+                "99.0" : 0.0618285631754668,
+                "99.9" : 0.0618285631754668,
+                "99.99" : 0.0618285631754668,
+                "99.999" : 0.0618285631754668,
+                "99.9999" : 0.0618285631754668,
+                "100.0" : 0.0618285631754668
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06167196157902202,
+                    0.061546119619404,
+                    0.0618285631754668
+                ],
+                [
+                    0.059421851400253134,
+                    0.05942334474439499,
+                    0.05963357660128926
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7247724625389094E-4,
+            "scoreError" : 3.652051036922586E-5,
+            "scoreConfidence" : [
+                3.359567358846651E-4,
+                4.089977566231168E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.604513311172076E-4,
+                "50.0" : 3.7239190349071716E-4,
+                "90.0" : 3.8492934351186175E-4,
+                "95.0" : 3.8492934351186175E-4,
+                "99.0" : 3.8492934351186175E-4,
+                "99.9" : 3.8492934351186175E-4,
+                "99.99" : 3.8492934351186175E-4,
+                "99.999" : 3.8492934351186175E-4,
+                "99.9999" : 3.8492934351186175E-4,
+                "100.0" : 3.8492934351186175E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.8399085379410244E-4,
+                    3.8416623328817775E-4,
+                    3.8492934351186175E-4
+                ],
+                [
+                    3.607929531873318E-4,
+                    3.6053276262466426E-4,
+                    3.604513311172076E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.104287369453591,
+            "scoreError" : 0.06063499121273583,
+            "scoreConfidence" : [
+                2.0436523782408553,
+                2.164922360666327
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.0744039890064303,
+                "50.0" : 2.079811474888958,
+                "90.0" : 2.186439230682615,
+                "95.0" : 2.191645838702608,
+                "99.0" : 2.191645838702608,
+                "99.9" : 2.191645838702608,
+                "99.99" : 2.191645838702608,
+                "99.999" : 2.191645838702608,
+                "99.9999" : 2.191645838702608,
+                "100.0" : 2.191645838702608
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.1316045051150896,
+                    2.191645838702608,
+                    2.0836741683333333,
+                    2.0754060867399877,
+                    2.0755469740610084
+                ],
+                [
+                    2.139579758502674,
+                    2.1196783651971174,
+                    2.0744039890064303,
+                    2.0759487814445827,
+                    2.0753852274330775
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013491658080424624,
+            "scoreError" : 4.7688441139171216E-4,
+            "scoreConfidence" : [
+                0.013014773669032911,
+                0.013968542491816336
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013329785871670427,
+                "50.0" : 0.013492933241176609,
+                "90.0" : 0.01365604021379625,
+                "95.0" : 0.01365604021379625,
+                "99.0" : 0.01365604021379625,
+                "99.9" : 0.01365604021379625,
+                "99.99" : 0.01365604021379625,
+                "99.999" : 0.01365604021379625,
+                "99.9999" : 0.01365604021379625,
+                "100.0" : 0.01365604021379625
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013335994465611444,
+                    0.013343827890902297,
+                    0.013329785871670427
+                ],
+                [
+                    0.013642261449116403,
+                    0.01365604021379625,
+                    0.01364203859145092
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1709781385603364,
+            "scoreError" : 0.060363680616816934,
+            "scoreConfidence" : [
+                1.1106144579435195,
+                1.2313418191771532
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1507193351743183,
+                "50.0" : 1.1712905578897224,
+                "90.0" : 1.1912503111375818,
+                "95.0" : 1.1912503111375818,
+                "99.0" : 1.1912503111375818,
+                "99.9" : 1.1912503111375818,
+                "99.99" : 1.1912503111375818,
+                "99.999" : 1.1912503111375818,
+                "99.9999" : 1.1912503111375818,
+                "100.0" : 1.1912503111375818
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.1903088114734588,
+                    1.1903023315877173,
+                    1.1912503111375818
+                ],
+                [
+                    1.1522787841917272,
+                    1.1507193351743183,
+                    1.1510092577972149
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010520519767184822,
+            "scoreError" : 0.0010802800978350412,
+            "scoreConfidence" : [
+                0.00944023966934978,
+                0.011600799865019863
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010163267288777412,
+                "50.0" : 0.010522581747785512,
+                "90.0" : 0.01087560741870162,
+                "95.0" : 0.01087560741870162,
+                "99.0" : 0.01087560741870162,
+                "99.9" : 0.01087560741870162,
+                "99.99" : 0.01087560741870162,
+                "99.999" : 0.01087560741870162,
+                "99.9999" : 0.01087560741870162,
+                "100.0" : 0.01087560741870162
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010163267288777412,
+                    0.010167271353248459,
+                    0.010176078486082533
+                ],
+                [
+                    0.010871809046810416,
+                    0.01087560741870162,
+                    0.01086908500948849
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0864984821155237,
+            "scoreError" : 0.15346636845771866,
+            "scoreConfidence" : [
+                2.933032113657805,
+                3.2399648505732426
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.0288825384615383,
+                "50.0" : 3.0870738126110138,
+                "90.0" : 3.1502985528967256,
+                "95.0" : 3.1502985528967256,
+                "99.0" : 3.1502985528967256,
+                "99.9" : 3.1502985528967256,
+                "99.99" : 3.1502985528967256,
+                "99.999" : 3.1502985528967256,
+                "99.9999" : 3.1502985528967256,
+                "100.0" : 3.1502985528967256
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.1502985528967256,
+                    3.1350902652037616,
+                    3.1194458084840924
+                ],
+                [
+                    3.0288825384615383,
+                    3.054701816737935,
+                    3.030571910909091
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8147491423653825,
+            "scoreError" : 0.0883464490130639,
+            "scoreConfidence" : [
+                2.7264026933523184,
+                2.9030955913784466
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7833463799053715,
+                "50.0" : 2.8140743504389727,
+                "90.0" : 2.846749418161116,
+                "95.0" : 2.846749418161116,
+                "99.0" : 2.846749418161116,
+                "99.9" : 2.846749418161116,
+                "99.99" : 2.846749418161116,
+                "99.999" : 2.846749418161116,
+                "99.9999" : 2.846749418161116,
+                "100.0" : 2.846749418161116
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.787208103400223,
+                    2.7833463799053715,
+                    2.7876848090858415
+                ],
+                [
+                    2.8430422518476406,
+                    2.846749418161116,
+                    2.8404638917921043
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.18177313600353648,
+            "scoreError" : 0.004283599904123124,
+            "scoreConfidence" : [
+                0.17748953609941334,
+                0.18605673590765962
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.18033652392115845,
+                "50.0" : 0.18171061082804263,
+                "90.0" : 0.18338735974033119,
+                "95.0" : 0.18338735974033119,
+                "99.0" : 0.18338735974033119,
+                "99.9" : 0.18338735974033119,
+                "99.99" : 0.18338735974033119,
+                "99.999" : 0.18338735974033119,
+                "99.9999" : 0.18338735974033119,
+                "100.0" : 0.18338735974033119
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.18043720001082603,
+                    0.18037837566738818,
+                    0.18033652392115845
+                ],
+                [
+                    0.18298402164525926,
+                    0.18311533503625577,
+                    0.18338735974033119
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.38319391418981835,
+            "scoreError" : 0.0022288471653245183,
+            "scoreConfidence" : [
+                0.38096506702449384,
+                0.38542276135514286
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.38232773413365956,
+                "50.0" : 0.38289639176121204,
+                "90.0" : 0.3845877076875745,
+                "95.0" : 0.3845877076875745,
+                "99.0" : 0.3845877076875745,
+                "99.9" : 0.3845877076875745,
+                "99.99" : 0.3845877076875745,
+                "99.999" : 0.3845877076875745,
+                "99.9999" : 0.3845877076875745,
+                "100.0" : 0.3845877076875745
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3828937448502948,
+                    0.382849142261016,
+                    0.38232773413365956
+                ],
+                [
+                    0.3845877076875745,
+                    0.38360611753423607,
+                    0.38289903867212927
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15951871141677043,
+            "scoreError" : 0.0010124065043843132,
+            "scoreConfidence" : [
+                0.15850630491238613,
+                0.16053111792115474
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1591173864880346,
+                "50.0" : 0.1595001333707903,
+                "90.0" : 0.16015657212408513,
+                "95.0" : 0.16015657212408513,
+                "99.0" : 0.16015657212408513,
+                "99.9" : 0.16015657212408513,
+                "99.99" : 0.16015657212408513,
+                "99.999" : 0.16015657212408513,
+                "99.9999" : 0.16015657212408513,
+                "100.0" : 0.16015657212408513
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15950514345412786,
+                    0.15949512328745274,
+                    0.15959676131122424
+                ],
+                [
+                    0.16015657212408513,
+                    0.15924128183569802,
+                    0.1591173864880346
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40757949729086373,
+            "scoreError" : 0.02802860581906537,
+            "scoreConfidence" : [
+                0.3795508914717984,
+                0.4356081031099291
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3983964626907295,
+                "50.0" : 0.4064245120762716,
+                "90.0" : 0.4202216848474662,
+                "95.0" : 0.4202216848474662,
+                "99.0" : 0.4202216848474662,
+                "99.9" : 0.4202216848474662,
+                "99.99" : 0.4202216848474662,
+                "99.999" : 0.4202216848474662,
+                "99.9999" : 0.4202216848474662,
+                "100.0" : 0.4202216848474662
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.39852082210887063,
+                    0.3990731002035197,
+                    0.3983964626907295
+                ],
+                [
+                    0.4202216848474662,
+                    0.41548898994557315,
+                    0.4137759239490235
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14406169158852453,
+            "scoreError" : 0.005702699867736376,
+            "scoreConfidence" : [
+                0.13835899172078814,
+                0.14976439145626091
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14200250164008918,
+                "50.0" : 0.14406439424868678,
+                "90.0" : 0.14612237656530824,
+                "95.0" : 0.14612237656530824,
+                "99.0" : 0.14612237656530824,
+                "99.9" : 0.14612237656530824,
+                "99.99" : 0.14612237656530824,
+                "99.999" : 0.14612237656530824,
+                "99.9999" : 0.14612237656530824,
+                "100.0" : 0.14612237656530824
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14612237656530824,
+                    0.14580107610660756,
+                    0.145813171561051
+                ],
+                [
+                    0.14200250164008918,
+                    0.142327712390766,
+                    0.14230331126732504
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.0439713310377427,
+            "scoreError" : 0.0037818332428812274,
+            "scoreConfidence" : [
+                0.04018949779486147,
+                0.04775316428062393
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04272789586528971,
+                "50.0" : 0.04391563406105933,
+                "90.0" : 0.04543678772223964,
+                "95.0" : 0.04543678772223964,
+                "99.0" : 0.04543678772223964,
+                "99.9" : 0.04543678772223964,
+                "99.99" : 0.04543678772223964,
+                "99.999" : 0.04543678772223964,
+                "99.9999" : 0.04543678772223964,
+                "100.0" : 0.04543678772223964
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04543678772223964,
+                    0.04508487838075444,
+                    0.045067943481004104
+                ],
+                [
+                    0.04276332464111456,
+                    0.042747156136053725,
+                    0.04272789586528971
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7847547.581007187,
+            "scoreError" : 290399.7915993287,
+            "scoreConfidence" : [
+                7557147.789407859,
+                8137947.372606516
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7740567.177244582,
+                "50.0" : 7847951.154780369,
+                "90.0" : 7950288.798887122,
+                "95.0" : 7950288.798887122,
+                "99.0" : 7950288.798887122,
+                "99.9" : 7950288.798887122,
+                "99.99" : 7950288.798887122,
+                "99.999" : 7950288.798887122,
+                "99.9999" : 7950288.798887122,
+                "100.0" : 7950288.798887122
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7755794.151937985,
+                    7763859.380139643,
+                    7740567.177244582
+                ],
+                [
+                    7950288.798887122,
+                    7932042.929421094,
+                    7942733.048412698
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-08T03-01-13Z-5e00d101b8f11c4bce099b8d0d36137289f1b189-jdk17.json
+++ b/performance-results/2026-03-08T03-01-13Z-5e00d101b8f11c4bce099b8d0d36137289f1b189-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3705070413457676,
+            "scoreError" : 0.04957974718138266,
+            "scoreConfidence" : [
+                3.320927294164385,
+                3.42008678852715
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3637637703533976,
+                "50.0" : 3.368498804908599,
+                "90.0" : 3.3812667852124747,
+                "95.0" : 3.3812667852124747,
+                "99.0" : 3.3812667852124747,
+                "99.9" : 3.3812667852124747,
+                "99.99" : 3.3812667852124747,
+                "99.999" : 3.3812667852124747,
+                "99.9999" : 3.3812667852124747,
+                "100.0" : 3.3812667852124747
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3637637703533976,
+                    3.3665892361869223
+                ],
+                [
+                    3.3704083736302755,
+                    3.3812667852124747
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.692807716064824,
+            "scoreError" : 0.01678839934474565,
+            "scoreConfidence" : [
+                1.6760193167200783,
+                1.7095961154095698
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6903920808608843,
+                "50.0" : 1.6925563671172967,
+                "90.0" : 1.6957260491638184,
+                "95.0" : 1.6957260491638184,
+                "99.0" : 1.6957260491638184,
+                "99.9" : 1.6957260491638184,
+                "99.99" : 1.6957260491638184,
+                "99.999" : 1.6957260491638184,
+                "99.9999" : 1.6957260491638184,
+                "100.0" : 1.6957260491638184
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.694255022818389,
+                    1.6957260491638184
+                ],
+                [
+                    1.6903920808608843,
+                    1.6908577114162042
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8477961267898266,
+            "scoreError" : 0.06732566136281237,
+            "scoreConfidence" : [
+                0.7804704654270143,
+                0.915121788152639
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8376246193640843,
+                "50.0" : 0.8464652917364328,
+                "90.0" : 0.8606293043223564,
+                "95.0" : 0.8606293043223564,
+                "99.0" : 0.8606293043223564,
+                "99.9" : 0.8606293043223564,
+                "99.99" : 0.8606293043223564,
+                "99.999" : 0.8606293043223564,
+                "99.9999" : 0.8606293043223564,
+                "100.0" : 0.8606293043223564
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.851659373241109,
+                    0.8606293043223564
+                ],
+                [
+                    0.8412712102317565,
+                    0.8376246193640843
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.287582766454005,
+            "scoreError" : 0.1514144211559747,
+            "scoreConfidence" : [
+                16.13616834529803,
+                16.438997187609978
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.19992900434237,
+                "50.0" : 16.29877008127091,
+                "90.0" : 16.34349557787962,
+                "95.0" : 16.34349557787962,
+                "99.0" : 16.34349557787962,
+                "99.9" : 16.34349557787962,
+                "99.99" : 16.34349557787962,
+                "99.999" : 16.34349557787962,
+                "99.9999" : 16.34349557787962,
+                "100.0" : 16.34349557787962
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.258397958514408,
+                    16.274479391294612,
+                    16.19992900434237
+                ],
+                [
+                    16.34349557787962,
+                    16.323060771247206,
+                    16.326133895445796
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2809.686824872433,
+            "scoreError" : 25.572966820653967,
+            "scoreConfidence" : [
+                2784.113858051779,
+                2835.259791693087
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2804.3079781073257,
+                "50.0" : 2806.1070498040126,
+                "90.0" : 2827.928862988284,
+                "95.0" : 2827.928862988284,
+                "99.0" : 2827.928862988284,
+                "99.9" : 2827.928862988284,
+                "99.99" : 2827.928862988284,
+                "99.999" : 2827.928862988284,
+                "99.9999" : 2827.928862988284,
+                "100.0" : 2827.928862988284
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2807.3873048780665,
+                    2808.951021157084,
+                    2827.928862988284
+                ],
+                [
+                    2804.826794729959,
+                    2804.718987373879,
+                    2804.3079781073257
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 72702.52778019651,
+            "scoreError" : 264.43922635268854,
+            "scoreConfidence" : [
+                72438.08855384383,
+                72966.9670065492
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72583.09380461718,
+                "50.0" : 72713.73458931362,
+                "90.0" : 72818.04667239127,
+                "95.0" : 72818.04667239127,
+                "99.0" : 72818.04667239127,
+                "99.9" : 72818.04667239127,
+                "99.99" : 72818.04667239127,
+                "99.999" : 72818.04667239127,
+                "99.9999" : 72818.04667239127,
+                "100.0" : 72818.04667239127
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72668.28794031806,
+                    72614.85094150511,
+                    72583.09380461718
+                ],
+                [
+                    72771.7060840383,
+                    72759.1812383092,
+                    72818.04667239127
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 363.1148201232836,
+            "scoreError" : 12.127937898219171,
+            "scoreConfidence" : [
+                350.98688222506445,
+                375.24275802150277
+            ],
+            "scorePercentiles" : {
+                "0.0" : 358.0228860950052,
+                "50.0" : 363.1846060409721,
+                "90.0" : 367.34326585297697,
+                "95.0" : 367.34326585297697,
+                "99.0" : 367.34326585297697,
+                "99.9" : 367.34326585297697,
+                "99.99" : 367.34326585297697,
+                "99.999" : 367.34326585297697,
+                "99.9999" : 367.34326585297697,
+                "100.0" : 367.34326585297697
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    358.0228860950052,
+                    359.7946490979991,
+                    359.8431959447432
+                ],
+                [
+                    366.52601613720105,
+                    367.158907611776,
+                    367.34326585297697
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 123.9592383926792,
+            "scoreError" : 1.6268004527760047,
+            "scoreConfidence" : [
+                122.33243793990319,
+                125.5860388454552
+            ],
+            "scorePercentiles" : {
+                "0.0" : 123.0243160189994,
+                "50.0" : 123.95252330893807,
+                "90.0" : 124.75034727845238,
+                "95.0" : 124.75034727845238,
+                "99.0" : 124.75034727845238,
+                "99.9" : 124.75034727845238,
+                "99.99" : 124.75034727845238,
+                "99.999" : 124.75034727845238,
+                "99.9999" : 124.75034727845238,
+                "100.0" : 124.75034727845238
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    123.77011899705333,
+                    123.0243160189994,
+                    124.75034727845238
+                ],
+                [
+                    124.30560144369389,
+                    123.83630581156353,
+                    124.0687408063126
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06063302124218259,
+            "scoreError" : 0.003449572676921066,
+            "scoreConfidence" : [
+                0.05718344856526152,
+                0.06408259391910365
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.059467830774262605,
+                "50.0" : 0.060642714325641965,
+                "90.0" : 0.06178048459219354,
+                "95.0" : 0.06178048459219354,
+                "99.0" : 0.06178048459219354,
+                "99.9" : 0.06178048459219354,
+                "99.99" : 0.06178048459219354,
+                "99.999" : 0.06178048459219354,
+                "99.9999" : 0.06178048459219354,
+                "100.0" : 0.06178048459219354
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06178048459219354,
+                    0.06177697534517375,
+                    0.06170825788775416
+                ],
+                [
+                    0.05957717076352977,
+                    0.05948740809018173,
+                    0.059467830774262605
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.659674146580972E-4,
+            "scoreError" : 3.010276536499961E-5,
+            "scoreConfidence" : [
+                3.358646492930976E-4,
+                3.9607018002309685E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.560516914571012E-4,
+                "50.0" : 3.66016261087395E-4,
+                "90.0" : 3.759366242125375E-4,
+                "95.0" : 3.759366242125375E-4,
+                "99.0" : 3.759366242125375E-4,
+                "99.9" : 3.759366242125375E-4,
+                "99.99" : 3.759366242125375E-4,
+                "99.999" : 3.759366242125375E-4,
+                "99.9999" : 3.759366242125375E-4,
+                "100.0" : 3.759366242125375E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.560953350688471E-4,
+                    3.560516914571012E-4,
+                    3.563589082057225E-4
+                ],
+                [
+                    3.759366242125375E-4,
+                    3.7567361396906746E-4,
+                    3.7568831503530746E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1695909670039946,
+            "scoreError" : 0.06781428303082107,
+            "scoreConfidence" : [
+                2.1017766839731733,
+                2.237405250034816
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.136523701986755,
+                "50.0" : 2.1438886218727853,
+                "90.0" : 2.2653174735440347,
+                "95.0" : 2.271507496479673,
+                "99.0" : 2.271507496479673,
+                "99.9" : 2.271507496479673,
+                "99.99" : 2.271507496479673,
+                "99.999" : 2.271507496479673,
+                "99.9999" : 2.271507496479673,
+                "100.0" : 2.271507496479673
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.2096072671232876,
+                    2.1831083894346213,
+                    2.1407286166523973,
+                    2.136523701986755,
+                    2.1391917935828877
+                ],
+                [
+                    2.192843730760798,
+                    2.271507496479673,
+                    2.1470486270931732,
+                    2.1377095684053016,
+                    2.1376404785210514
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013562850970191663,
+            "scoreError" : 2.8494145278013634E-4,
+            "scoreConfidence" : [
+                0.013277909517411526,
+                0.0138477924229718
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013466025065275557,
+                "50.0" : 0.013555149783739475,
+                "90.0" : 0.01368352504532611,
+                "95.0" : 0.01368352504532611,
+                "99.0" : 0.01368352504532611,
+                "99.9" : 0.01368352504532611,
+                "99.99" : 0.01368352504532611,
+                "99.999" : 0.01368352504532611,
+                "99.9999" : 0.01368352504532611,
+                "100.0" : 0.01368352504532611
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013476632358668684,
+                    0.013471438247065622,
+                    0.013466025065275557
+                ],
+                [
+                    0.01368352504532611,
+                    0.013645817896003734,
+                    0.013633667208810265
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.9862705284426103,
+            "scoreError" : 0.09402037227470392,
+            "scoreConfidence" : [
+                0.8922501561679064,
+                1.0802909007173143
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9552955707326393,
+                "50.0" : 0.9863840724953477,
+                "90.0" : 1.0170784902878063,
+                "95.0" : 1.0170784902878063,
+                "99.0" : 1.0170784902878063,
+                "99.9" : 1.0170784902878063,
+                "99.99" : 1.0170784902878063,
+                "99.999" : 1.0170784902878063,
+                "99.9999" : 1.0170784902878063,
+                "100.0" : 1.0170784902878063
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0170784902878063,
+                    1.0167629387962587,
+                    1.0167893615290768
+                ],
+                [
+                    0.9560052061944365,
+                    0.9552955707326393,
+                    0.9556916031154434
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010683419352870718,
+            "scoreError" : 8.288586849559548E-4,
+            "scoreConfidence" : [
+                0.009854560667914763,
+                0.011512278037826673
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010342639182955839,
+                "50.0" : 0.010718201751870762,
+                "90.0" : 0.01095454069401875,
+                "95.0" : 0.01095454069401875,
+                "99.0" : 0.01095454069401875,
+                "99.9" : 0.01095454069401875,
+                "99.99" : 0.01095454069401875,
+                "99.999" : 0.01095454069401875,
+                "99.9999" : 0.01095454069401875,
+                "100.0" : 0.01095454069401875
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01049081130250514,
+                    0.010342639182955839,
+                    0.010417605194512968
+                ],
+                [
+                    0.01094932754199523,
+                    0.010945592201236384,
+                    0.01095454069401875
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0882324221028132,
+            "scoreError" : 0.12851287368606215,
+            "scoreConfidence" : [
+                2.959719548416751,
+                3.2167452957888756
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.042536659975669,
+                "50.0" : 3.0860839854583446,
+                "90.0" : 3.142785400377121,
+                "95.0" : 3.142785400377121,
+                "99.0" : 3.142785400377121,
+                "99.9" : 3.142785400377121,
+                "99.99" : 3.142785400377121,
+                "99.999" : 3.142785400377121,
+                "99.9999" : 3.142785400377121,
+                "100.0" : 3.142785400377121
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.122779376404494,
+                    3.142785400377121,
+                    3.122861531835206
+                ],
+                [
+                    3.049388594512195,
+                    3.049042969512195,
+                    3.042536659975669
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.6969272357192224,
+            "scoreError" : 0.04583839011343597,
+            "scoreConfidence" : [
+                2.6510888456057864,
+                2.7427656258326585
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6815573471849867,
+                "50.0" : 2.6960053224150116,
+                "90.0" : 2.7135973969072165,
+                "95.0" : 2.7135973969072165,
+                "99.0" : 2.7135973969072165,
+                "99.9" : 2.7135973969072165,
+                "99.99" : 2.7135973969072165,
+                "99.999" : 2.7135973969072165,
+                "99.9999" : 2.7135973969072165,
+                "100.0" : 2.7135973969072165
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.681634334316354,
+                    2.6815573471849867,
+                    2.6830528690987125
+                ],
+                [
+                    2.708957775731311,
+                    2.712763691076756,
+                    2.7135973969072165
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.182440294729723,
+            "scoreError" : 0.008557494677951964,
+            "scoreConfidence" : [
+                0.17388280005177104,
+                0.19099778940767498
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17961179751064174,
+                "50.0" : 0.182197732651168,
+                "90.0" : 0.1862365245828367,
+                "95.0" : 0.1862365245828367,
+                "99.0" : 0.1862365245828367,
+                "99.9" : 0.1862365245828367,
+                "99.99" : 0.1862365245828367,
+                "99.999" : 0.1862365245828367,
+                "99.9999" : 0.1862365245828367,
+                "100.0" : 0.1862365245828367
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17979251041872674,
+                    0.17961179751064174,
+                    0.17971425367957589
+                ],
+                [
+                    0.1862365245828367,
+                    0.1846029548836093,
+                    0.18468372730294746
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.3836418293237271,
+            "scoreError" : 0.003035017134508095,
+            "scoreConfidence" : [
+                0.380606812189219,
+                0.3866768464582352
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3825909031295432,
+                "50.0" : 0.3835850061509293,
+                "90.0" : 0.3849385421301821,
+                "95.0" : 0.3849385421301821,
+                "99.0" : 0.3849385421301821,
+                "99.9" : 0.3849385421301821,
+                "99.99" : 0.3849385421301821,
+                "99.999" : 0.3849385421301821,
+                "99.9999" : 0.3849385421301821,
+                "100.0" : 0.3849385421301821
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.38445561183300014,
+                    0.3844532410810395,
+                    0.3849385421301821
+                ],
+                [
+                    0.3826959065477785,
+                    0.382716771220819,
+                    0.3825909031295432
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.16065087167320005,
+            "scoreError" : 0.009786329868564323,
+            "scoreConfidence" : [
+                0.15086454180463574,
+                0.17043720154176437
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1573164656976104,
+                "50.0" : 0.16019725944963428,
+                "90.0" : 0.16518782138786567,
+                "95.0" : 0.16518782138786567,
+                "99.0" : 0.16518782138786567,
+                "99.9" : 0.16518782138786567,
+                "99.99" : 0.16518782138786567,
+                "99.999" : 0.16518782138786567,
+                "99.9999" : 0.16518782138786567,
+                "100.0" : 0.16518782138786567
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15757617690622883,
+                    0.15778846174479702,
+                    0.1573164656976104
+                ],
+                [
+                    0.16343024714822685,
+                    0.16518782138786567,
+                    0.16260605715447154
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.41140630038155873,
+            "scoreError" : 0.0064231957430168855,
+            "scoreConfidence" : [
+                0.40498310463854187,
+                0.4178294961245756
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.4084684126128334,
+                "50.0" : 0.41073980335134475,
+                "90.0" : 0.41526709251723276,
+                "95.0" : 0.41526709251723276,
+                "99.0" : 0.41526709251723276,
+                "99.9" : 0.41526709251723276,
+                "99.99" : 0.41526709251723276,
+                "99.999" : 0.41526709251723276,
+                "99.9999" : 0.41526709251723276,
+                "100.0" : 0.41526709251723276
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.4125397854873974,
+                    0.41072960961885985,
+                    0.4084684126128334
+                ],
+                [
+                    0.41526709251723276,
+                    0.4106829049691992,
+                    0.41074999708382964
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14979255141343392,
+            "scoreError" : 0.006541937147078247,
+            "scoreConfidence" : [
+                0.14325061426635569,
+                0.15633448856051216
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14768793586070417,
+                "50.0" : 0.14947746359990757,
+                "90.0" : 0.15295433828387886,
+                "95.0" : 0.15295433828387886,
+                "99.0" : 0.15295433828387886,
+                "99.9" : 0.15295433828387886,
+                "99.99" : 0.15295433828387886,
+                "99.999" : 0.15295433828387886,
+                "99.9999" : 0.15295433828387886,
+                "100.0" : 0.15295433828387886
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15295433828387886,
+                    0.15140537488834047,
+                    0.1511841566232274
+                ],
+                [
+                    0.147752732247865,
+                    0.14777077057658775,
+                    0.14768793586070417
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04279529022703502,
+            "scoreError" : 9.735311040381529E-4,
+            "scoreConfidence" : [
+                0.04182175912299687,
+                0.043768821331073175
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.04230151910712171,
+                "50.0" : 0.042833988252413996,
+                "90.0" : 0.04324267288632511,
+                "95.0" : 0.04324267288632511,
+                "99.0" : 0.04324267288632511,
+                "99.9" : 0.04324267288632511,
+                "99.99" : 0.04324267288632511,
+                "99.999" : 0.04324267288632511,
+                "99.9999" : 0.04324267288632511,
+                "100.0" : 0.04324267288632511
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04324267288632511,
+                    0.042802439570269864,
+                    0.04286553693455813
+                ],
+                [
+                    0.04305656198332874,
+                    0.042503010880606595,
+                    0.04230151910712171
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7930190.279663075,
+            "scoreError" : 102931.94033007127,
+            "scoreConfidence" : [
+                7827258.339333003,
+                8033122.219993146
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7881057.641449961,
+                "50.0" : 7944924.02366379,
+                "90.0" : 7966824.964968153,
+                "95.0" : 7966824.964968153,
+                "99.0" : 7966824.964968153,
+                "99.9" : 7966824.964968153,
+                "99.99" : 7966824.964968153,
+                "99.999" : 7966824.964968153,
+                "99.9999" : 7966824.964968153,
+                "100.0" : 7966824.964968153
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7966824.964968153,
+                    7881057.641449961,
+                    7887582.321766562
+                ],
+                [
+                    7955828.702466189,
+                    7950998.316375199,
+                    7938849.730952381
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-08T04-13-20Z-bd3914d3ac1504b132bb661cbdcbaee48844c22b-jdk17.json
+++ b/performance-results/2026-03-08T04-13-20Z-bd3914d3ac1504b132bb661cbdcbaee48844c22b-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3656492230251738,
+            "scoreError" : 0.048203907792729386,
+            "scoreConfidence" : [
+                3.3174453152324443,
+                3.413853130817903
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3573737438410207,
+                "50.0" : 3.365266942844578,
+                "90.0" : 3.3746892625705183,
+                "95.0" : 3.3746892625705183,
+                "99.0" : 3.3746892625705183,
+                "99.9" : 3.3746892625705183,
+                "99.99" : 3.3746892625705183,
+                "99.999" : 3.3746892625705183,
+                "99.9999" : 3.3746892625705183,
+                "100.0" : 3.3746892625705183
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.362399966077973,
+                    3.3746892625705183
+                ],
+                [
+                    3.3573737438410207,
+                    3.368133919611183
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6914080573939285,
+            "scoreError" : 0.007973549356418275,
+            "scoreConfidence" : [
+                1.6834345080375102,
+                1.6993816067503469
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.690063635402378,
+                "50.0" : 1.6913097657419105,
+                "90.0" : 1.692949062689515,
+                "95.0" : 1.692949062689515,
+                "99.0" : 1.692949062689515,
+                "99.9" : 1.692949062689515,
+                "99.99" : 1.692949062689515,
+                "99.999" : 1.692949062689515,
+                "99.9999" : 1.692949062689515,
+                "100.0" : 1.692949062689515
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6917376399832889,
+                    1.692949062689515
+                ],
+                [
+                    1.690063635402378,
+                    1.6908818915005321
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8544523533425397,
+            "scoreError" : 0.016335306163153613,
+            "scoreConfidence" : [
+                0.8381170471793861,
+                0.8707876595056933
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8520850351292028,
+                "50.0" : 0.8538533905733083,
+                "90.0" : 0.858017597094339,
+                "95.0" : 0.858017597094339,
+                "99.0" : 0.858017597094339,
+                "99.9" : 0.858017597094339,
+                "99.99" : 0.858017597094339,
+                "99.999" : 0.858017597094339,
+                "99.9999" : 0.858017597094339,
+                "100.0" : 0.858017597094339
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.85359045932262,
+                    0.858017597094339
+                ],
+                [
+                    0.8520850351292028,
+                    0.8541163218239967
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.800440489395843,
+            "scoreError" : 0.4114401603130158,
+            "scoreConfidence" : [
+                16.389000329082826,
+                17.21188064970886
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.64088843597399,
+                "50.0" : 16.813136495591706,
+                "90.0" : 16.948253797801556,
+                "95.0" : 16.948253797801556,
+                "99.0" : 16.948253797801556,
+                "99.9" : 16.948253797801556,
+                "99.99" : 16.948253797801556,
+                "99.999" : 16.948253797801556,
+                "99.9999" : 16.948253797801556,
+                "100.0" : 16.948253797801556
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.948253797801556,
+                    16.918858283655474,
+                    16.930660481946163
+                ],
+                [
+                    16.64088843597399,
+                    16.65656722946994,
+                    16.70741470752794
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2703.0503820468325,
+            "scoreError" : 147.38170880806132,
+            "scoreConfidence" : [
+                2555.668673238771,
+                2850.432090854894
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2653.230116554803,
+                "50.0" : 2702.3562692384307,
+                "90.0" : 2754.3022005993753,
+                "95.0" : 2754.3022005993753,
+                "99.0" : 2754.3022005993753,
+                "99.9" : 2754.3022005993753,
+                "99.99" : 2754.3022005993753,
+                "99.999" : 2754.3022005993753,
+                "99.9999" : 2754.3022005993753,
+                "100.0" : 2754.3022005993753
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2747.421643071973,
+                    2751.195255081453,
+                    2754.3022005993753
+                ],
+                [
+                    2653.230116554803,
+                    2657.2908954048885,
+                    2654.862181568499
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73262.46172163512,
+            "scoreError" : 2010.0540723582178,
+            "scoreConfidence" : [
+                71252.4076492769,
+                75272.51579399334
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72584.27229186129,
+                "50.0" : 73245.46328937789,
+                "90.0" : 73980.44050327885,
+                "95.0" : 73980.44050327885,
+                "99.0" : 73980.44050327885,
+                "99.9" : 73980.44050327885,
+                "99.99" : 73980.44050327885,
+                "99.999" : 73980.44050327885,
+                "99.9999" : 73980.44050327885,
+                "100.0" : 73980.44050327885
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72642.28786648589,
+                    72584.27229186129,
+                    72601.77591733595
+                ],
+                [
+                    73848.63871226988,
+                    73917.35503857887,
+                    73980.44050327885
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 369.42951426252876,
+            "scoreError" : 2.240485009503031,
+            "scoreConfidence" : [
+                367.18902925302575,
+                371.66999927203176
+            ],
+            "scorePercentiles" : {
+                "0.0" : 368.6497517117026,
+                "50.0" : 369.18508654652,
+                "90.0" : 370.4556712373342,
+                "95.0" : 370.4556712373342,
+                "99.0" : 370.4556712373342,
+                "99.9" : 370.4556712373342,
+                "99.99" : 370.4556712373342,
+                "99.999" : 370.4556712373342,
+                "99.9999" : 370.4556712373342,
+                "100.0" : 370.4556712373342
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    369.2910004891054,
+                    370.3752102686514,
+                    370.4556712373342
+                ],
+                [
+                    368.72627926444466,
+                    369.0791726039345,
+                    368.6497517117026
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 129.87156216364681,
+            "scoreError" : 6.313168148564211,
+            "scoreConfidence" : [
+                123.5583940150826,
+                136.18473031221103
+            ],
+            "scorePercentiles" : {
+                "0.0" : 127.68384408659742,
+                "50.0" : 129.83853124235674,
+                "90.0" : 132.1695466561515,
+                "95.0" : 132.1695466561515,
+                "99.0" : 132.1695466561515,
+                "99.9" : 132.1695466561515,
+                "99.99" : 132.1695466561515,
+                "99.999" : 132.1695466561515,
+                "99.9999" : 132.1695466561515,
+                "100.0" : 132.1695466561515
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    127.79710039880933,
+                    127.98809604476664,
+                    127.68384408659742
+                ],
+                [
+                    132.1695466561515,
+                    131.9018193556092,
+                    131.68896643994682
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06052621034131916,
+            "scoreError" : 0.003637810338139346,
+            "scoreConfidence" : [
+                0.05688840000317981,
+                0.0641640206794585
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.05926122592401643,
+                "50.0" : 0.060571121968337034,
+                "90.0" : 0.06180905014494008,
+                "95.0" : 0.06180905014494008,
+                "99.0" : 0.06180905014494008,
+                "99.9" : 0.06180905014494008,
+                "99.99" : 0.06180905014494008,
+                "99.999" : 0.06180905014494008,
+                "99.9999" : 0.06180905014494008,
+                "100.0" : 0.06180905014494008
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06164743923188361,
+                    0.06166443668103422,
+                    0.06180905014494008
+                ],
+                [
+                    0.05949480470479046,
+                    0.05928030536125009,
+                    0.05926122592401643
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.6387140511527687E-4,
+            "scoreError" : 2.4513342742963433E-5,
+            "scoreConfidence" : [
+                3.393580623723134E-4,
+                3.883847478582403E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.557143124074144E-4,
+                "50.0" : 3.638809527477426E-4,
+                "90.0" : 3.719437311924093E-4,
+                "95.0" : 3.719437311924093E-4,
+                "99.0" : 3.719437311924093E-4,
+                "99.9" : 3.719437311924093E-4,
+                "99.99" : 3.719437311924093E-4,
+                "99.999" : 3.719437311924093E-4,
+                "99.9999" : 3.719437311924093E-4,
+                "100.0" : 3.719437311924093E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.7189139680530076E-4,
+                    3.719437311924093E-4,
+                    3.7171657057478085E-4
+                ],
+                [
+                    3.5604533492070427E-4,
+                    3.559170847910518E-4,
+                    3.557143124074144E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1213440400414925,
+            "scoreError" : 0.06073572171531442,
+            "scoreConfidence" : [
+                2.060608318326178,
+                2.182079761756807
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.088339213823345,
+                "50.0" : 2.098594126910805,
+                "90.0" : 2.1967834735422906,
+                "95.0" : 2.1998096515618126,
+                "99.0" : 2.1998096515618126,
+                "99.9" : 2.1998096515618126,
+                "99.99" : 2.1998096515618126,
+                "99.999" : 2.1998096515618126,
+                "99.9999" : 2.1998096515618126,
+                "100.0" : 2.1998096515618126
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.1493963329035033,
+                    2.1998096515618126,
+                    2.101961499369483,
+                    2.0917650386948337,
+                    2.0952267544521264
+                ],
+                [
+                    2.1695478713665945,
+                    2.137487998503954,
+                    2.0913543301965705,
+                    2.088551709542702,
+                    2.088339213823345
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013876769787968708,
+            "scoreError" : 3.0876899609701335E-5,
+            "scoreConfidence" : [
+                0.013845892888359006,
+                0.01390764668757841
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0138657208684825,
+                "50.0" : 0.013875801112913259,
+                "90.0" : 0.013893645610632404,
+                "95.0" : 0.013893645610632404,
+                "99.0" : 0.013893645610632404,
+                "99.9" : 0.013893645610632404,
+                "99.99" : 0.013893645610632404,
+                "99.999" : 0.013893645610632404,
+                "99.9999" : 0.013893645610632404,
+                "100.0" : 0.013893645610632404
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013869552232906293,
+                    0.013867348361178597,
+                    0.0138657208684825
+                ],
+                [
+                    0.013893645610632404,
+                    0.013882301661692234,
+                    0.013882049992920226
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.9832379146588858,
+            "scoreError" : 0.0784115213729975,
+            "scoreConfidence" : [
+                0.9048263932858882,
+                1.0616494360318833
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.9573255204863106,
+                "50.0" : 0.9834203471049774,
+                "90.0" : 1.0092941485518216,
+                "95.0" : 1.0092941485518216,
+                "99.0" : 1.0092941485518216,
+                "99.9" : 1.0092941485518216,
+                "99.99" : 1.0092941485518216,
+                "99.999" : 1.0092941485518216,
+                "99.9999" : 1.0092941485518216,
+                "100.0" : 1.0092941485518216
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.9583510312410158,
+                    0.9573255204863106,
+                    0.9574694922929632
+                ],
+                [
+                    1.008489662968939,
+                    1.008497632412263,
+                    1.0092941485518216
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.01018445412184664,
+            "scoreError" : 1.6955669070717325E-4,
+            "scoreConfidence" : [
+                0.010014897431139466,
+                0.010354010812553813
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010124079680653757,
+                "50.0" : 0.010180709220058936,
+                "90.0" : 0.010255692993071422,
+                "95.0" : 0.010255692993071422,
+                "99.0" : 0.010255692993071422,
+                "99.9" : 0.010255692993071422,
+                "99.99" : 0.010255692993071422,
+                "99.999" : 0.010255692993071422,
+                "99.9999" : 0.010255692993071422,
+                "100.0" : 0.010255692993071422
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010255692993071422,
+                    0.010226325515853457,
+                    0.010234559316760651
+                ],
+                [
+                    0.010124079680653757,
+                    0.010130974300476141,
+                    0.010135092924264413
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.997795211439081,
+            "scoreError" : 0.050234065509130316,
+            "scoreConfidence" : [
+                2.9475611459299507,
+                3.048029276948211
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9725051402257874,
+                "50.0" : 3.000494511450775,
+                "90.0" : 3.0156008101265823,
+                "95.0" : 3.0156008101265823,
+                "99.0" : 3.0156008101265823,
+                "99.9" : 3.0156008101265823,
+                "99.99" : 3.0156008101265823,
+                "99.999" : 3.0156008101265823,
+                "99.9999" : 3.0156008101265823,
+                "100.0" : 3.0156008101265823
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.9725051402257874,
+                    2.990672996411483,
+                    2.98403529176611
+                ],
+                [
+                    3.013641003614458,
+                    3.0156008101265823,
+                    3.010316026490066
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7222238996994084,
+            "scoreError" : 0.2414251550306489,
+            "scoreConfidence" : [
+                2.4807987446687596,
+                2.963649054730057
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6431349606236787,
+                "50.0" : 2.7213988511213243,
+                "90.0" : 2.8033469764573993,
+                "95.0" : 2.8033469764573993,
+                "99.0" : 2.8033469764573993,
+                "99.9" : 2.8033469764573993,
+                "99.99" : 2.8033469764573993,
+                "99.999" : 2.8033469764573993,
+                "99.9999" : 2.8033469764573993,
+                "100.0" : 2.8033469764573993
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.6431349606236787,
+                    2.6437190346286017,
+                    2.6440745559080097
+                ],
+                [
+                    2.8033469764573993,
+                    2.800344724244121,
+                    2.798723146334639
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17876320117733477,
+            "scoreError" : 0.00266787647992117,
+            "scoreConfidence" : [
+                0.1760953246974136,
+                0.18143107765725594
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17785320237608265,
+                "50.0" : 0.17877584996573825,
+                "90.0" : 0.17969615696984942,
+                "95.0" : 0.17969615696984942,
+                "99.0" : 0.17969615696984942,
+                "99.9" : 0.17969615696984942,
+                "99.99" : 0.17969615696984942,
+                "99.999" : 0.17969615696984942,
+                "99.9999" : 0.17969615696984942,
+                "100.0" : 0.17969615696984942
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17796381499145786,
+                    0.17787105062075345,
+                    0.17785320237608265
+                ],
+                [
+                    0.17969615696984942,
+                    0.17960709716584647,
+                    0.17958788494001868
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.37679537356704024,
+            "scoreError" : 0.008996411287118172,
+            "scoreConfidence" : [
+                0.36779896227992204,
+                0.38579178485415844
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3734762242680012,
+                "50.0" : 0.3768284551198754,
+                "90.0" : 0.37980509039118876,
+                "95.0" : 0.37980509039118876,
+                "99.0" : 0.37980509039118876,
+                "99.9" : 0.37980509039118876,
+                "99.99" : 0.37980509039118876,
+                "99.999" : 0.37980509039118876,
+                "99.9999" : 0.37980509039118876,
+                "100.0" : 0.37980509039118876
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3734762242680012,
+                    0.3740488055732186,
+                    0.3740987244500973
+                ],
+                [
+                    0.37978521093008244,
+                    0.37955818578965345,
+                    0.37980509039118876
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1567739978363705,
+            "scoreError" : 0.0022163355691536225,
+            "scoreConfidence" : [
+                0.15455766226721687,
+                0.15899033340552413
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15573584878451405,
+                "50.0" : 0.15688974755455515,
+                "90.0" : 0.15768875235737487,
+                "95.0" : 0.15768875235737487,
+                "99.0" : 0.15768875235737487,
+                "99.9" : 0.15768875235737487,
+                "99.99" : 0.15768875235737487,
+                "99.999" : 0.15768875235737487,
+                "99.9999" : 0.15768875235737487,
+                "100.0" : 0.15768875235737487
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.15651497705538947,
+                    0.15605087048047064,
+                    0.15573584878451405
+                ],
+                [
+                    0.15738902028675303,
+                    0.15768875235737487,
+                    0.15726451805372083
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4099833294014306,
+            "scoreError" : 0.026382380497520647,
+            "scoreConfidence" : [
+                0.38360094890390994,
+                0.4363657098989513
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.39920442557183344,
+                "50.0" : 0.40954154337261506,
+                "90.0" : 0.422028044269075,
+                "95.0" : 0.422028044269075,
+                "99.0" : 0.422028044269075,
+                "99.9" : 0.422028044269075,
+                "99.99" : 0.422028044269075,
+                "99.999" : 0.422028044269075,
+                "99.9999" : 0.422028044269075,
+                "100.0" : 0.422028044269075
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.422028044269075,
+                    0.41717553470715835,
+                    0.41553411696999915
+                ],
+                [
+                    0.4024088851152871,
+                    0.403548969775231,
+                    0.39920442557183344
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14707209166461452,
+            "scoreError" : 0.007827607185163917,
+            "scoreConfidence" : [
+                0.1392444844794506,
+                0.15489969884977844
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14439283080410645,
+                "50.0" : 0.14694984012383866,
+                "90.0" : 0.1507723564008624,
+                "95.0" : 0.1507723564008624,
+                "99.0" : 0.1507723564008624,
+                "99.9" : 0.1507723564008624,
+                "99.99" : 0.1507723564008624,
+                "99.999" : 0.1507723564008624,
+                "99.9999" : 0.1507723564008624,
+                "100.0" : 0.1507723564008624
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1507723564008624,
+                    0.1489216892227964,
+                    0.14891731069349098
+                ],
+                [
+                    0.1449823695541863,
+                    0.1444459933122445,
+                    0.14439283080410645
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.043046024526516576,
+            "scoreError" : 0.002330276185521302,
+            "scoreConfidence" : [
+                0.04071574834099528,
+                0.045376300712037874
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.0422853474620706,
+                "50.0" : 0.04304092345233136,
+                "90.0" : 0.04382039765038912,
+                "95.0" : 0.04382039765038912,
+                "99.0" : 0.04382039765038912,
+                "99.9" : 0.04382039765038912,
+                "99.99" : 0.04382039765038912,
+                "99.999" : 0.04382039765038912,
+                "99.9999" : 0.04382039765038912,
+                "100.0" : 0.04382039765038912
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.04228787188237384,
+                    0.0422853474620706,
+                    0.0422892069015097
+                ],
+                [
+                    0.04382039765038912,
+                    0.04380068325960317,
+                    0.04379264000315303
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7953036.917273383,
+            "scoreError" : 86849.92190450738,
+            "scoreConfidence" : [
+                7866186.995368876,
+                8039886.83917789
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7906347.052173913,
+                "50.0" : 7959689.289578361,
+                "90.0" : 7988196.595047924,
+                "95.0" : 7988196.595047924,
+                "99.0" : 7988196.595047924,
+                "99.9" : 7988196.595047924,
+                "99.99" : 7988196.595047924,
+                "99.999" : 7988196.595047924,
+                "99.9999" : 7988196.595047924,
+                "100.0" : 7988196.595047924
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7926787.789223455,
+                    7906347.052173913,
+                    7961011.972951472
+                ],
+                [
+                    7988196.595047924,
+                    7958366.60620525,
+                    7977511.488038277
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-09T00-08-34Z-761df3189cac32bdb75942e69fb3ee914cdc1a56-jdk17.json
+++ b/performance-results/2026-03-09T00-08-34Z-761df3189cac32bdb75942e69fb3ee914cdc1a56-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.3655120600342157,
+            "scoreError" : 0.04151748184524881,
+            "scoreConfidence" : [
+                3.323994578188967,
+                3.4070295418794645
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.357667623883852,
+                "50.0" : 3.3655176002605462,
+                "90.0" : 3.373345415731919,
+                "95.0" : 3.373345415731919,
+                "99.0" : 3.373345415731919,
+                "99.9" : 3.373345415731919,
+                "99.99" : 3.373345415731919,
+                "99.999" : 3.373345415731919,
+                "99.9999" : 3.373345415731919,
+                "100.0" : 3.373345415731919
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.357667623883852,
+                    3.3662033130147857
+                ],
+                [
+                    3.364831887506307,
+                    3.373345415731919
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.6887755547938248,
+            "scoreError" : 0.013579762796273341,
+            "scoreConfidence" : [
+                1.6751957919975515,
+                1.702355317590098
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.686245064452572,
+                "50.0" : 1.689036341247728,
+                "90.0" : 1.6907844722272711,
+                "95.0" : 1.6907844722272711,
+                "99.0" : 1.6907844722272711,
+                "99.9" : 1.6907844722272711,
+                "99.99" : 1.6907844722272711,
+                "99.999" : 1.6907844722272711,
+                "99.9999" : 1.6907844722272711,
+                "100.0" : 1.6907844722272711
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6878801520936295,
+                    1.6907844722272711
+                ],
+                [
+                    1.686245064452572,
+                    1.6901925304018266
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.852934538126146,
+            "scoreError" : 0.0039948520380368524,
+            "scoreConfidence" : [
+                0.8489396860881091,
+                0.8569293901641828
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.852414887474048,
+                "50.0" : 0.8527468880813333,
+                "90.0" : 0.8538294888678694,
+                "95.0" : 0.8538294888678694,
+                "99.0" : 0.8538294888678694,
+                "99.9" : 0.8538294888678694,
+                "99.99" : 0.8538294888678694,
+                "99.999" : 0.8538294888678694,
+                "99.9999" : 0.8538294888678694,
+                "100.0" : 0.8538294888678694
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8538294888678694,
+                    0.852414887474048
+                ],
+                [
+                    0.8527976022309015,
+                    0.852696173931765
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.586425754897473,
+            "scoreError" : 0.4464012599607137,
+            "scoreConfidence" : [
+                16.14002449493676,
+                17.032827014858185
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.436424303636944,
+                "50.0" : 16.587227366379366,
+                "90.0" : 16.73748711945828,
+                "95.0" : 16.73748711945828,
+                "99.0" : 16.73748711945828,
+                "99.9" : 16.73748711945828,
+                "99.99" : 16.73748711945828,
+                "99.999" : 16.73748711945828,
+                "99.9999" : 16.73748711945828,
+                "100.0" : 16.73748711945828
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.436424303636944,
+                    16.447944797763775,
+                    16.439175056192035
+                ],
+                [
+                    16.731013317338835,
+                    16.726509934994958,
+                    16.73748711945828
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2809.7861914370624,
+            "scoreError" : 96.81678093123543,
+            "scoreConfidence" : [
+                2712.969410505827,
+                2906.6029723682977
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2775.3770374287933,
+                "50.0" : 2810.6423892212606,
+                "90.0" : 2842.013419828492,
+                "95.0" : 2842.013419828492,
+                "99.0" : 2842.013419828492,
+                "99.9" : 2842.013419828492,
+                "99.99" : 2842.013419828492,
+                "99.999" : 2842.013419828492,
+                "99.9999" : 2842.013419828492,
+                "100.0" : 2842.013419828492
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2778.452533584808,
+                    2775.3770374287933,
+                    2781.1223786895707
+                ],
+                [
+                    2841.5893793377586,
+                    2840.162399752951,
+                    2842.013419828492
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73028.09178595414,
+            "scoreError" : 653.9777202159274,
+            "scoreConfidence" : [
+                72374.1140657382,
+                73682.06950617007
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72801.53628738047,
+                "50.0" : 73031.64939030781,
+                "90.0" : 73259.65838628479,
+                "95.0" : 73259.65838628479,
+                "99.0" : 73259.65838628479,
+                "99.9" : 73259.65838628479,
+                "99.99" : 73259.65838628479,
+                "99.999" : 73259.65838628479,
+                "99.9999" : 73259.65838628479,
+                "100.0" : 73259.65838628479
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    73259.65838628479,
+                    73230.01969169539,
+                    73232.02236317158
+                ],
+                [
+                    72812.03489827231,
+                    72833.27908892024,
+                    72801.53628738047
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 356.95950413521433,
+            "scoreError" : 12.53677324693169,
+            "scoreConfidence" : [
+                344.4227308882826,
+                369.49627738214605
+            ],
+            "scorePercentiles" : {
+                "0.0" : 352.24166881486843,
+                "50.0" : 356.8213636267758,
+                "90.0" : 361.69113769906767,
+                "95.0" : 361.69113769906767,
+                "99.0" : 361.69113769906767,
+                "99.9" : 361.69113769906767,
+                "99.99" : 361.69113769906767,
+                "99.999" : 361.69113769906767,
+                "99.9999" : 361.69113769906767,
+                "100.0" : 361.69113769906767
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    360.20279210851396,
+                    361.69113769906767,
+                    361.1125771728545
+                ],
+                [
+                    352.24166881486843,
+                    353.0689138709438,
+                    353.4399351450377
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 127.20679246458117,
+            "scoreError" : 6.970941421910835,
+            "scoreConfidence" : [
+                120.23585104267033,
+                134.177733886492
+            ],
+            "scorePercentiles" : {
+                "0.0" : 124.34837664708658,
+                "50.0" : 127.42092852316418,
+                "90.0" : 129.46384861848284,
+                "95.0" : 129.46384861848284,
+                "99.0" : 129.46384861848284,
+                "99.9" : 129.46384861848284,
+                "99.99" : 129.46384861848284,
+                "99.999" : 129.46384861848284,
+                "99.9999" : 129.46384861848284,
+                "100.0" : 129.46384861848284
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    129.44253299077124,
+                    129.46384861848284,
+                    129.45589422149166
+                ],
+                [
+                    124.34837664708658,
+                    125.13077825409756,
+                    125.39932405555713
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06130525704029973,
+            "scoreError" : 0.0012886416479328026,
+            "scoreConfidence" : [
+                0.060016615392366926,
+                0.06259389868823254
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.06084082067459207,
+                "50.0" : 0.06130310548883272,
+                "90.0" : 0.061783610108860854,
+                "95.0" : 0.061783610108860854,
+                "99.0" : 0.061783610108860854,
+                "99.9" : 0.061783610108860854,
+                "99.99" : 0.061783610108860854,
+                "99.999" : 0.061783610108860854,
+                "99.9999" : 0.061783610108860854,
+                "100.0" : 0.061783610108860854
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.061783610108860854,
+                    0.06167284136714606,
+                    0.06171148969126241
+                ],
+                [
+                    0.060889410789417606,
+                    0.06084082067459207,
+                    0.060933369610519386
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7068729725869875E-4,
+            "scoreError" : 2.1303588385775116E-5,
+            "scoreConfidence" : [
+                3.493837088729236E-4,
+                3.919908856444739E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6322673591429E-4,
+                "50.0" : 3.705678407832333E-4,
+                "90.0" : 3.779285751700225E-4,
+                "95.0" : 3.779285751700225E-4,
+                "99.0" : 3.779285751700225E-4,
+                "99.9" : 3.779285751700225E-4,
+                "99.99" : 3.779285751700225E-4,
+                "99.999" : 3.779285751700225E-4,
+                "99.9999" : 3.779285751700225E-4,
+                "100.0" : 3.779285751700225E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.769817636359092E-4,
+                    3.779189151755235E-4,
+                    3.779285751700225E-4
+                ],
+                [
+                    3.641539179305575E-4,
+                    3.6391387572588964E-4,
+                    3.6322673591429E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.152870336329508,
+            "scoreError" : 0.06212718177278174,
+            "scoreConfidence" : [
+                2.0907431545567263,
+                2.2149975181022894
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.105857926721415,
+                "50.0" : 2.1452598073179363,
+                "90.0" : 2.2305006073600917,
+                "95.0" : 2.234283558633013,
+                "99.0" : 2.234283558633013,
+                "99.9" : 2.234283558633013,
+                "99.99" : 2.234283558633013,
+                "99.999" : 2.234283558633013,
+                "99.9999" : 2.234283558633013,
+                "100.0" : 2.234283558633013
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.1964540459037996,
+                    2.160707778785915,
+                    2.1564790454937475,
+                    2.1237993979613505,
+                    2.1260273488520407
+                ],
+                [
+                    2.179860322580645,
+                    2.234283558633013,
+                    2.1340405691421256,
+                    2.105857926721415,
+                    2.111193369221026
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013480512798766291,
+            "scoreError" : 3.1026949705679574E-5,
+            "scoreConfidence" : [
+                0.01344948584906061,
+                0.013511539748471971
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013459918806766485,
+                "50.0" : 0.013483448847765938,
+                "90.0" : 0.013489978946701038,
+                "95.0" : 0.013489978946701038,
+                "99.0" : 0.013489978946701038,
+                "99.9" : 0.013489978946701038,
+                "99.99" : 0.013489978946701038,
+                "99.999" : 0.013489978946701038,
+                "99.9999" : 0.013489978946701038,
+                "100.0" : 0.013489978946701038
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.013489978946701038,
+                    0.0134860125728573,
+                    0.01348834637909872
+                ],
+                [
+                    0.013480885122674575,
+                    0.013459918806766485,
+                    0.013477934964499625
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0375670877584706,
+            "scoreError" : 0.0941721069687719,
+            "scoreConfidence" : [
+                0.9433949807896987,
+                1.1317391947272426
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0060556942655936,
+                "50.0" : 1.0368986677034064,
+                "90.0" : 1.0702247335188355,
+                "95.0" : 1.0702247335188355,
+                "99.0" : 1.0702247335188355,
+                "99.9" : 1.0702247335188355,
+                "99.99" : 1.0702247335188355,
+                "99.999" : 1.0702247335188355,
+                "99.9999" : 1.0702247335188355,
+                "100.0" : 1.0702247335188355
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0702247335188355,
+                    1.0679881731097822,
+                    1.066388271137648
+                ],
+                [
+                    1.0060556942655936,
+                    1.0074090642691649,
+                    1.0073365902497986
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010461354729383745,
+            "scoreError" : 8.995836086228466E-4,
+            "scoreConfidence" : [
+                0.009561771120760898,
+                0.011360938338006592
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.010237544259945537,
+                "50.0" : 0.010297296501281335,
+                "90.0" : 0.011064500211323861,
+                "95.0" : 0.011064500211323861,
+                "99.0" : 0.011064500211323861,
+                "99.9" : 0.011064500211323861,
+                "99.99" : 0.011064500211323861,
+                "99.999" : 0.011064500211323861,
+                "99.9999" : 0.011064500211323861,
+                "100.0" : 0.011064500211323861
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010284837708030369,
+                    0.010297218515101465,
+                    0.010297374487461205
+                ],
+                [
+                    0.010237544259945537,
+                    0.010586653194440033,
+                    0.011064500211323861
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 3.0446880548888973,
+            "scoreError" : 0.2488145934942332,
+            "scoreConfidence" : [
+                2.795873461394664,
+                3.2935026483831304
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.966650333926453,
+                "50.0" : 3.0196472662925284,
+                "90.0" : 3.204705526585522,
+                "95.0" : 3.204705526585522,
+                "99.0" : 3.204705526585522,
+                "99.9" : 3.204705526585522,
+                "99.99" : 3.204705526585522,
+                "99.999" : 3.204705526585522,
+                "99.9999" : 3.204705526585522,
+                "100.0" : 3.204705526585522
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.0307434296969697,
+                    3.204705526585522,
+                    3.0819377726432533
+                ],
+                [
+                    3.0085511028880867,
+                    2.975540163593099,
+                    2.966650333926453
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.697679360497989,
+            "scoreError" : 0.10178027937082977,
+            "scoreConfidence" : [
+                2.5958990811271594,
+                2.799459639868819
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6622757814745808,
+                "50.0" : 2.6988738244279045,
+                "90.0" : 2.7331687666028968,
+                "95.0" : 2.7331687666028968,
+                "99.0" : 2.7331687666028968,
+                "99.9" : 2.7331687666028968,
+                "99.99" : 2.7331687666028968,
+                "99.999" : 2.7331687666028968,
+                "99.9999" : 2.7331687666028968,
+                "100.0" : 2.7331687666028968
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.729474784661572,
+                    2.729572566320961,
+                    2.7331687666028968
+                ],
+                [
+                    2.6633113997336886,
+                    2.668272864194237,
+                    2.6622757814745808
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17917669082353294,
+            "scoreError" : 0.0019539435796662413,
+            "scoreConfidence" : [
+                0.1772227472438667,
+                0.18113063440319918
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17845912277821402,
+                "50.0" : 0.17918223828569252,
+                "90.0" : 0.17984423694432455,
+                "95.0" : 0.17984423694432455,
+                "99.0" : 0.17984423694432455,
+                "99.9" : 0.17984423694432455,
+                "99.99" : 0.17984423694432455,
+                "99.999" : 0.17984423694432455,
+                "99.9999" : 0.17984423694432455,
+                "100.0" : 0.17984423694432455
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.17859372756009573,
+                    0.17857422731736933,
+                    0.17845912277821402
+                ],
+                [
+                    0.17984423694432455,
+                    0.17981808132990487,
+                    0.17977074901128928
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.37766637282017174,
+            "scoreError" : 0.008317339386982514,
+            "scoreConfidence" : [
+                0.3693490334331892,
+                0.3859837122071543
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3732994323789615,
+                "50.0" : 0.3782474272723532,
+                "90.0" : 0.380446559347181,
+                "95.0" : 0.380446559347181,
+                "99.0" : 0.380446559347181,
+                "99.9" : 0.380446559347181,
+                "99.99" : 0.380446559347181,
+                "99.999" : 0.380446559347181,
+                "99.9999" : 0.380446559347181,
+                "100.0" : 0.380446559347181
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.37686688385151684,
+                    0.37536769460605834,
+                    0.3732994323789615
+                ],
+                [
+                    0.3796279706931896,
+                    0.38038969604412326,
+                    0.380446559347181
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.1579850229755323,
+            "scoreError" : 0.010115597052766762,
+            "scoreConfidence" : [
+                0.14786942592276553,
+                0.16810062002829906
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15461193920841063,
+                "50.0" : 0.1579598160766429,
+                "90.0" : 0.16137095425279566,
+                "95.0" : 0.16137095425279566,
+                "99.0" : 0.16137095425279566,
+                "99.9" : 0.16137095425279566,
+                "99.99" : 0.16137095425279566,
+                "99.999" : 0.16137095425279566,
+                "99.9999" : 0.16137095425279566,
+                "100.0" : 0.16137095425279566
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16137095425279566,
+                    0.16132421368651997,
+                    0.16113545385991201
+                ],
+                [
+                    0.15461193920841063,
+                    0.1547841782933738,
+                    0.15468339855218177
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.4122235810456225,
+            "scoreError" : 0.005230018617219445,
+            "scoreConfidence" : [
+                0.40699356242840307,
+                0.41745359966284196
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.410793085113375,
+                "50.0" : 0.4116528000540195,
+                "90.0" : 0.41565689758510327,
+                "95.0" : 0.41565689758510327,
+                "99.0" : 0.41565689758510327,
+                "99.9" : 0.41565689758510327,
+                "99.99" : 0.41565689758510327,
+                "99.999" : 0.41565689758510327,
+                "99.9999" : 0.41565689758510327,
+                "100.0" : 0.41565689758510327
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.41565689758510327,
+                    0.41271995810978124,
+                    0.410793085113375
+                ],
+                [
+                    0.4108659453574363,
+                    0.4122920951144094,
+                    0.41101350499362954
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14720567332692985,
+            "scoreError" : 0.005188348212407993,
+            "scoreConfidence" : [
+                0.14201732511452186,
+                0.15239402153933784
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.1445949732070561,
+                "50.0" : 0.14786828598673457,
+                "90.0" : 0.14877588546052337,
+                "95.0" : 0.14877588546052337,
+                "99.0" : 0.14877588546052337,
+                "99.9" : 0.14877588546052337,
+                "99.99" : 0.14877588546052337,
+                "99.999" : 0.14877588546052337,
+                "99.9999" : 0.14877588546052337,
+                "100.0" : 0.14877588546052337
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14702789531874852,
+                    0.14540439027262814,
+                    0.1445949732070561
+                ],
+                [
+                    0.14877588546052337,
+                    0.14870867665472065,
+                    0.1487222190479023
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04349469871380655,
+            "scoreError" : 0.0012107250819267542,
+            "scoreConfidence" : [
+                0.042283973631879794,
+                0.0447054237957333
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.043086306726526954,
+                "50.0" : 0.043482140983066866,
+                "90.0" : 0.04392667428927856,
+                "95.0" : 0.04392667428927856,
+                "99.0" : 0.04392667428927856,
+                "99.9" : 0.04392667428927856,
+                "99.99" : 0.04392667428927856,
+                "99.999" : 0.04392667428927856,
+                "99.9999" : 0.04392667428927856,
+                "100.0" : 0.04392667428927856
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.043893550090419085,
+                    0.04392667428927856,
+                    0.04384367914436158
+                ],
+                [
+                    0.04309737921048095,
+                    0.043120602821772144,
+                    0.043086306726526954
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7740849.160983648,
+            "scoreError" : 258489.5179102516,
+            "scoreConfidence" : [
+                7482359.643073397,
+                7999338.6788939
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7654557.155317521,
+                "50.0" : 7739565.528354728,
+                "90.0" : 7829242.823161189,
+                "95.0" : 7829242.823161189,
+                "99.0" : 7829242.823161189,
+                "99.9" : 7829242.823161189,
+                "99.99" : 7829242.823161189,
+                "99.999" : 7829242.823161189,
+                "99.9999" : 7829242.823161189,
+                "100.0" : 7829242.823161189
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7829242.823161189,
+                    7824647.093041439,
+                    7820978.706020328
+                ],
+                [
+                    7658152.350689127,
+                    7657516.837672282,
+                    7654557.155317521
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/performance-results/2026-03-09T03-14-09Z-426a2ccd6fc8863055bcf28ff355b4f566424373-jdk17.json
+++ b/performance-results/2026-03-09T03-14-09Z-426a2ccd6fc8863055bcf28ff355b4f566424373-jdk17.json
@@ -1,0 +1,1283 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "5"
+        },
+        "primaryMetric" : {
+            "score" : 3.380089007695691,
+            "scoreError" : 0.02969016334277677,
+            "scoreConfidence" : [
+                3.3503988443529145,
+                3.4097791710384677
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.374558066808615,
+                "50.0" : 3.380038416922677,
+                "90.0" : 3.385721130128794,
+                "95.0" : 3.385721130128794,
+                "99.0" : 3.385721130128794,
+                "99.9" : 3.385721130128794,
+                "99.99" : 3.385721130128794,
+                "99.999" : 3.385721130128794,
+                "99.9999" : 3.385721130128794,
+                "100.0" : 3.385721130128794
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.380750253499045,
+                    3.385721130128794
+                ],
+                [
+                    3.374558066808615,
+                    3.3793265803463095
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 1.7050396550640148,
+            "scoreError" : 0.02388932914961135,
+            "scoreConfidence" : [
+                1.6811503259144034,
+                1.7289289842136262
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6998946267146704,
+                "50.0" : 1.7060118300627383,
+                "90.0" : 1.7082403334159122,
+                "95.0" : 1.7082403334159122,
+                "99.0" : 1.7082403334159122,
+                "99.9" : 1.7082403334159122,
+                "99.99" : 1.7082403334159122,
+                "99.999" : 1.7082403334159122,
+                "99.9999" : 1.7082403334159122,
+                "100.0" : 1.7082403334159122
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6998946267146704,
+                    1.7049174570402972
+                ],
+                [
+                    1.7071062030851794,
+                    1.7082403334159122
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ComplexQueryPerformance.benchMarkSimpleQueriesThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 2,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howManyItems" : "20"
+        },
+        "primaryMetric" : {
+            "score" : 0.8590134911066798,
+            "scoreError" : 0.012802838932611213,
+            "scoreConfidence" : [
+                0.8462106521740685,
+                0.871816330039291
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.8561729487119133,
+                "50.0" : 0.8595535803229741,
+                "90.0" : 0.8607738550688572,
+                "95.0" : 0.8607738550688572,
+                "99.0" : 0.8607738550688572,
+                "99.9" : 0.8607738550688572,
+                "99.99" : 0.8607738550688572,
+                "99.999" : 0.8607738550688572,
+                "99.9999" : 0.8607738550688572,
+                "100.0" : 0.8607738550688572
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    0.8596656989111876,
+                    0.8607738550688572
+                ],
+                [
+                    0.8561729487119133,
+                    0.8594414617347608
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16.86381862488936,
+            "scoreError" : 0.3704566600796434,
+            "scoreConfidence" : [
+                16.493361964809715,
+                17.234275284969
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.72439084978535,
+                "50.0" : 16.871649848978038,
+                "90.0" : 16.99871455248562,
+                "95.0" : 16.99871455248562,
+                "99.0" : 16.99871455248562,
+                "99.9" : 16.99871455248562,
+                "99.99" : 16.99871455248562,
+                "99.999" : 16.99871455248562,
+                "99.9999" : 16.99871455248562,
+                "100.0" : 16.99871455248562
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    16.99871455248562,
+                    16.975488035568645,
+                    16.97631434634902
+                ],
+                [
+                    16.767811662387434,
+                    16.74019230276008,
+                    16.72439084978535
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkThroughput_getImmediateFields",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2792.085952400193,
+            "scoreError" : 50.589759185979396,
+            "scoreConfidence" : [
+                2741.4961932142137,
+                2842.6757115861724
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2775.385271843407,
+                "50.0" : 2789.431776855121,
+                "90.0" : 2813.7084894519967,
+                "95.0" : 2813.7084894519967,
+                "99.0" : 2813.7084894519967,
+                "99.9" : 2813.7084894519967,
+                "99.99" : 2813.7084894519967,
+                "99.999" : 2813.7084894519967,
+                "99.9999" : 2813.7084894519967,
+                "100.0" : 2813.7084894519967
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    2801.6813913704655,
+                    2809.1112311930224,
+                    2813.7084894519967
+                ],
+                [
+                    2775.385271843407,
+                    2777.182162339777,
+                    2775.4471682024873
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 73811.93090381764,
+            "scoreError" : 3414.5164073428627,
+            "scoreConfidence" : [
+                70397.41449647478,
+                77226.4473111605
+            ],
+            "scorePercentiles" : {
+                "0.0" : 72682.84457812316,
+                "50.0" : 73805.91107664343,
+                "90.0" : 74955.46035525156,
+                "95.0" : 74955.46035525156,
+                "99.0" : 74955.46035525156,
+                "99.9" : 74955.46035525156,
+                "99.99" : 74955.46035525156,
+                "99.999" : 74955.46035525156,
+                "99.9999" : 74955.46035525156,
+                "100.0" : 74955.46035525156
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    72717.50254239887,
+                    72682.84457812316,
+                    72701.33436565127
+                ],
+                [
+                    74920.12397059296,
+                    74894.319610888,
+                    74955.46035525156
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 364.96566779849104,
+            "scoreError" : 9.177747456474973,
+            "scoreConfidence" : [
+                355.7879203420161,
+                374.143415254966
+            ],
+            "scorePercentiles" : {
+                "0.0" : 361.1935290373305,
+                "50.0" : 365.18703666578733,
+                "90.0" : 368.09439837625496,
+                "95.0" : 368.09439837625496,
+                "99.0" : 368.09439837625496,
+                "99.9" : 368.09439837625496,
+                "99.99" : 368.09439837625496,
+                "99.999" : 368.09439837625496,
+                "99.9999" : 368.09439837625496,
+                "100.0" : 368.09439837625496
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    367.8992673043258,
+                    368.09439837625496,
+                    367.7723405042609
+                ],
+                [
+                    361.1935290373305,
+                    362.60173282731375,
+                    362.23273874146025
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationThroughput",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 128.32751284830326,
+            "scoreError" : 2.4270179096621978,
+            "scoreConfidence" : [
+                125.90049493864106,
+                130.75453075796545
+            ],
+            "scorePercentiles" : {
+                "0.0" : 126.61498912627475,
+                "50.0" : 128.58922823467913,
+                "90.0" : 128.99375662478312,
+                "95.0" : 128.99375662478312,
+                "99.0" : 128.99375662478312,
+                "99.9" : 128.99375662478312,
+                "99.99" : 128.99375662478312,
+                "99.999" : 128.99375662478312,
+                "99.9999" : 128.99375662478312,
+                "100.0" : 128.99375662478312
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    128.3708548608316,
+                    128.58607815248033,
+                    128.59237831687793
+                ],
+                [
+                    126.61498912627475,
+                    128.99375662478312,
+                    128.80702000857173
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.06059988606811275,
+            "scoreError" : 0.002073615055358726,
+            "scoreConfidence" : [
+                0.058526271012754025,
+                0.06267350112347148
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.05965328075973228,
+                "50.0" : 0.060706423489142076,
+                "90.0" : 0.0613584166487707,
+                "95.0" : 0.0613584166487707,
+                "99.0" : 0.0613584166487707,
+                "99.9" : 0.0613584166487707,
+                "99.99" : 0.0613584166487707,
+                "99.999" : 0.0613584166487707,
+                "99.9999" : 0.0613584166487707,
+                "100.0" : 0.0613584166487707
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.06106985645801527,
+                    0.06128576890171781,
+                    0.0613584166487707
+                ],
+                [
+                    0.06034299052026888,
+                    0.05965328075973228,
+                    0.05988900312017152
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DFSelectionSetPerformance.benchMarkAvgTime_getImmediateFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.616036386173231E-4,
+            "scoreError" : 2.2471002058968985E-5,
+            "scoreConfidence" : [
+                3.391326365583541E-4,
+                3.8407464067629206E-4
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.541392202403834E-4,
+                "50.0" : 3.6162916271208396E-4,
+                "90.0" : 3.689652064123162E-4,
+                "95.0" : 3.689652064123162E-4,
+                "99.0" : 3.689652064123162E-4,
+                "99.9" : 3.689652064123162E-4,
+                "99.99" : 3.689652064123162E-4,
+                "99.999" : 3.689652064123162E-4,
+                "99.9999" : 3.689652064123162E-4,
+                "100.0" : 3.689652064123162E-4
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.541392202403834E-4,
+                    3.5436493329092346E-4,
+                    3.5436248974043884E-4
+                ],
+                [
+                    3.6889339213324446E-4,
+                    3.689652064123162E-4,
+                    3.688965898866318E-4
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.DataLoaderPerformance.executeRequestWithDataLoaders",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.098946893277151,
+            "scoreError" : 0.06375792852191926,
+            "scoreConfidence" : [
+                2.035188964755232,
+                2.1627048217990703
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.0483325474093794,
+                "50.0" : 2.101156110775073,
+                "90.0" : 2.1739914449737685,
+                "95.0" : 2.1776125617243633,
+                "99.0" : 2.1776125617243633,
+                "99.9" : 2.1776125617243633,
+                "99.99" : 2.1776125617243633,
+                "99.999" : 2.1776125617243633,
+                "99.9999" : 2.1776125617243633,
+                "100.0" : 2.1776125617243633
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.1776125617243633,
+                    2.1414013942184154,
+                    2.100875642857143,
+                    2.100306313313734,
+                    2.101436578693003
+                ],
+                [
+                    2.1174539536311667,
+                    2.1048044438131313,
+                    2.0483325474093794,
+                    2.0488748967424706,
+                    2.048370600368701
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF1Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 0.013663119564008822,
+            "scoreError" : 3.5733610512371164E-4,
+            "scoreConfidence" : [
+                0.01330578345888511,
+                0.014020455669132533
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.013542429518613164,
+                "50.0" : 0.013664147665268933,
+                "90.0" : 0.013781733651963115,
+                "95.0" : 0.013781733651963115,
+                "99.0" : 0.013781733651963115,
+                "99.9" : 0.013781733651963115,
+                "99.99" : 0.013781733651963115,
+                "99.999" : 0.013781733651963115,
+                "99.9999" : 0.013781733651963115,
+                "100.0" : 0.013781733651963115
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.01355036519759619,
+                    0.013547671698205229,
+                    0.013542429518613164
+                ],
+                [
+                    0.013777930132941677,
+                    0.01377858718473356,
+                    0.013781733651963115
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENF2Performance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0118088009623774,
+            "scoreError" : 0.00550581002382075,
+            "scoreConfidence" : [
+                1.0063029909385566,
+                1.0173146109861981
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0097115285743135,
+                "50.0" : 1.0116763778888052,
+                "90.0" : 1.0138420952960259,
+                "95.0" : 1.0138420952960259,
+                "99.0" : 1.0138420952960259,
+                "99.9" : 1.0138420952960259,
+                "99.99" : 1.0138420952960259,
+                "99.999" : 1.0138420952960259,
+                "99.9999" : 1.0138420952960259,
+                "100.0" : 1.0138420952960259
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.0130318725688816,
+                    1.0138420952960259,
+                    1.0138411642335767
+                ],
+                [
+                    1.010320883208729,
+                    1.0097115285743135,
+                    1.0101052618927382
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "2"
+        },
+        "primaryMetric" : {
+            "score" : 0.010225874991564942,
+            "scoreError" : 9.328705664708764E-4,
+            "scoreConfidence" : [
+                0.009293004425094066,
+                0.011158745558035818
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.009919381300116253,
+                "50.0" : 0.010225803380388416,
+                "90.0" : 0.01053078955582233,
+                "95.0" : 0.01053078955582233,
+                "99.0" : 0.01053078955582233,
+                "99.9" : 0.01053078955582233,
+                "99.99" : 0.01053078955582233,
+                "99.999" : 0.01053078955582233,
+                "99.9999" : 0.01053078955582233,
+                "100.0" : 0.01053078955582233
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.010527260762281328,
+                    0.010530613499852575,
+                    0.01053078955582233
+                ],
+                [
+                    0.009924345998495503,
+                    0.009922858832821657,
+                    0.009919381300116253
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFDeepIntrospectionPerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "howDeep" : "10"
+        },
+        "primaryMetric" : {
+            "score" : 2.9912636909096815,
+            "scoreError" : 0.3510187480829088,
+            "scoreConfidence" : [
+                2.6402449428267727,
+                3.3422824389925903
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.875811877515814,
+                "50.0" : 2.9894597422290494,
+                "90.0" : 3.1101630006218905,
+                "95.0" : 3.1101630006218905,
+                "99.0" : 3.1101630006218905,
+                "99.9" : 3.1101630006218905,
+                "99.99" : 3.1101630006218905,
+                "99.999" : 3.1101630006218905,
+                "99.9999" : 3.1101630006218905,
+                "100.0" : 3.1101630006218905
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    3.1101630006218905,
+                    3.099898296778191,
+                    3.1064089875776397
+                ],
+                [
+                    2.875811877515814,
+                    2.8762787952846463,
+                    2.879021187679908
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.ENFExtraLargePerformance.benchMarkAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.6984990210929336,
+            "scoreError" : 0.037960658861312495,
+            "scoreConfidence" : [
+                2.660538362231621,
+                2.736459679954246
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6830543739270385,
+                "50.0" : 2.6996733515666023,
+                "90.0" : 2.7131585613130764,
+                "95.0" : 2.7131585613130764,
+                "99.0" : 2.7131585613130764,
+                "99.9" : 2.7131585613130764,
+                "99.99" : 2.7131585613130764,
+                "99.999" : 2.7131585613130764,
+                "99.9999" : 2.7131585613130764,
+                "100.0" : 2.7131585613130764
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.691806892088267,
+                    2.6830543739270385,
+                    2.68477336
+                ],
+                [
+                    2.7131585613130764,
+                    2.710661128184282,
+                    2.7075398110449376
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkDeepAbstractConcrete",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.17594176124826652,
+            "scoreError" : 4.758502797050278E-4,
+            "scoreConfidence" : [
+                0.17546591096856148,
+                0.17641761152797156
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.17576681339309255,
+                "50.0" : 0.1759307530661478,
+                "90.0" : 0.1762459740394783,
+                "95.0" : 0.1762459740394783,
+                "99.0" : 0.1762459740394783,
+                "99.9" : 0.1762459740394783,
+                "99.99" : 0.1762459740394783,
+                "99.999" : 0.1762459740394783,
+                "99.9999" : 0.1762459740394783,
+                "100.0" : 0.1762459740394783
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.1759048647317502,
+                    0.17580600247881578,
+                    0.17576681339309255
+                ],
+                [
+                    0.17595664140054543,
+                    0.1759702714459167,
+                    0.1762459740394783
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.37405135261767103,
+            "scoreError" : 0.006962466523267646,
+            "scoreConfidence" : [
+                0.3670888860944034,
+                0.3810138191409387
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.37131363704886383,
+                "50.0" : 0.3742431737547314,
+                "90.0" : 0.37639988057061124,
+                "95.0" : 0.37639988057061124,
+                "99.0" : 0.37639988057061124,
+                "99.9" : 0.37639988057061124,
+                "99.99" : 0.37639988057061124,
+                "99.999" : 0.37639988057061124,
+                "99.9999" : 0.37639988057061124,
+                "100.0" : 0.37639988057061124
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.37620399571138363,
+                    0.37639988057061124,
+                    0.3762957328792896
+                ],
+                [
+                    0.37228235179807906,
+                    0.37181251769779894,
+                    0.37131363704886383
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkNoOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.15964646379757172,
+            "scoreError" : 0.008960690910152426,
+            "scoreConfidence" : [
+                0.1506857728874193,
+                0.16860715470772414
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.15647168762810784,
+                "50.0" : 0.1596620824239994,
+                "90.0" : 0.16300641354241377,
+                "95.0" : 0.16300641354241377,
+                "99.0" : 0.16300641354241377,
+                "99.9" : 0.16300641354241377,
+                "99.99" : 0.16300641354241377,
+                "99.999" : 0.16300641354241377,
+                "99.9999" : 0.16300641354241377,
+                "100.0" : 0.16300641354241377
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.16231842690191367,
+                    0.16232666279258515,
+                    0.16300641354241377
+                ],
+                [
+                    0.1567498539743248,
+                    0.15647168762810784,
+                    0.15700573794608513
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.40076242964666536,
+            "scoreError" : 0.05210576923286294,
+            "scoreConfidence" : [
+                0.34865666041380244,
+                0.4528681988795283
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.3833180379853578,
+                "50.0" : 0.400410158716933,
+                "90.0" : 0.4196555934955938,
+                "95.0" : 0.4196555934955938,
+                "99.0" : 0.4196555934955938,
+                "99.9" : 0.4196555934955938,
+                "99.99" : 0.4196555934955938,
+                "99.999" : 0.4196555934955938,
+                "99.9999" : 0.4196555934955938,
+                "100.0" : 0.4196555934955938
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.3840235414922622,
+                    0.3841494757606023,
+                    0.3833180379853578
+                ],
+                [
+                    0.4196555934955938,
+                    0.4167570874729121,
+                    0.4166708416732636
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkOverlapNoFrag",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.14466996328558393,
+            "scoreError" : 0.010331058643012217,
+            "scoreConfidence" : [
+                0.1343389046425717,
+                0.15500102192859616
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.14133061062509716,
+                "50.0" : 0.14402110896009784,
+                "90.0" : 0.14875102729517464,
+                "95.0" : 0.14875102729517464,
+                "99.0" : 0.14875102729517464,
+                "99.9" : 0.14875102729517464,
+                "99.99" : 0.14875102729517464,
+                "99.999" : 0.14875102729517464,
+                "99.9999" : 0.14875102729517464,
+                "100.0" : 0.14875102729517464
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.14133061062509716,
+                    0.14140120891660304,
+                    0.1413888687224296
+                ],
+                [
+                    0.14875102729517464,
+                    0.14850705515060644,
+                    0.14664100900359264
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.benchmarkRepeatedFields",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 0.04298514712457707,
+            "scoreError" : 0.003358187074374902,
+            "scoreConfidence" : [
+                0.03962696005020217,
+                0.04634333419895197
+            ],
+            "scorePercentiles" : {
+                "0.0" : 0.041619429635086316,
+                "50.0" : 0.043123010360141156,
+                "90.0" : 0.04428151791826632,
+                "95.0" : 0.04428151791826632,
+                "99.0" : 0.04428151791826632,
+                "99.9" : 0.04428151791826632,
+                "99.99" : 0.04428151791826632,
+                "99.999" : 0.04428151791826632,
+                "99.9999" : 0.04428151791826632,
+                "100.0" : 0.04428151791826632
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    0.042314375568061606,
+                    0.041819431649290965,
+                    0.041619429635086316
+                ],
+                [
+                    0.04428151791826632,
+                    0.0439444828245365,
+                    0.04393164515222071
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "performance.OverlappingFieldValidationPerformance.overlappingFieldValidationAvgTime",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/home/ec2-user/.sdkman/candidates/java/17.0.10-amzn/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "17.0.10",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.10+7-LTS",
+        "warmupIterations" : 2,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "size" : "100"
+        },
+        "primaryMetric" : {
+            "score" : 7718866.652108355,
+            "scoreError" : 92716.77270325882,
+            "scoreConfidence" : [
+                7626149.879405096,
+                7811583.424811615
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7679718.765924789,
+                "50.0" : 7719139.208552358,
+                "90.0" : 7753458.668217055,
+                "95.0" : 7753458.668217055,
+                "99.0" : 7753458.668217055,
+                "99.9" : 7753458.668217055,
+                "99.99" : 7753458.668217055,
+                "99.999" : 7753458.668217055,
+                "99.9999" : 7753458.668217055,
+                "100.0" : 7753458.668217055
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    7753458.668217055,
+                    7752822.444186047,
+                    7737673.30317092
+                ],
+                [
+                    7688921.617217525,
+                    7700605.113933795,
+                    7679718.765924789
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+


### PR DESCRIPTION
Backfills some missing performance statistics from November 2025 up until March 2026

Of course it's May 2026 now, so the pipeline has to be fixed again. Next on the list!