### PR TITLE
Add failing schema rebuild repros for issue 3384

### DIFF
--- a/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
@@ -6,12 +6,20 @@ import graphql.NestedInputSchema
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLAppliedDirectiveArgument
 import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLSchemaElement
 import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeVisitorStub
 import graphql.schema.GraphQLTypeReference
 import graphql.schema.GraphQLUnionType
+import graphql.schema.SchemaTransformer
+import graphql.util.TraversalControl
+import graphql.util.TraverserContext
+import spock.lang.Issue
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLBoolean
@@ -41,6 +49,7 @@ import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField
 import static graphql.schema.GraphQLInputObjectType.newInputObject
+import static graphql.schema.GraphQLInterfaceType.newInterface
 import static graphql.schema.GraphQLList.list
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
@@ -188,6 +197,74 @@ class SchemaUtilTest extends Specification {
         pet.types.findIndexOf { it instanceof GraphQLTypeReference } == -1
         person.interfaces.findIndexOf { it instanceof GraphQLTypeReference } == -1
         !(cacheEnabled.getType() instanceof GraphQLTypeReference)
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
+    def "can rebuild schema after removing root type that made an implemented interface reachable"() {
+        given:
+        def schema = issue3384Schema()
+        def node = schema.getType("Node")
+
+        when:
+        def rebuiltSchema = newSchema(schema)
+                .mutation((GraphQLObjectType) null)
+                .build()
+
+        then:
+        rebuiltSchema.getMutationType() == null
+        rebuiltSchema.getType("Node") == node
+        rebuiltSchema.getObjectType("Person").interfaces == [node]
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
+    def "can transform schema after deleting root type that made an implemented interface reachable"() {
+        given:
+        def schema = issue3384Schema()
+        def node = schema.getType("Node")
+
+        when:
+        def transformedSchema = SchemaTransformer.transformSchemaWithDeletes(schema, new GraphQLTypeVisitorStub() {
+            @Override
+            TraversalControl visitGraphQLObjectType(GraphQLObjectType graphQLObjectType, TraverserContext<GraphQLSchemaElement> context) {
+                if (graphQLObjectType.name == "Mutation") {
+                    return deleteNode(context)
+                }
+                return TraversalControl.CONTINUE
+            }
+        })
+
+        then:
+        transformedSchema.getMutationType() == null
+        transformedSchema.getType("Node") == node
+        transformedSchema.getObjectType("Person").interfaces == [node]
+    }
+
+    private GraphQLSchema issue3384Schema() {
+        def node = newInterface()
+                .name("Node")
+                .field(newFieldDefinition().name("id").type(GraphQLString))
+                .build()
+        def person = newObject()
+                .name("Person")
+                .withInterface(typeRef("Node"))
+                .field(newFieldDefinition().name("id").type(GraphQLString))
+                .build()
+        def query = newObject()
+                .name("Query")
+                .field(newFieldDefinition().name("person").type(person))
+                .build()
+        def mutation = newObject()
+                .name("Mutation")
+                .field(newFieldDefinition().name("node").type(node))
+                .build()
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(node, { env -> person })
+                .build()
+        return newSchema()
+                .query(query)
+                .mutation(mutation)
+                .codeRegistry(codeRegistry)
+                .build()
     }
 
     def "redefined types are caught"() {


### PR DESCRIPTION
## Summary

This PR intentionally adds failing Spock tests for https://github.com/graphql-java/graphql-java/issues/3384.

It covers two paths:

- rebuilding a schema with `GraphQLSchema.newSchema(schema).mutation((GraphQLObjectType) null).build()`
- deleting the mutation root via `SchemaTransformer.transformSchemaWithDeletes(...)`, which is the traversal-based schema modification API for delete operations

Both tests currently fail with the same `NullPointerException` in `GraphQLTypeResolvingVisitor.visitGraphQLObjectType`, reached from `SchemaUtil.replaceTypeReferences`.

## Findings

The traversal-based variant does not avoid the problem. Even with `transformSchemaWithDeletes(...)`, the rebuilt schema loses the `Node` interface from the type map while `Person` still has a resolved `Node` interface. During `replaceTypeReferences`, `GraphQLTypeResolvingVisitor` maps `Person.getInterfaces()` through the rebuilt type map and receives `null` for `Node`.

My current assumption is that the issue is in the schema rebuild/type collection path. In particular, `GraphQLTypeCollectingVisitor` accounts for dangling replaced strong references from fields, arguments, input fields, and applied directive arguments, but not from object/interface implemented interfaces. `SchemaTransformer.DummyRoot.rebuildSchema(...)` also only promotes changed extra types into additional types; in this repro `Node` is visited as an extra type but unchanged, so it is not retained as an additional type.

## Verification

This command is expected to fail on this PR:

```bash
./gradlew test --tests "graphql.schema.impl.SchemaUtilTest.can rebuild schema after removing root type that made an implemented interface reachable" --tests "graphql.schema.impl.SchemaUtilTest.can transform schema after deleting root type that made an implemented interface reachable"
```

Observed result: 2 tests run, 2 failed, both in `GraphQLTypeResolvingVisitor.visitGraphQLObjectType`.

`git diff --check` passes.
