### PR TITLE
Add executable description support

### DIFF
--- a/src/main/antlr/GraphqlOperation.g4
+++ b/src/main/antlr/GraphqlOperation.g4
@@ -3,11 +3,11 @@ import GraphqlCommon;
 
 operationDefinition:
 selectionSet |
-operationType  name? variableDefinitions? directives? selectionSet;
+description? operationType  name? variableDefinitions? directives? selectionSet;
 
 variableDefinitions : '(' variableDefinition+ ')';
 
-variableDefinition : variable ':' type defaultValue? directives?;
+variableDefinition : description? variable ':' type defaultValue? directives?;
 
 
 selectionSet :  '{' selection+ '}';
@@ -27,7 +27,7 @@ fragmentSpread : '...' fragmentName directives?;
 
 inlineFragment : '...' typeCondition? directives? selectionSet;
 
-fragmentDefinition : FRAGMENT fragmentName typeCondition directives? selectionSet;
+fragmentDefinition : description? FRAGMENT fragmentName typeCondition directives? selectionSet;
 
 
 typeCondition : ON_KEYWORD typeName;

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -249,8 +249,13 @@ public class AstPrinter {
         return false;
     }
 
+    private static boolean hasDescription(List<? extends Node<?>> nodes) {
+        return nodes.stream().anyMatch(AstPrinter::hasDescription);
+    }
+
     private NodePrinter<FragmentDefinition> fragmentDefinition() {
         return (out, node) -> {
+            description(out, node);
             out.append("fragment ");
             out.append(node.getName());
             out.append(" on ");
@@ -367,24 +372,17 @@ public class AstPrinter {
             String name = node.getName();
             // Anonymous queries with no directives or variable definitions can use
             // the query short form.
-            if (isEmpty(name) && isEmpty(node.getDirectives()) && isEmpty(node.getVariableDefinitions())
-                    && node.getOperation() == OperationDefinition.Operation.QUERY) {
+            if (canUseQueryShortForm(node)) {
                 node(out, node.getSelectionSet());
             } else {
+                description(out, node);
                 OperationDefinition.Operation op = node.getOperation();
                 out.append(op.toString().toLowerCase());
                 if (!isEmpty(name)) {
                     out.append(' ');
                     out.append(name);
                 }
-                if (!isEmpty(node.getVariableDefinitions())) {
-                    if (isEmpty(name)) {
-                        out.append(' ');
-                    }
-                    out.append('(');
-                    join(out, node.getVariableDefinitions(), argSep);
-                    out.append(')');
-                }
+                variableDefinitions(out, node, argSep);
                 if (!isEmpty(node.getDirectives())) {
                     out.append(' ');
                     directives(out, node.getDirectives());
@@ -395,6 +393,34 @@ public class AstPrinter {
                 node(out, node.getSelectionSet());
             }
         };
+    }
+
+    private boolean canUseQueryShortForm(OperationDefinition node) {
+        return (compactMode || !hasDescription(node))
+                && isEmpty(node.getName())
+                && isEmpty(node.getDirectives())
+                && isEmpty(node.getVariableDefinitions())
+                && node.getOperation() == OperationDefinition.Operation.QUERY;
+    }
+
+    private void variableDefinitions(StringBuilder out, OperationDefinition node, String argSep) {
+        if (isEmpty(node.getVariableDefinitions())) {
+            return;
+        }
+        if (isEmpty(node.getName())) {
+            out.append(' ');
+        }
+        if (!compactMode && hasDescription(node.getVariableDefinitions())) {
+            int offset = out.length();
+            out.append("(\n");
+            join(out, node.getVariableDefinitions(), "\n");
+            indent(out, offset);
+            out.append("\n)");
+            return;
+        }
+        out.append('(');
+        join(out, node.getVariableDefinitions(), argSep);
+        out.append(')');
     }
 
     private NodePrinter<OperationTypeDefinition> operationTypeDefinition() {
@@ -546,6 +572,7 @@ public class AstPrinter {
         String nameTypeSep = compactMode ? ":" : ": ";
         String defaultValueEquals = compactMode ? "=" : " = ";
         return (out, node) -> {
+            description(out, node);
             out.append('$');
             out.append(node.getName());
             out.append(nameTypeSep);

--- a/src/main/java/graphql/language/FragmentDefinition.java
+++ b/src/main/java/graphql/language/FragmentDefinition.java
@@ -27,7 +27,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
  */
 @PublicApi
 @NullMarked
-public class FragmentDefinition extends AbstractNode<FragmentDefinition> implements Definition<FragmentDefinition>, SelectionSetContainer<FragmentDefinition>, DirectivesContainer<FragmentDefinition>, NamedNode<FragmentDefinition> {
+public class FragmentDefinition extends AbstractDescribedNode<FragmentDefinition> implements Definition<FragmentDefinition>, SelectionSetContainer<FragmentDefinition>, DirectivesContainer<FragmentDefinition>, NamedNode<FragmentDefinition> {
 
     private final String name;
     private final TypeName typeCondition;
@@ -43,11 +43,12 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
                                  TypeName typeCondition,
                                  List<Directive> directives,
                                  SelectionSet selectionSet,
+                                 @Nullable Description description,
                                  @Nullable SourceLocation sourceLocation,
                                  List<Comment> comments,
                                  IgnoredChars ignoredChars,
                                  Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.typeCondition = typeCondition;
         this.directives = NodeUtil.DirectivesHolder.of(directives);
@@ -136,6 +137,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
                 assertNotNull(deepCopy(typeCondition)),
                 assertNotNull(deepCopy(directives.getDirectives())),
                 assertNotNull(deepCopy(selectionSet)),
+                description,
                 getSourceLocation(),
                 getComments(),
                 getIgnoredChars(),
@@ -174,6 +176,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
         private String name;
         private TypeName typeCondition;
+        private Description description;
         private ImmutableList<Directive> directives = emptyList();
         private SelectionSet selectionSet;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
@@ -187,6 +190,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
             this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.typeCondition = existing.getTypeCondition();
+            this.description = existing.getDescription();
             this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.selectionSet = existing.getSelectionSet();
             this.ignoredChars = existing.getIgnoredChars();
@@ -211,6 +215,11 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
         public Builder typeCondition(TypeName typeCondition) {
             this.typeCondition = typeCondition;
+            return this;
+        }
+
+        public Builder description(Description description) {
+            this.description = description;
             return this;
         }
 
@@ -247,7 +256,7 @@ public class FragmentDefinition extends AbstractNode<FragmentDefinition> impleme
 
 
         public FragmentDefinition build() {
-            return new FragmentDefinition(assertNotNull(name), assertNotNull(typeCondition), directives, assertNotNull(selectionSet), sourceLocation, comments, ignoredChars, additionalData);
+            return new FragmentDefinition(assertNotNull(name), assertNotNull(typeCondition), directives, assertNotNull(selectionSet), description, sourceLocation, comments, ignoredChars, additionalData);
         }
     }
 }

--- a/src/main/java/graphql/language/OperationDefinition.java
+++ b/src/main/java/graphql/language/OperationDefinition.java
@@ -26,7 +26,7 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 @PublicApi
 @NullMarked
-public class OperationDefinition extends AbstractNode<OperationDefinition> implements Definition<OperationDefinition>, SelectionSetContainer<OperationDefinition>, DirectivesContainer<OperationDefinition>, NamedNode<OperationDefinition> {
+public class OperationDefinition extends AbstractDescribedNode<OperationDefinition> implements Definition<OperationDefinition>, SelectionSetContainer<OperationDefinition>, DirectivesContainer<OperationDefinition>, NamedNode<OperationDefinition> {
 
     public enum Operation {
         QUERY, MUTATION, SUBSCRIPTION
@@ -49,11 +49,12 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
                                   List<VariableDefinition> variableDefinitions,
                                   List<Directive> directives,
                                   SelectionSet selectionSet,
+                                  @Nullable Description description,
                                   @Nullable SourceLocation sourceLocation,
                                   List<Comment> comments,
                                   IgnoredChars ignoredChars,
                                   Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.operation = operation;
         this.variableDefinitions = ImmutableList.copyOf(variableDefinitions);
@@ -147,6 +148,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
                 assertNotNull(deepCopy(variableDefinitions), "variableDefinitions deepCopy should not return null"),
                 assertNotNull(deepCopy(directives.getDirectives()), "directives deepCopy should not return null"),
                 assertNotNull(deepCopy(selectionSet), "selectionSet deepCopy should not return null"),
+                description,
                 getSourceLocation(),
                 getComments(),
                 getIgnoredChars(),
@@ -185,6 +187,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
         private ImmutableList<Comment> comments = emptyList();
         private String name;
         private Operation operation = Operation.QUERY;
+        private Description description;
         private ImmutableList<VariableDefinition> variableDefinitions = emptyList();
         private ImmutableList<Directive> directives = emptyList();
         private SelectionSet selectionSet;
@@ -199,6 +202,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
             this.comments = ImmutableList.copyOf(existing.getComments());
             this.name = existing.getName();
             this.operation = existing.getOperation();
+            this.description = existing.getDescription();
             this.variableDefinitions = ImmutableList.copyOf(existing.getVariableDefinitions());
             this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.selectionSet = existing.getSelectionSet();
@@ -224,6 +228,11 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
 
         public Builder operation(Operation operation) {
             this.operation = operation;
+            return this;
+        }
+
+        public Builder description(Description description) {
+            this.description = description;
             return this;
         }
 
@@ -275,6 +284,7 @@ public class OperationDefinition extends AbstractNode<OperationDefinition> imple
                     variableDefinitions,
                     directives,
                     selectionSet,
+                    description,
                     sourceLocation,
                     comments,
                     ignoredChars,

--- a/src/main/java/graphql/language/VariableDefinition.java
+++ b/src/main/java/graphql/language/VariableDefinition.java
@@ -21,7 +21,7 @@ import static graphql.collect.ImmutableKit.emptyMap;
 import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 @PublicApi
-public class VariableDefinition extends AbstractNode<VariableDefinition> implements DirectivesContainer<VariableDefinition>, NamedNode<VariableDefinition> {
+public class VariableDefinition extends AbstractDescribedNode<VariableDefinition> implements DirectivesContainer<VariableDefinition>, NamedNode<VariableDefinition> {
 
     private final String name;
     private final Type type;
@@ -37,11 +37,12 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
                                  Type type,
                                  Value defaultValue,
                                  List<Directive> directives,
+                                 Description description,
                                  SourceLocation sourceLocation,
                                  List<Comment> comments,
                                  IgnoredChars ignoredChars,
                                  Map<String, String> additionalData) {
-        super(sourceLocation, comments, ignoredChars, additionalData);
+        super(sourceLocation, comments, ignoredChars, additionalData, description);
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;
@@ -58,7 +59,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
     public VariableDefinition(String name,
                               Type type,
                               Value defaultValue) {
-        this(name, type, defaultValue, emptyList(), null, emptyList(), IgnoredChars.EMPTY, emptyMap());
+        this(name, type, defaultValue, emptyList(), null, null, emptyList(), IgnoredChars.EMPTY, emptyMap());
     }
 
     /**
@@ -69,7 +70,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
      */
     public VariableDefinition(String name,
                               Type type) {
-        this(name, type, null, emptyList(), null, emptyList(), IgnoredChars.EMPTY, emptyMap());
+        this(name, type, null, emptyList(), null, null, emptyList(), IgnoredChars.EMPTY, emptyMap());
     }
 
     public Value getDefaultValue() {
@@ -154,6 +155,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
                 deepCopy(type),
                 deepCopy(defaultValue),
                 deepCopy(directives.getDirectives()),
+                description,
                 getSourceLocation(),
                 getComments(),
                 getIgnoredChars(),
@@ -204,6 +206,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
         private ImmutableList<Comment> comments = emptyList();
         private Type type;
         private Value defaultValue;
+        private Description description;
         private ImmutableList<Directive> directives = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
@@ -217,6 +220,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
             this.name = existing.getName();
             this.type = existing.getType();
             this.defaultValue = existing.getDefaultValue();
+            this.description = existing.getDescription();
             this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -244,6 +248,11 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
 
         public Builder defaultValue(Value defaultValue) {
             this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public Builder description(Description description) {
+            this.description = description;
             return this;
         }
 
@@ -279,6 +288,7 @@ public class VariableDefinition extends AbstractNode<VariableDefinition> impleme
                     type,
                     defaultValue,
                     directives,
+                    description,
                     sourceLocation,
                     comments,
                     ignoredChars,

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -142,6 +142,7 @@ public class GraphqlAntlrToLanguage {
         if (ctx.name() != null) {
             operationDefinition.name(ctx.name().getText());
         }
+        operationDefinition.description(newDescription(ctx.description()));
         operationDefinition.variableDefinitions(createVariableDefinitions(ctx.variableDefinitions()));
         operationDefinition.selectionSet(createSelectionSet(ctx.selectionSet()));
         operationDefinition.directives(createDirectives(ctx.directives()));
@@ -178,6 +179,7 @@ public class GraphqlAntlrToLanguage {
     protected VariableDefinition createVariableDefinition(GraphqlParser.VariableDefinitionContext ctx) {
         VariableDefinition.Builder variableDefinition = VariableDefinition.newVariableDefinition();
         addCommonData(variableDefinition, ctx);
+        variableDefinition.description(newDescription(ctx.description()));
         variableDefinition.name(ctx.variable().name().getText());
         if (ctx.defaultValue() != null) {
             Value value = createValue(ctx.defaultValue().value());
@@ -192,6 +194,7 @@ public class GraphqlAntlrToLanguage {
     protected FragmentDefinition createFragmentDefinition(GraphqlParser.FragmentDefinitionContext ctx) {
         FragmentDefinition.Builder fragmentDefinition = FragmentDefinition.newFragmentDefinition();
         addCommonData(fragmentDefinition, ctx);
+        fragmentDefinition.description(newDescription(ctx.description()));
         fragmentDefinition.name(ctx.fragmentName().getText());
         fragmentDefinition.typeCondition(TypeName.newTypeName().name(ctx.typeCondition().typeName().getText()).build());
         fragmentDefinition.directives(createDirectives(ctx.directives()));

--- a/src/test/groovy/graphql/ParseAndValidateTest.groovy
+++ b/src/test/groovy/graphql/ParseAndValidateTest.groovy
@@ -59,6 +59,33 @@ class ParseAndValidateTest extends Specification {
         errors.isEmpty()
     }
 
+    def "executable descriptions do not affect validation"() {
+        def input = ExecutionInput.newExecutionInput('''
+            "Fetches a hero"
+            query HeroName(
+                "The target episode"
+                $episode: Episode = JEDI
+            ) {
+                hero(episode: $episode) {
+                    ...heroFields
+                }
+            }
+
+            "Reusable hero fields"
+            fragment heroFields on Character {
+                name
+            }
+        ''').build()
+        def result = ParseAndValidate.parse(input)
+
+        when:
+        def errors = ParseAndValidate.validate(StarWarsSchema.starWarsSchema, result.getDocument(), input.getLocale())
+
+        then:
+        !result.isFailure()
+        errors.isEmpty()
+    }
+
     def "will validate documents with actual problems"() {
 
         def input = ExecutionInput.newExecutionInput("query { hero }").variables([var1: 1]).build()

--- a/src/test/groovy/graphql/language/AstPrinterTest.groovy
+++ b/src/test/groovy/graphql/language/AstPrinterTest.groovy
@@ -406,6 +406,45 @@ query HeroNameAndFriends($episode: Episode = "JEDI") {
 '''
     }
 
+    def "ast printing of executable descriptions"() {
+        def query = '''
+"Fetches a hero"
+query getHero(
+  "The hero id"
+  $id: ID!
+) {
+  hero(id: $id) {
+    ...heroFields
+  }
+}
+
+"Reusable hero fields"
+fragment heroFields on Hero {
+  name
+}
+'''
+        def document = parse(query)
+        String output = printAst(document)
+
+        expect:
+        output == '''"Fetches a hero"
+query getHero(
+  "The hero id"
+  $id: ID!
+) {
+  hero(id: $id) {
+    ...heroFields
+  }
+}
+
+"Reusable hero fields"
+fragment heroFields on Hero {
+  name
+}
+'''
+        isParseableAst(output)
+    }
+
 //-------------------------------------------------
     def "ast printing of null"() {
         def query = '''

--- a/src/test/groovy/graphql/parser/ParserTest.groovy
+++ b/src/test/groovy/graphql/parser/ParserTest.groovy
@@ -5,6 +5,7 @@ import graphql.language.ArrayValue
 import graphql.language.AstComparator
 import graphql.language.AstPrinter
 import graphql.language.BooleanValue
+import graphql.language.DescribedNode
 import graphql.language.Description
 import graphql.language.Directive
 import graphql.language.DirectiveDefinition
@@ -107,6 +108,53 @@ class ParserTest extends Specification {
         Document document = new Parser().parseDocument(input)
         then:
         isEqual(document, expectedResult.build())
+    }
+
+    def "parse executable descriptions"() {
+        given:
+        def input = '''
+            "Fetches a hero"
+            query getHero(
+                "The hero id"
+                $id: ID!
+            ) {
+                hero(id: $id) {
+                    ...heroFields
+                }
+            }
+
+            "Reusable hero fields"
+            fragment heroFields on Hero {
+                name
+            }
+        '''
+
+        when:
+        Document document = new Parser().parseDocument(input)
+        OperationDefinition operationDefinition = document.definitions[0] as OperationDefinition
+        VariableDefinition variableDefinition = operationDefinition.variableDefinitions[0]
+        FragmentDefinition fragmentDefinition = document.definitions[1] as FragmentDefinition
+
+        then:
+        (operationDefinition as DescribedNode).description.content == "Fetches a hero"
+        (variableDefinition as DescribedNode).description.content == "The hero id"
+        (fragmentDefinition as DescribedNode).description.content == "Reusable hero fields"
+    }
+
+    def "description is not allowed on query shorthand"() {
+        given:
+        def input = '''
+            "Shorthand descriptions are not part of the executable grammar"
+            {
+                hero
+            }
+        '''
+
+        when:
+        new Parser().parseDocument(input)
+
+        then:
+        thrown(InvalidSyntaxException)
     }
 
     def "parse mutation"() {


### PR DESCRIPTION
## Summary
- add executable grammar support for descriptions on operation, variable, and fragment definitions
- preserve those descriptions on executable AST nodes and print them in non-compact AST output
- keep query shorthand description-free and cover validation behavior

Fixes #4077

## Testing
- ./gradlew test --rerun-tasks --tests graphql.parser.ParserTest --tests graphql.language.AstPrinterTest --tests graphql.ParseAndValidateTest --tests graphql.parser.SDLParserTest --tests graphql.schema.idl.SchemaParserTest