### PR TITLE
Allow empty unions to be completed by extensions

### DIFF
--- a/src/main/java/graphql/schema/idl/SchemaTypeExtensionsChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeExtensionsChecker.java
@@ -16,6 +16,7 @@ import graphql.language.ScalarTypeDefinition;
 import graphql.language.TypeDefinition;
 import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
+import graphql.language.UnionTypeExtensionDefinition;
 import graphql.schema.idl.errors.MissingTypeError;
 import graphql.schema.idl.errors.NonUniqueArgumentError;
 import graphql.schema.idl.errors.NonUniqueNameError;
@@ -158,24 +159,62 @@ class SchemaTypeExtensionsChecker {
         typeRegistry.unionTypeExtensions()
                 .forEach((name, extensions) -> {
                     checkTypeExtensionHasCorrespondingType(errors, typeRegistry, name, extensions, UnionTypeDefinition.class);
+                    Set<String> previousMemberTypes = unionMemberTypes(typeRegistry, name);
 
-                    extensions.forEach(extension -> {
-                        List<TypeName> memberTypes = extension.getMemberTypes().stream()
-                                .map(t -> TypeInfo.typeInfo(t).getTypeName()).collect(Collectors.toList());
-
-                        checkNamedUniqueness(errors, memberTypes, TypeName::getName,
-                                (namedMember, memberType) -> new NonUniqueNameError(extension, namedMember));
-
-                        memberTypes.forEach(
-                                memberType -> {
-                                    ObjectTypeDefinition unionTypeDefinition = typeRegistry.getTypeOrNull(memberType, ObjectTypeDefinition.class);
-                                    if (unionTypeDefinition == null) {
-                                        errors.add(new MissingTypeError("union member", extension, memberType));
-                                    }
-                                }
-                        );
-                    });
+                    extensions.forEach(extension -> checkUnionTypeExtension(errors, typeRegistry, previousMemberTypes, extension));
                 });
+    }
+
+    private void checkUnionTypeExtension(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, Set<String> previousMemberTypes, UnionTypeExtensionDefinition extension) {
+        List<TypeName> memberTypes = extension.getMemberTypes().stream()
+                .map(t -> TypeInfo.typeInfo(t).getTypeName()).collect(Collectors.toList());
+
+        checkNamedUniqueness(errors, memberTypes, TypeName::getName,
+                (namedMember, memberType) -> new NonUniqueNameError(extension, namedMember));
+
+        memberTypes.forEach(memberType -> checkUnionMemberTypeExists(errors, typeRegistry, extension, memberType));
+        checkUnionMemberTypesAreNew(errors, previousMemberTypes, extension, memberTypes);
+    }
+
+    private void checkUnionMemberTypeExists(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, UnionTypeExtensionDefinition extension, TypeName memberType) {
+        ObjectTypeDefinition unionTypeDefinition = typeRegistry.getTypeOrNull(memberType, ObjectTypeDefinition.class);
+        if (unionTypeDefinition != null) {
+            return;
+        }
+        errors.add(new MissingTypeError("union member", extension, memberType));
+    }
+
+    private void checkUnionMemberTypesAreNew(List<GraphQLError> errors, Set<String> previousMemberTypes, UnionTypeExtensionDefinition extension, List<TypeName> memberTypes) {
+        Set<String> duplicateMemberTypes = duplicateMemberTypes(memberTypes);
+        memberTypes.stream()
+                .filter(memberType -> !duplicateMemberTypes.contains(memberType.getName()))
+                .filter(memberType -> previousMemberTypes.contains(memberType.getName()))
+                .forEach(memberType -> errors.add(new NonUniqueNameError(extension, memberType.getName())));
+
+        memberTypes.forEach(memberType -> previousMemberTypes.add(memberType.getName()));
+    }
+
+    private Set<String> duplicateMemberTypes(List<TypeName> memberTypes) {
+        Set<String> seen = new HashSet<>();
+        Set<String> duplicates = new HashSet<>();
+        memberTypes.forEach(memberType -> {
+            if (!seen.add(memberType.getName())) {
+                duplicates.add(memberType.getName());
+            }
+        });
+        return duplicates;
+    }
+
+    private Set<String> unionMemberTypes(TypeDefinitionRegistry typeRegistry, String name) {
+        Set<String> memberTypes = new HashSet<>();
+        UnionTypeDefinition baseTypeDef = typeRegistry.getTypeOrNull(name, UnionTypeDefinition.class);
+        if (baseTypeDef == null) {
+            return memberTypes;
+        }
+        baseTypeDef.getMemberTypes().stream()
+                .map(t -> TypeInfo.typeInfo(t).getTypeName().getName())
+                .forEach(memberTypes::add);
+        return memberTypes;
     }
 
     /*

--- a/src/main/java/graphql/schema/idl/UnionTypesChecker.java
+++ b/src/main/java/graphql/schema/idl/UnionTypesChecker.java
@@ -13,9 +13,9 @@ import graphql.schema.idl.errors.UnionTypeError;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 
 /**
  * UnionType check, details in https://spec.graphql.org/June2018/#sec-Type-System.
@@ -33,18 +33,15 @@ class UnionTypesChecker {
 
     void checkUnionType(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
         List<UnionTypeDefinition> unionTypes = typeRegistry.getTypes(UnionTypeDefinition.class);
-        List<UnionTypeExtensionDefinition> unionTypeExtensions = typeRegistry.getTypes(UnionTypeExtensionDefinition.class);
 
-        Stream.concat(unionTypes.stream(), unionTypeExtensions.stream())
-                .forEach(type -> checkUnionType(typeRegistry, type, errors));
+        unionTypes.forEach(type -> checkUnionType(typeRegistry, type, errors));
     }
 
     private void checkUnionType(TypeDefinitionRegistry typeRegistry, UnionTypeDefinition unionTypeDefinition, List<GraphQLError> errors) {
         assertTypeName(unionTypeDefinition, errors);
 
-        //noinspection rawtypes
         List<Type> memberTypes = unionTypeDefinition.getMemberTypes();
-        if (memberTypes == null || memberTypes.isEmpty()) {
+        if (!hasMemberTypes(typeRegistry, unionTypeDefinition)) {
             errors.add(new UnionTypeError(unionTypeDefinition, format("Union type '%s' must include one or more member types.", unionTypeDefinition.getName())));
             return;
         }
@@ -64,6 +61,16 @@ class UnionTypesChecker {
             }
             typeNames.add(memberTypeName);
         }
+    }
+
+    private boolean hasMemberTypes(TypeDefinitionRegistry typeRegistry, UnionTypeDefinition unionTypeDefinition) {
+        if (!unionTypeDefinition.getMemberTypes().isEmpty()) {
+            return true;
+        }
+
+        List<UnionTypeExtensionDefinition> extensions = typeRegistry.unionTypeExtensions()
+                .getOrDefault(unionTypeDefinition.getName(), emptyList());
+        return extensions.stream().anyMatch(extension -> !extension.getMemberTypes().isEmpty());
     }
 
     private void assertTypeName(UnionTypeDefinition unionTypeDefinition, List<GraphQLError> errors) {

--- a/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaGeneratorTest.groovy
@@ -29,6 +29,7 @@ import graphql.schema.idl.errors.NotAnInputTypeError
 import graphql.schema.idl.errors.NotAnOutputTypeError
 import graphql.schema.idl.errors.SchemaProblem
 import graphql.schema.visibility.GraphqlFieldVisibility
+import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.function.UnaryOperator
@@ -1528,6 +1529,64 @@ class SchemaGeneratorTest extends Specification {
         unionType.types.stream().anyMatch({ t -> (t.getName() == "Bar") })
         unionType.types.stream().anyMatch({ t -> (t.getName() == "Baz") })
         unionType.directivesByName.containsKey("directive")
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/4200")
+    def "empty union base definition gets member types from extension"() {
+        def spec = """
+            type Cat {
+                meow: String
+            }
+
+            type Dog {
+                bark: String
+            }
+
+            union Pet
+
+            extend union Pet = Cat | Dog
+
+            type Query {
+                pet: Pet
+            }
+        """
+
+        when:
+        def schema = schema(spec)
+        GraphQLUnionType unionType = schema.getType("Pet") as GraphQLUnionType
+
+        then:
+        unionType.types*.name == ["Cat", "Dog"]
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/4200")
+    def "empty union base definition gets member types from multiple extensions"() {
+        def spec = """
+            type Cat {
+                meow: String
+            }
+
+            type Dog {
+                bark: String
+            }
+
+            union Pet
+
+            extend union Pet = | Cat
+
+            extend union Pet = Dog
+
+            type Query {
+                pet: Pet
+            }
+        """
+
+        when:
+        def schema = schema(spec)
+        GraphQLUnionType unionType = schema.getType("Pet") as GraphQLUnionType
+
+        then:
+        unionType.types*.name == ["Cat", "Dog"]
     }
 
     def "enum extension types are combined"() {

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -1179,7 +1179,7 @@ class SchemaTypeCheckerTest extends Specification {
 
         expect:
 
-        result.size() == 3
+        result.size() == 4
         errorContaining(result, "The extension 'NonExistent' type [@n:n] is missing its base underlying type")
         errorContaining(result, "The union member type 'Buzz' is not present when resolving type 'FooBar' [@n:n]")
         errorContaining(result, "The type 'FooBar' [@n:n] has declared an union member with a non unique name 'Foo'")
@@ -1785,6 +1785,52 @@ class SchemaTypeCheckerTest extends Specification {
 
         then:
         errorContaining(result, "Union type 'UnionType' must include one or more member types.")
+    }
+
+    def "union type with directive only extension must include one or more member types"() {
+        given:
+        def sdl = """
+            directive @directive on UNION
+
+            type Query { hello: String }
+
+            union UnionType
+
+            extend union UnionType @directive
+        """
+
+        when:
+        def result = check(sdl)
+
+        then:
+        errorContaining(result, "Union type 'UnionType' must include one or more member types.")
+    }
+
+    @Unroll
+    def "union extension must not redefine member types from previous union type: #scenario"() {
+        given:
+        def sdl = """
+            type Query { pet: Pet }
+
+            type Cat {
+                id: ID
+            }
+
+            union Pet $baseMembers
+
+            $extensions
+        """
+
+        when:
+        def result = check(sdl)
+
+        then:
+        errorContaining(result, "The type 'Pet' [@n:n] has declared an union member with a non unique name 'Cat'")
+
+        where:
+        scenario             | baseMembers | extensions
+        "base definition"    | "= Cat"     | "extend union Pet = Cat"
+        "earlier extension"  | ""          | "extend union Pet = Cat\nextend union Pet = Cat"
     }
 
     def "The member types of a Union type must all be object base types"() {


### PR DESCRIPTION
## Summary
- Allow SDL union definitions with no base members when union extensions provide members
- Keep truly empty unions invalid, including directive-only extensions
- Validate union extension members against the previous effective union so duplicates across the base definition or earlier extensions are rejected
- Add regression coverage for #4200 and additional draft-spec union extension cases

Fixes #4200

## Testing
- ./gradlew test --tests graphql.schema.idl.SchemaGeneratorTest --tests graphql.schema.idl.SchemaTypeCheckerTest