### PR TITLE
Disallow descriptions on root operation mappings

### DIFF
--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -19,7 +19,7 @@ schemaExtension :
     EXTEND SCHEMA directives
 ;
 
-operationTypeDefinition : description? operationType ':' typeName;
+operationTypeDefinition : operationType ':' typeName;
 
 typeDefinition:
 scalarTypeDefinition |

--- a/src/test/groovy/graphql/parser/SDLParserTest.groovy
+++ b/src/test/groovy/graphql/parser/SDLParserTest.groovy
@@ -309,6 +309,66 @@ schema @d1 @d2 {
         isEqual(document.definitions[0], schema.build())
     }
 
+    def "schema definition can have a description"() {
+        given:
+        def input = '''
+"Schema description"
+schema {
+    query: OpType1
+}
+'''
+
+        when:
+        def document = new Parser().parseDocument(input)
+
+        then:
+        document.definitions.size() == 1
+        SchemaDefinition schemaDefinition = document.definitions[0] as SchemaDefinition
+        schemaDefinition.description.content == "Schema description"
+        schemaDefinition.operationTypeDefinitions[0].name == "query"
+        schemaDefinition.operationTypeDefinitions[0].typeName.name == "OpType1"
+    }
+
+    def "schema root operation type mapping cannot have a description"() {
+        given:
+        def input = '''
+schema {
+    "Query root operation mapping"
+    query: Query
+}
+'''
+
+        when:
+        new Parser().parseDocument(input)
+
+        then:
+        def e = thrown(InvalidSyntaxException)
+
+        e.location.line == 3
+        e.location.column == 5
+        e.offendingToken == '"Query root operation mapping"'
+    }
+
+    def "schema extension root operation type mapping cannot have a description"() {
+        given:
+        def input = '''
+extend schema {
+    "Query root operation mapping"
+    query: Query
+}
+'''
+
+        when:
+        new Parser().parseDocument(input)
+
+        then:
+        def e = thrown(InvalidSyntaxException)
+
+        e.location.line == 3
+        e.location.column == 5
+        e.offendingToken == '"Query root operation mapping"'
+    }
+
     def "extend schema"() {
         given:
         def input = """
@@ -1069,4 +1129,3 @@ directive @myDirective on
         e.offendingToken == "<EOF>"
     }
 }
-


### PR DESCRIPTION
## Summary

Removes the stale SDL grammar allowance for descriptions directly before schema root operation type mappings, e.g. inside `schema { "desc" query: Query }`.

This aligns GraphQL Java with the GraphQL spec and graphql-js: schema definitions can have descriptions, but `RootOperationTypeDefinition` / `OperationTypeDefinition` itself does not.

## Background

The `description?` on `operationTypeDefinition` was introduced by PR #706 while adding block strings and SDL descriptions from issue #685. It appears to have been a broad grammar change rather than intentional support for root operation mapping descriptions: the parser never preserved this description on `OperationTypeDefinition`, and the AST printer/schema generator do not expose it.

## Tests

- `./gradlew test --tests graphql.parser.SDLParserTest`