### PR TITLE
Add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- add a 7-day cooldown to Dependabot Gradle version updates
- add a 7-day cooldown to Dependabot GitHub Actions version updates

## Testing
- ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); puts 'dependabot.yml is valid YAML'"