### PR TITLE
Fix schema rebuild after root type deletion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -607,11 +607,13 @@ tasks.register('markGeneratedEqualsHashCode') {
     def jacocoDir = layout.buildDirectory.dir('classes-jacoco/java/main')
 
     inputs.dir(originalDir)
+    inputs.property("generatedAnnotationTaskVersion", 2)
     outputs.dir(jacocoDir)
 
     doLast {
         def src = originalDir.get().asFile
         def dest = jacocoDir.get().asFile
+        project.delete(dest)
         if (!src.exists()) return
 
         // Copy all class files to a separate directory for JaCoCo
@@ -635,8 +637,10 @@ tasks.register('markGeneratedEqualsHashCode') {
                     if (method.invisibleAnnotations == null) {
                         method.invisibleAnnotations = []
                     }
-                    method.invisibleAnnotations.add(new org.objectweb.asm.tree.AnnotationNode(ANNOTATION))
-                    modified = true
+                    if (!method.invisibleAnnotations.any { it.desc == ANNOTATION }) {
+                        method.invisibleAnnotations.add(new org.objectweb.asm.tree.AnnotationNode(ANNOTATION))
+                        modified = true
+                    }
                 }
             }
 
@@ -797,6 +801,5 @@ tasks.withType(PublishToMavenRepository) {
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
-
 
 

--- a/src/main/java/graphql/schema/impl/GraphQLTypeCollectingVisitor.java
+++ b/src/main/java/graphql/schema/impl/GraphQLTypeCollectingVisitor.java
@@ -27,7 +27,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Supplier;
 
 import static graphql.schema.GraphQLTypeUtil.unwrapAllAs;
 import static graphql.util.TraversalControl.CONTINUE;
@@ -43,8 +42,9 @@ import static java.lang.String.format;
  * themselves are not collected - only concrete type instances are stored in the result map.
  * <p>
  * Because type references are not followed, this visitor also tracks "indirect strong references"
- * - types that are directly referenced (not via type reference) by fields, arguments, and input
- * fields. This handles edge cases where schema transformations replace type references with
+ * - types that are directly referenced (not via type reference) by fields, arguments,
+ * input fields, implemented interfaces, and union members. This handles edge cases where
+ * schema transformations replace type references with
  * actual types, which would otherwise be missed during traversal.
  *
  * @see SchemaUtil#visitPartiallySchema
@@ -77,6 +77,7 @@ public class GraphQLTypeCollectingVisitor extends GraphQLTypeVisitorStub {
     public TraversalControl visitGraphQLObjectType(GraphQLObjectType node, TraverserContext<GraphQLSchemaElement> context) {
         assertTypeUniqueness(node, result);
         save(node.getName(), node);
+        saveIndirectStrongReferences(node.getInterfaces());
         return CONTINUE;
     }
 
@@ -91,6 +92,7 @@ public class GraphQLTypeCollectingVisitor extends GraphQLTypeVisitorStub {
     public TraversalControl visitGraphQLInterfaceType(GraphQLInterfaceType node, TraverserContext<GraphQLSchemaElement> context) {
         assertTypeUniqueness(node, result);
         save(node.getName(), node);
+        saveIndirectStrongReferences(node.getInterfaces());
         return CONTINUE;
     }
 
@@ -98,37 +100,44 @@ public class GraphQLTypeCollectingVisitor extends GraphQLTypeVisitorStub {
     public TraversalControl visitGraphQLUnionType(GraphQLUnionType node, TraverserContext<GraphQLSchemaElement> context) {
         assertTypeUniqueness(node, result);
         save(node.getName(), node);
+        saveIndirectStrongReferences(node.getTypes());
         return CONTINUE;
     }
 
     @Override
     public TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
-        saveIndirectStrongReference(node::getType);
+        saveIndirectStrongReference(node.getType());
         return CONTINUE;
     }
 
     @Override
     public TraversalControl visitGraphQLInputObjectField(GraphQLInputObjectField node, TraverserContext<GraphQLSchemaElement> context) {
-        saveIndirectStrongReference(node::getType);
+        saveIndirectStrongReference(node.getType());
         return CONTINUE;
     }
 
     @Override
     public TraversalControl visitGraphQLArgument(GraphQLArgument node, TraverserContext<GraphQLSchemaElement> context) {
-        saveIndirectStrongReference(node::getType);
+        saveIndirectStrongReference(node.getType());
         return CONTINUE;
     }
 
     @Override
     public TraversalControl visitGraphQLAppliedDirectiveArgument(GraphQLAppliedDirectiveArgument node, TraverserContext<GraphQLSchemaElement> context) {
-        saveIndirectStrongReference(node::getType);
+        saveIndirectStrongReference(node.getType());
         return CONTINUE;
     }
 
-    private void saveIndirectStrongReference(Supplier<GraphQLType> typeSupplier) {
-        GraphQLNamedType type = unwrapAllAs(typeSupplier.get());
+    private void saveIndirectStrongReference(GraphQLType graphQLType) {
+        GraphQLNamedType type = unwrapAllAs(graphQLType);
         if (!(type instanceof GraphQLTypeReference)) {
             indirectStrongReferences.put(type.getName(), type);
+        }
+    }
+
+    private void saveIndirectStrongReferences(List<? extends GraphQLType> types) {
+        for (GraphQLType type : types) {
+            saveIndirectStrongReference(type);
         }
     }
 

--- a/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
@@ -19,7 +19,6 @@ import graphql.schema.GraphQLUnionType
 import graphql.schema.SchemaTransformer
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
-import spock.lang.Issue
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLBoolean
@@ -199,7 +198,6 @@ class SchemaUtilTest extends Specification {
         !(cacheEnabled.getType() instanceof GraphQLTypeReference)
     }
 
-    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
     def "can rebuild schema after removing root type that made an implemented interface reachable"() {
         given:
         def schema = issue3384Schema()
@@ -216,7 +214,6 @@ class SchemaUtilTest extends Specification {
         rebuiltSchema.getObjectType("Person").interfaces == [node]
     }
 
-    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
     def "can transform schema after deleting root type that made an implemented interface reachable"() {
         given:
         def schema = issue3384Schema()
@@ -239,7 +236,6 @@ class SchemaUtilTest extends Specification {
         transformedSchema.getObjectType("Person").interfaces == [node]
     }
 
-    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
     def "can rebuild schema after removing root type that made a union member reachable"() {
         given:
         def schema = issue3384UnionSchema()
@@ -256,7 +252,6 @@ class SchemaUtilTest extends Specification {
         rebuiltSchema.getType("Pet").types == [cat]
     }
 
-    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
     def "can rebuild schema after removing root type that made an interface implemented by another interface reachable"() {
         given:
         def schema = issue3384InterfaceInheritanceSchema()

--- a/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
@@ -6,12 +6,20 @@ import graphql.NestedInputSchema
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLAppliedDirectiveArgument
 import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLSchemaElement
 import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeVisitorStub
 import graphql.schema.GraphQLTypeReference
 import graphql.schema.GraphQLUnionType
+import graphql.schema.SchemaTransformer
+import graphql.util.TraversalControl
+import graphql.util.TraverserContext
+import spock.lang.Issue
 import spock.lang.Specification
 
 import static graphql.Scalars.GraphQLBoolean
@@ -41,6 +49,7 @@ import static graphql.schema.GraphQLArgument.newArgument
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField
 import static graphql.schema.GraphQLInputObjectType.newInputObject
+import static graphql.schema.GraphQLInterfaceType.newInterface
 import static graphql.schema.GraphQLList.list
 import static graphql.schema.GraphQLObjectType.newObject
 import static graphql.schema.GraphQLSchema.newSchema
@@ -188,6 +197,74 @@ class SchemaUtilTest extends Specification {
         pet.types.findIndexOf { it instanceof GraphQLTypeReference } == -1
         person.interfaces.findIndexOf { it instanceof GraphQLTypeReference } == -1
         !(cacheEnabled.getType() instanceof GraphQLTypeReference)
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
+    def "can rebuild schema after removing root type that made an implemented interface reachable"() {
+        given:
+        def schema = issue3384Schema()
+        def node = schema.getType("Node")
+
+        when:
+        def rebuiltSchema = newSchema(schema)
+                .mutation((GraphQLObjectType) null)
+                .build()
+
+        then:
+        rebuiltSchema.getMutationType() == null
+        rebuiltSchema.getType("Node") == node
+        rebuiltSchema.getObjectType("Person").interfaces == [node]
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
+    def "can transform schema after deleting root type that made an implemented interface reachable"() {
+        given:
+        def schema = issue3384Schema()
+        def node = schema.getType("Node")
+
+        when:
+        def transformedSchema = SchemaTransformer.transformSchemaWithDeletes(schema, new GraphQLTypeVisitorStub() {
+            @Override
+            TraversalControl visitGraphQLObjectType(GraphQLObjectType graphQLObjectType, TraverserContext<GraphQLSchemaElement> context) {
+                if (graphQLObjectType.name == "Mutation") {
+                    return deleteNode(context)
+                }
+                return TraversalControl.CONTINUE
+            }
+        })
+
+        then:
+        transformedSchema.getMutationType() == null
+        transformedSchema.getType("Node") == node
+        transformedSchema.getObjectType("Person").interfaces == [node]
+    }
+
+    private GraphQLSchema issue3384Schema() {
+        def node = newInterface()
+                .name("Node")
+                .field(newFieldDefinition().name("id").type(GraphQLString))
+                .build()
+        def person = newObject()
+                .name("Person")
+                .withInterface(typeRef("Node"))
+                .field(newFieldDefinition().name("id").type(GraphQLString))
+                .build()
+        def query = newObject()
+                .name("Query")
+                .field(newFieldDefinition().name("person").type(person))
+                .build()
+        def mutation = newObject()
+                .name("Mutation")
+                .field(newFieldDefinition().name("node").type(node))
+                .build()
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(node, { env -> person })
+                .build()
+        return newSchema()
+                .query(query)
+                .mutation(mutation)
+                .codeRegistry(codeRegistry)
+                .build()
     }
 
     def "redefined types are caught"() {

--- a/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
@@ -200,7 +200,7 @@ class SchemaUtilTest extends Specification {
 
     def "can rebuild schema after removing root type that made an implemented interface reachable"() {
         given:
-        def schema = issue3384Schema()
+        def schema = schemaWithObjectImplementingInterfaceThroughTypeReference()
         def node = schema.getType("Node")
 
         when:
@@ -216,7 +216,7 @@ class SchemaUtilTest extends Specification {
 
     def "can transform schema after deleting root type that made an implemented interface reachable"() {
         given:
-        def schema = issue3384Schema()
+        def schema = schemaWithObjectImplementingInterfaceThroughTypeReference()
         def node = schema.getType("Node")
 
         when:
@@ -238,7 +238,7 @@ class SchemaUtilTest extends Specification {
 
     def "can rebuild schema after removing root type that made a union member reachable"() {
         given:
-        def schema = issue3384UnionSchema()
+        def schema = schemaWithUnionMemberThroughTypeReference()
         def cat = schema.getObjectType("Cat")
 
         when:
@@ -254,7 +254,7 @@ class SchemaUtilTest extends Specification {
 
     def "can rebuild schema after removing root type that made an interface implemented by another interface reachable"() {
         given:
-        def schema = issue3384InterfaceInheritanceSchema()
+        def schema = schemaWithInterfaceImplementingInterfaceThroughTypeReference()
         def node = schema.getType("Node")
 
         when:
@@ -268,7 +268,7 @@ class SchemaUtilTest extends Specification {
         rebuiltSchema.getType("NamedNode").interfaces == [node]
     }
 
-    private GraphQLSchema issue3384Schema() {
+    private GraphQLSchema schemaWithObjectImplementingInterfaceThroughTypeReference() {
         def node = newInterface()
                 .name("Node")
                 .field(newFieldDefinition().name("id").type(GraphQLString))
@@ -296,7 +296,7 @@ class SchemaUtilTest extends Specification {
                 .build()
     }
 
-    private GraphQLSchema issue3384UnionSchema() {
+    private GraphQLSchema schemaWithUnionMemberThroughTypeReference() {
         def cat = newObject()
                 .name("Cat")
                 .field(newFieldDefinition().name("name").type(GraphQLString))
@@ -323,7 +323,7 @@ class SchemaUtilTest extends Specification {
                 .build()
     }
 
-    private GraphQLSchema issue3384InterfaceInheritanceSchema() {
+    private GraphQLSchema schemaWithInterfaceImplementingInterfaceThroughTypeReference() {
         def node = newInterface()
                 .name("Node")
                 .field(newFieldDefinition().name("id").type(GraphQLString))

--- a/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/impl/SchemaUtilTest.groovy
@@ -239,6 +239,40 @@ class SchemaUtilTest extends Specification {
         transformedSchema.getObjectType("Person").interfaces == [node]
     }
 
+    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
+    def "can rebuild schema after removing root type that made a union member reachable"() {
+        given:
+        def schema = issue3384UnionSchema()
+        def cat = schema.getObjectType("Cat")
+
+        when:
+        def rebuiltSchema = newSchema(schema)
+                .mutation((GraphQLObjectType) null)
+                .build()
+
+        then:
+        rebuiltSchema.getMutationType() == null
+        rebuiltSchema.getType("Cat") == cat
+        rebuiltSchema.getType("Pet").types == [cat]
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/3384")
+    def "can rebuild schema after removing root type that made an interface implemented by another interface reachable"() {
+        given:
+        def schema = issue3384InterfaceInheritanceSchema()
+        def node = schema.getType("Node")
+
+        when:
+        def rebuiltSchema = newSchema(schema)
+                .mutation((GraphQLObjectType) null)
+                .build()
+
+        then:
+        rebuiltSchema.getMutationType() == null
+        rebuiltSchema.getType("Node") == node
+        rebuiltSchema.getType("NamedNode").interfaces == [node]
+    }
+
     private GraphQLSchema issue3384Schema() {
         def node = newInterface()
                 .name("Node")
@@ -259,6 +293,63 @@ class SchemaUtilTest extends Specification {
                 .build()
         def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
                 .typeResolver(node, { env -> person })
+                .build()
+        return newSchema()
+                .query(query)
+                .mutation(mutation)
+                .codeRegistry(codeRegistry)
+                .build()
+    }
+
+    private GraphQLSchema issue3384UnionSchema() {
+        def cat = newObject()
+                .name("Cat")
+                .field(newFieldDefinition().name("name").type(GraphQLString))
+                .build()
+        def pet = GraphQLUnionType.newUnionType()
+                .name("Pet")
+                .possibleType(typeRef("Cat"))
+                .build()
+        def query = newObject()
+                .name("Query")
+                .field(newFieldDefinition().name("pet").type(pet))
+                .build()
+        def mutation = newObject()
+                .name("Mutation")
+                .field(newFieldDefinition().name("cat").type(cat))
+                .build()
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(pet, { env -> cat })
+                .build()
+        return newSchema()
+                .query(query)
+                .mutation(mutation)
+                .codeRegistry(codeRegistry)
+                .build()
+    }
+
+    private GraphQLSchema issue3384InterfaceInheritanceSchema() {
+        def node = newInterface()
+                .name("Node")
+                .field(newFieldDefinition().name("id").type(GraphQLString))
+                .build()
+        def namedNode = newInterface()
+                .name("NamedNode")
+                .withInterface(typeRef("Node"))
+                .field(newFieldDefinition().name("id").type(GraphQLString))
+                .field(newFieldDefinition().name("name").type(GraphQLString))
+                .build()
+        def query = newObject()
+                .name("Query")
+                .field(newFieldDefinition().name("node").type(namedNode))
+                .build()
+        def mutation = newObject()
+                .name("Mutation")
+                .field(newFieldDefinition().name("node").type(node))
+                .build()
+        def codeRegistry = GraphQLCodeRegistry.newCodeRegistry()
+                .typeResolver(node, { env -> null })
+                .typeResolver(namedNode, { env -> null })
                 .build()
         return newSchema()
                 .query(query)


### PR DESCRIPTION
## Summary

Fixes https://github.com/graphql-java/graphql-java/issues/3384.

The core issue is that a built `GraphQLSchema` can contain two views of the same relationship:

- the original child list used for rebuild traversal, which may still contain `GraphQLTypeReference("Node")`
- the resolved accessor view used by runtime/schema APIs, where `Person.getInterfaces()` returns the actual `GraphQLInterfaceType Node` instance

In the #3384 repro, `Person` was originally created with `.withInterface(typeRef("Node"))`. During schema build, that reference is resolved and `Person.getInterfaces()` starts returning the real `Node` interface. Later, when the mutation root is removed, `Node` is no longer reachable through the deleted mutation field. The rebuilt schema still reaches `Person` from `Query`, and `Person` still implements `Node`, so `Node` must remain in the rebuilt type map.

The catch is that schema build collection intentionally traverses `getChildrenWithTypeReferences()`. For `Person`, that traversal sees the original `GraphQLTypeReference("Node")`, not the already-resolved `Node` object returned by `Person.getInterfaces()`. So the collector can visit `Person` without collecting the resolved `Node` interface. Later, `GraphQLTypeResolvingVisitor` uses `Person.getInterfaces()`, looks up `Node` in the rebuilt type map, and fails because `Node` was missed during collection.

This is what the code calls an indirect strong reference:

- indirect: the traverser did not visit it as a normal child node, because the child list exposes the original type reference
- strong: the schema element already holds the actual `GraphQLNamedType` object through an accessor such as `getInterfaces()` or `getTypes()`

`GraphQLTypeCollectingVisitor` already handled this pattern for field, argument, input field, and applied directive argument types. This PR extends the same collection logic to:

- object implemented interfaces
- interface implemented interfaces
- union member types

The same original-reference versus resolved-accessor split exists for unions and interface inheritance:

- `GraphQLUnionType.getChildrenWithTypeReferences()` exposes original possible types, while `getTypes()` can return resolved object types
- `GraphQLInterfaceType.getChildrenWithTypeReferences()` exposes original implemented interfaces, while `getInterfaces()` can return resolved interfaces

This does not keep every deleted-path extra type alive. It only preserves resolved named types that are still referenced by a schema element that remains reachable in the rebuilt schema.

## Repro Coverage

Adds #3384 Spock coverage for these schema rebuild cases:

- object implementing an interface through a type reference
- union containing a member through a type reference
- interface implementing another interface through a type reference

The object/interface case is covered through both paths:

- direct rebuild with `GraphQLSchema.newSchema(schema).mutation((GraphQLObjectType) null).build()`
- traversal-based deletion with `SchemaTransformer.transformSchemaWithDeletes(...)`

The union and interface-inheritance cases specifically prove why `GraphQLTypeCollectingVisitor` needs to follow `getTypes()` and `getInterfaces()`, not just field/argument/input references.

Before the collector change, these cases fail during rebuild with an NPE in `GraphQLTypeResolvingVisitor`; they now pass.

## Local Test Stability

This PR also keeps the local build cleanup from the previous version of #4390: `markGeneratedEqualsHashCode` now cleans `classes-jacoco` before rewriting and does not append duplicate `graphql.coverage.Generated` annotations. That prevents local-only ArchUnit failures in `JMHForkArchRuleTest` after interrupted or repeated incremental runs.

## Verification

```bash
./gradlew test --tests "graphql.schema.impl.SchemaUtilTest.can rebuild schema after removing root type that made an implemented interface reachable" --tests "graphql.schema.impl.SchemaUtilTest.can transform schema after deleting root type that made an implemented interface reachable" --tests "graphql.schema.impl.SchemaUtilTest.can rebuild schema after removing root type that made a union member reachable" --tests "graphql.schema.impl.SchemaUtilTest.can rebuild schema after removing root type that made an interface implemented by another interface reachable"

./gradlew test --tests graphql.schema.impl.SchemaUtilTest
```

Also ran:

```bash
git diff --check
```
