### PR TITLE
Capture partial results on cancellation

### DIFF
--- a/src/main/java/graphql/ExecutionInput.java
+++ b/src/main/java/graphql/ExecutionInput.java
@@ -11,7 +11,8 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CompletableFuture;
+
 import java.util.function.Consumer;
 
 import static graphql.Assert.assertNotNull;
@@ -34,7 +35,7 @@ public class ExecutionInput {
     private final DataLoaderRegistry dataLoaderRegistry;
     private final ExecutionId executionId;
     private final Locale locale;
-    private final AtomicBoolean cancelled;
+    private final CompletableFuture<Void> cancellationFuture;
     private final boolean profileExecution;
 
     /**
@@ -60,7 +61,7 @@ public class ExecutionInput {
         this.locale = builder.locale != null ? builder.locale : Locale.getDefault(); // always have a locale in place
         this.localContext = builder.localContext;
         this.extensions = builder.extensions;
-        this.cancelled = builder.cancelled;
+        this.cancellationFuture = builder.cancellationFuture;
         this.profileExecution = builder.profileExecution;
     }
 
@@ -211,7 +212,7 @@ public class ExecutionInput {
      * @return true if the execution should be cancelled
      */
     public boolean isCancelled() {
-        return cancelled.get();
+        return cancellationFuture.isDone();
     }
 
     /**
@@ -219,7 +220,18 @@ public class ExecutionInput {
      * and the graphql engine needs to be running on a thread to allow is to respect this flag.
      */
     public void cancel() {
-        cancelled.set(true);
+        cancellationFuture.complete(null);
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} that completes when {@link #cancel()} is called.
+     * This allows async code to race against cancellation without polling.
+     *
+     * @return a future that completes (with null) when this execution is cancelled
+     */
+    @Internal
+    public CompletableFuture<Void> getCancellationFuture() {
+        return cancellationFuture;
     }
 
 
@@ -241,7 +253,7 @@ public class ExecutionInput {
                 .operationName(this.operationName)
                 .context(this.context)
                 .internalTransferContext(this.graphQLContext)
-                .internalTransferCancelBoolean(this.cancelled)
+                .internalTransferCancellationFuture(this.cancellationFuture)
                 .localContext(this.localContext)
                 .root(this.root)
                 .dataLoaderRegistry(this.dataLoaderRegistry)
@@ -306,7 +318,7 @@ public class ExecutionInput {
         private DataLoaderRegistry dataLoaderRegistry = EMPTY_DATALOADER_REGISTRY;
         private Locale locale = Locale.getDefault();
         private ExecutionId executionId;
-        private AtomicBoolean cancelled = new AtomicBoolean(false);
+        private CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
         private boolean profileExecution;
 
         /**
@@ -412,9 +424,8 @@ public class ExecutionInput {
             return this;
         }
 
-        // hidden on purpose
-        private Builder internalTransferCancelBoolean(AtomicBoolean cancelled) {
-            this.cancelled = cancelled;
+        private Builder internalTransferCancellationFuture(CompletableFuture<Void> cancellationFuture) {
+            this.cancellationFuture = cancellationFuture;
             return this;
         }
 

--- a/src/main/java/graphql/GraphQLUnusualConfiguration.java
+++ b/src/main/java/graphql/GraphQLUnusualConfiguration.java
@@ -277,6 +277,14 @@ public class GraphQLUnusualConfiguration {
             return new ResponseMapFactoryConfig(this);
         }
 
+        /**
+         * @return an element that allows you to control cancellation behavior
+         */
+        @ExperimentalApi
+        public CancellationConfig cancellation() {
+            return new CancellationConfig(this);
+        }
+
         private void put(String named, Object value) {
             if (graphQLContext != null) {
                 graphQLContext.put(named, value);
@@ -407,6 +415,55 @@ public class GraphQLUnusualConfiguration {
         @ExperimentalApi
         public ResponseMapFactoryConfig setFactory(ResponseMapFactory factory) {
             contextConfig.put(ResponseMapFactory.class.getCanonicalName(), factory);
+            return this;
+        }
+    }
+
+    public static class CancellationConfig extends BaseContextConfig {
+
+        /**
+         * The context key used to enable capturing partial results when an execution is cancelled.
+         */
+        @ExperimentalApi
+        public static final String CAPTURE_PARTIAL_RESULTS_ON_CANCEL = "graphql.capturePartialResultsOnCancel";
+
+        /**
+         * The context key used to store the cancellation {@link java.util.concurrent.CompletableFuture}
+         * that completes when {@link ExecutionInput#cancel()} is called.
+         * This is only set when {@link #CAPTURE_PARTIAL_RESULTS_ON_CANCEL} is enabled.
+         */
+        @Internal
+        public static final String CANCELLATION_FUTURE_KEY = CAPTURE_PARTIAL_RESULTS_ON_CANCEL + ".cancelFuture";
+
+        private CancellationConfig(GraphQLContextConfiguration contextConfig) {
+            super(contextConfig);
+        }
+
+        /**
+         * Returns true if partial results should be captured when the execution is cancelled via
+         * {@link ExecutionInput#cancel()}.
+         *
+         * @return true if partial results capture on cancel is enabled
+         */
+        @ExperimentalApi
+        public boolean isCapturePartialResultsOnCancelEnabled() {
+            return contextConfig.getBoolean(CAPTURE_PARTIAL_RESULTS_ON_CANCEL);
+        }
+
+        /**
+         * When enabled, if {@link ExecutionInput#cancel()} is called during execution, the engine will
+         * return the partial results of any fields that have already completed, along with an error
+         * indicating the execution was cancelled.
+         * <p>
+         * By default this is false and cancellation returns only the cancellation error with null data.
+         *
+         * @param enable true to enable capturing partial results on cancel
+         *
+         * @return this config object for chaining
+         */
+        @ExperimentalApi
+        public CancellationConfig capturePartialResultsOnCancel(boolean enable) {
+            contextConfig.put(CAPTURE_PARTIAL_RESULTS_ON_CANCEL, enable);
             return this;
         }
     }

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -2,7 +2,10 @@ package graphql.execution;
 
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
+import graphql.GraphQLContext;
 import graphql.PublicSpi;
+
+import java.util.concurrent.CompletionException;
 
 import java.util.List;
 import java.util.Map;
@@ -29,8 +32,47 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
                 return;
             }
 
-            Map<String, Object> resolvedValuesByField = executionContext.getResponseMapFactory().createInsertionOrdered(fieldNames, results);
-            overallResult.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
+            completeResultFuture(overallResult, executionContext, fieldNames, results);
         };
+    }
+
+    protected BiConsumer<List<Object>, Throwable> handleResultsWithPartialData(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
+        return (List<Object> results, Throwable exception) -> {
+            // when partial results on cancel is enabled the results list will already have partial data
+            // (already-completed fields) so we can build a partial response even if exception is set
+            if (exception != null) {
+                Throwable cause = exception instanceof CompletionException ? exception.getCause() : exception;
+                if (cause instanceof AbortExecutionException && results != null
+                        && capturePartialResults(executionContext)) {
+                    executionContext.addError((AbortExecutionException) cause);
+                    completeResultFuture(overallResult, executionContext, fieldNames, results);
+                    return;
+                }
+                handleNonNullException(executionContext, overallResult, exception);
+                return;
+            }
+
+            // check if cancel fired while results were being gathered (no exception, but cancelled)
+            Throwable cancelException = executionContext.possibleCancellation(null);
+            if (cancelException != null) {
+                Throwable cancelCause = cancelException instanceof CompletionException ? cancelException.getCause() : cancelException;
+                if (cancelCause instanceof AbortExecutionException && results != null
+                        && capturePartialResults(executionContext)) {
+                    // we have partial data from already-completed CFs — use it
+                    executionContext.addError((AbortExecutionException) cancelCause);
+                    completeResultFuture(overallResult, executionContext, fieldNames, results);
+                } else {
+                    handleNonNullException(executionContext, overallResult, cancelException);
+                }
+                return;
+            }
+
+            completeResultFuture(overallResult, executionContext, fieldNames, results);
+        };
+    }
+
+    protected void completeResultFuture(CompletableFuture<ExecutionResult> overallResult, ExecutionContext executionContext, List<String> fieldNames, List<Object> results) {
+        Map<String, Object> resolvedValuesByField = executionContext.getResponseMapFactory().createInsertionOrdered(fieldNames, results);
+        overallResult.complete(new ExecutionResultImpl(resolvedValuesByField, executionContext.getErrors()));
     }
 }

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -4,8 +4,6 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.PublicSpi;
 
-import java.util.concurrent.CompletionException;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -37,28 +35,18 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
 
     protected BiConsumer<List<Object>, Throwable> handleResultsWithPartialData(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
         return (List<Object> results, Throwable exception) -> {
-            // when partial results on cancel is enabled the results list will already have partial data
-            // (already-completed fields) so we can build a partial response even if exception is set
             if (exception != null) {
-                Throwable cause = exception instanceof CompletionException ? exception.getCause() : exception;
-                if (cause instanceof AbortExecutionException && results != null
-                        && capturePartialResults(executionContext)) {
-                    executionContext.addError((AbortExecutionException) cause);
-                    completeResultFuture(overallResult, executionContext, fieldNames, results);
-                    return;
-                }
                 handleNonNullException(executionContext, overallResult, exception);
                 return;
             }
 
-            // check if cancel fired while results were being gathered (no exception, but cancelled)
+            // No exception, but cancellation may have fired while the already-completed field values
+            // were being gathered. When it has, the results list already holds the partial data from
+            // the fields that completed before cancellation, so we can return it alongside the error.
             Throwable cancelException = executionContext.possibleCancellation(null);
             if (cancelException != null) {
-                Throwable cancelCause = cancelException instanceof CompletionException ? cancelException.getCause() : cancelException;
-                if (cancelCause instanceof AbortExecutionException && results != null
-                        && capturePartialResults(executionContext)) {
-                    // we have partial data from already-completed CFs — use it
-                    executionContext.addError((AbortExecutionException) cancelCause);
+                if (capturePartialResults(executionContext)) {
+                    executionContext.addError((AbortExecutionException) cancelException);
                     completeResultFuture(overallResult, executionContext, fieldNames, results);
                 } else {
                     handleNonNullException(executionContext, overallResult, cancelException);

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -2,7 +2,6 @@ package graphql.execution;
 
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
-import graphql.GraphQLContext;
 import graphql.PublicSpi;
 
 import java.util.concurrent.CompletionException;

--- a/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AbstractAsyncExecutionStrategy.java
@@ -25,32 +25,16 @@ public abstract class AbstractAsyncExecutionStrategy extends ExecutionStrategy {
             exception = executionContext.possibleCancellation(exception);
 
             if (exception != null) {
-                handleNonNullException(executionContext, overallResult, exception);
-                return;
-            }
-
-            completeResultFuture(overallResult, executionContext, fieldNames, results);
-        };
-    }
-
-    protected BiConsumer<List<Object>, Throwable> handleResultsWithPartialData(ExecutionContext executionContext, List<String> fieldNames, CompletableFuture<ExecutionResult> overallResult) {
-        return (List<Object> results, Throwable exception) -> {
-            if (exception != null) {
-                handleNonNullException(executionContext, overallResult, exception);
-                return;
-            }
-
-            // No exception, but cancellation may have fired while the already-completed field values
-            // were being gathered. When it has, the results list already holds the partial data from
-            // the fields that completed before cancellation, so we can return it alongside the error.
-            Throwable cancelException = executionContext.possibleCancellation(null);
-            if (cancelException != null) {
-                if (capturePartialResults(executionContext)) {
-                    executionContext.addError((AbortExecutionException) cancelException);
+                // A cancellation that fired after some fields already completed arrives here as a
+                // synthesised AbortExecutionException with a non-null results list (a real field
+                // failure always has null results). When partial capture is enabled we keep those
+                // results and attach the cancellation error; otherwise we report the error as usual.
+                if (results != null && capturePartialResults(executionContext)) {
+                    executionContext.addError((AbortExecutionException) exception);
                     completeResultFuture(overallResult, executionContext, fieldNames, results);
-                } else {
-                    handleNonNullException(executionContext, overallResult, cancelException);
+                    return;
                 }
+                handleNonNullException(executionContext, overallResult, exception);
                 return;
             }
 

--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -1,7 +1,9 @@
 package graphql.execution;
 
 import graphql.Assert;
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.GraphQLUnusualConfiguration;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -21,6 +23,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static graphql.Assert.assertTrue;
+import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CANCELLATION_FUTURE_KEY;
+import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CAPTURE_PARTIAL_RESULTS_ON_CANCEL;
 import static java.util.stream.Collectors.toList;
 
 @Internal
@@ -56,6 +60,17 @@ public class Async {
          * @return a CompletableFuture to a List of values
          */
         CompletableFuture<List<T>> await();
+
+        /**
+         * Like {@link #await()} but when {@link GraphQLUnusualConfiguration.CancellationConfig#CAPTURE_PARTIAL_RESULTS_ON_CANCEL}
+         * is enabled in the context and an {@link AbortExecutionException} causes a CF to fail, the already-completed
+         * CFs will have their values harvested and returned as partial results rather than completing exceptionally.
+         *
+         * @param graphQLContext the context to check for the partial results flag
+         *
+         * @return a CompletableFuture to a List of values (possibly partial on cancellation)
+         */
+        CompletableFuture<List<T>> await(GraphQLContext graphQLContext);
 
         /**
          * This will return a {@code CompletableFuture<List<T>>} if ANY of the input values are async
@@ -105,6 +120,11 @@ public class Async {
         }
 
         @Override
+        public CompletableFuture<List<T>> await(GraphQLContext graphQLContext) {
+            return await();
+        }
+
+        @Override
         public Object awaitPolymorphic() {
             Assert.assertTrue(ix == 0, () -> "expected size was " + 0 + " got " + ix);
             return Collections.emptyList();
@@ -147,6 +167,11 @@ public class Async {
             }
             //noinspection unchecked
             return CompletableFuture.completedFuture(Collections.singletonList((T) value));
+        }
+
+        @Override
+        public CompletableFuture<List<T>> await(GraphQLContext graphQLContext) {
+            return await();
         }
 
         @Override
@@ -230,6 +255,101 @@ public class Async {
                         });
             }
             return overallResult;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public CompletableFuture<List<T>> await(GraphQLContext graphQLContext) {
+            commonSizeAssert();
+            if (cfCount == 0) {
+                return CompletableFuture.completedFuture(materialisedList(array));
+            }
+            if (!graphQLContext.getBoolean(CAPTURE_PARTIAL_RESULTS_ON_CANCEL)) {
+                return await();
+            }
+
+            CompletableFuture<Void> cancellationFuture = graphQLContext.get(CANCELLATION_FUTURE_KEY);
+            if (cancellationFuture == null) {
+                return await();
+            }
+
+            CompletableFuture<List<T>> overallResult = new CompletableFuture<>();
+            CompletableFuture<T>[] cfsArr = copyOnlyCFsToArray();
+            CompletableFuture<Void> allOf = CompletableFuture.allOf(cfsArr);
+
+            // race: either all CFs complete normally, or cancellation fires first
+            CompletableFuture.anyOf(allOf, cancellationFuture)
+                    .whenComplete((ignored, exception) -> {
+                        if (overallResult.isDone()) {
+                            return;
+                        }
+                        if (exception != null) {
+                            // a CF failed — not our abort path, propagate
+                            overallResult.completeExceptionally(exception);
+                            return;
+                        }
+                        if (!allOf.isDone()) {
+                            // cancellation fired before allOf: harvest already-completed CFs
+                            List<T> partialResults = harvestPartialResults(array);
+                            overallResult.complete(partialResults);
+                            return;
+                        }
+                        // allOf finished normally: collect all results
+                        overallResult.complete(collectAllResults(array, cfsArr));
+                    });
+
+            // also handle when allOf completes (either normally or exceptionally) after the race
+            allOf.whenComplete((ignored, exception) -> {
+                if (overallResult.isDone()) {
+                    return;
+                }
+                if (exception != null) {
+                    // a CF in allOf failed — propagate
+                    overallResult.completeExceptionally(exception);
+                    return;
+                }
+                overallResult.complete(collectAllResults(array, cfsArr));
+            });
+
+            return overallResult;
+        }
+
+        @SuppressWarnings("unchecked")
+        private List<T> harvestPartialResults(Object[] array) {
+            List<T> partialResults = new ArrayList<>(array.length);
+            for (Object object : array) {
+                if (object instanceof CompletableFuture) {
+                    CompletableFuture<T> cf = (CompletableFuture<T>) object;
+                    if (cf.isDone() && !cf.isCompletedExceptionally()) {
+                        partialResults.add(cf.join());
+                    } else {
+                        partialResults.add(null);
+                    }
+                } else {
+                    partialResults.add((T) object);
+                }
+            }
+            return partialResults;
+        }
+
+        @SuppressWarnings("unchecked")
+        private List<T> collectAllResults(Object[] array, CompletableFuture<T>[] cfsArr) {
+            List<T> results = new ArrayList<>(array.length);
+            if (cfsArr.length == array.length) {
+                for (CompletableFuture<T> cf : cfsArr) {
+                    results.add(cf.join());
+                }
+            } else {
+                for (Object object : array) {
+                    if (object instanceof CompletableFuture) {
+                        CompletableFuture<T> cf = (CompletableFuture<T>) object;
+                        results.add(cf.join());
+                    } else {
+                        results.add((T) object);
+                    }
+                }
+            }
+            return results;
         }
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -268,79 +268,35 @@ public class Async {
             }
 
             CompletableFuture<List<T>> overallResult = new CompletableFuture<>();
-            CompletableFuture<T>[] cfsArr = copyOnlyCFsToArray();
-            CompletableFuture<Void> allOf = CompletableFuture.allOf(cfsArr);
+            CompletableFuture<Void> allOf = CompletableFuture.allOf(copyOnlyCFsToArray());
 
-            // race: either all CFs complete normally, or cancellation fires first
-            CompletableFuture.anyOf(allOf, cancellationFuture)
-                    .whenComplete((ignored, exception) -> {
-                        if (overallResult.isDone()) {
-                            return;
-                        }
-                        if (exception != null) {
-                            // a CF failed — not our abort path, propagate
-                            overallResult.completeExceptionally(exception);
-                            return;
-                        }
-                        if (!allOf.isDone()) {
-                            // cancellation fired before allOf: harvest already-completed CFs
-                            List<T> partialResults = harvestPartialResults(array);
-                            overallResult.complete(partialResults);
-                            return;
-                        }
-                        // allOf finished normally: collect all results
-                        overallResult.complete(collectAllResults(array, cfsArr));
-                    });
-
-            // also handle when allOf completes (either normally or exceptionally) after the race
-            allOf.whenComplete((ignored, exception) -> {
-                if (overallResult.isDone()) {
-                    return;
-                }
+            // Race "all field futures complete" against cancellation. The cancellation future always
+            // completes normally (see ExecutionInput#cancel), so anyOf can only complete exceptionally
+            // when a field future fails - in which case we propagate that failure.
+            CompletableFuture.anyOf(allOf, cancellationFuture).whenComplete((ignored, exception) -> {
                 if (exception != null) {
-                    // a CF in allOf failed — propagate
                     overallResult.completeExceptionally(exception);
                     return;
                 }
-                overallResult.complete(collectAllResults(array, cfsArr));
+                // Either every field future is done (allOf won) or cancellation won the race. In both
+                // cases we harvest whatever has completed; field futures that are not yet done become
+                // null. join() is safe here: if allOf is not done then no field future has failed (a
+                // failure would have completed allOf exceptionally and taken the branch above).
+                overallResult.complete(harvestResults(array));
             });
 
             return overallResult;
         }
 
         @SuppressWarnings("unchecked")
-        private List<T> harvestPartialResults(Object[] array) {
-            List<T> partialResults = new ArrayList<>(array.length);
+        private List<T> harvestResults(Object[] array) {
+            List<T> results = new ArrayList<>(array.length);
             for (Object object : array) {
                 if (object instanceof CompletableFuture) {
                     CompletableFuture<T> cf = (CompletableFuture<T>) object;
-                    if (cf.isDone() && !cf.isCompletedExceptionally()) {
-                        partialResults.add(cf.join());
-                    } else {
-                        partialResults.add(null);
-                    }
+                    results.add(cf.isDone() ? cf.join() : null);
                 } else {
-                    partialResults.add((T) object);
-                }
-            }
-            return partialResults;
-        }
-
-        @SuppressWarnings("unchecked")
-        private List<T> collectAllResults(Object[] array, CompletableFuture<T>[] cfsArr) {
-            List<T> results = new ArrayList<>(array.length);
-            if (cfsArr.length == array.length) {
-                for (CompletableFuture<T> cf : cfsArr) {
-                    results.add(cf.join());
-                }
-            } else {
-                for (Object object : array) {
-                    if (object instanceof CompletableFuture) {
-                        CompletableFuture<T> cf = (CompletableFuture<T>) object;
-                        results.add(cf.join());
-                    } else {
-                        results.add((T) object);
-                    }
+                    results.add((T) object);
                 }
             }
             return results;

--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -1,9 +1,7 @@
 package graphql.execution;
 
 import graphql.Assert;
-import graphql.GraphQLContext;
 import graphql.Internal;
-import graphql.GraphQLUnusualConfiguration;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -23,8 +21,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static graphql.Assert.assertTrue;
-import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CANCELLATION_FUTURE_KEY;
-import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CAPTURE_PARTIAL_RESULTS_ON_CANCEL;
 import static java.util.stream.Collectors.toList;
 
 @Internal
@@ -62,15 +58,18 @@ public class Async {
         CompletableFuture<List<T>> await();
 
         /**
-         * Like {@link #await()} but when {@link GraphQLUnusualConfiguration.CancellationConfig#CAPTURE_PARTIAL_RESULTS_ON_CANCEL}
-         * is enabled in the context and an {@link AbortExecutionException} causes a CF to fail, the already-completed
-         * CFs will have their values harvested and returned as partial results rather than completing exceptionally.
+         * Like {@link #await()} but races against the given cancellation future. If the cancellation future
+         * completes before all the tracked futures complete, the already-completed futures will have their
+         * values harvested and returned as partial results (with {@code null} for incomplete entries)
+         * rather than completing exceptionally.
          *
-         * @param graphQLContext the context to check for the partial results flag
+         * <p>If {@code cancellationFuture} is {@code null}, this behaves identically to {@link #await()}.
+         *
+         * @param cancellationFuture a future that, when completed, signals cancellation; may be {@code null}
          *
          * @return a CompletableFuture to a List of values (possibly partial on cancellation)
          */
-        CompletableFuture<List<T>> await(GraphQLContext graphQLContext);
+        CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture);
 
         /**
          * This will return a {@code CompletableFuture<List<T>>} if ANY of the input values are async
@@ -120,7 +119,7 @@ public class Async {
         }
 
         @Override
-        public CompletableFuture<List<T>> await(GraphQLContext graphQLContext) {
+        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture) {
             return await();
         }
 
@@ -170,7 +169,7 @@ public class Async {
         }
 
         @Override
-        public CompletableFuture<List<T>> await(GraphQLContext graphQLContext) {
+        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture) {
             return await();
         }
 
@@ -259,16 +258,11 @@ public class Async {
 
         @SuppressWarnings("unchecked")
         @Override
-        public CompletableFuture<List<T>> await(GraphQLContext graphQLContext) {
+        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture) {
             commonSizeAssert();
             if (cfCount == 0) {
                 return CompletableFuture.completedFuture(materialisedList(array));
             }
-            if (!graphQLContext.getBoolean(CAPTURE_PARTIAL_RESULTS_ON_CANCEL)) {
-                return await();
-            }
-
-            CompletableFuture<Void> cancellationFuture = graphQLContext.get(CANCELLATION_FUTURE_KEY);
             if (cancellationFuture == null) {
                 return await();
             }

--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -196,11 +196,6 @@ public class Async {
         }
 
         @Override
-        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture) {
-            return await();
-        }
-
-        @Override
         public Object awaitPolymorphic() {
             commonSizeAssert();
             if (value instanceof CompletableFuture) {
@@ -321,52 +316,6 @@ public class Async {
                 if (object instanceof CompletableFuture) {
                     CompletableFuture<T> cf = (CompletableFuture<T>) object;
                     results.add(doneOrNull(cf));
-                } else {
-                    results.add((T) object);
-                }
-            }
-            return results;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture) {
-            commonSizeAssert();
-            if (cfCount == 0) {
-                return CompletableFuture.completedFuture(materialisedList(array));
-            }
-            if (cancellationFuture == null) {
-                return await();
-            }
-
-            CompletableFuture<List<T>> overallResult = new CompletableFuture<>();
-            CompletableFuture<Void> allOf = CompletableFuture.allOf(copyOnlyCFsToArray());
-
-            // Race "all field futures complete" against cancellation. The cancellation future always
-            // completes normally (see ExecutionInput#cancel), so anyOf can only complete exceptionally
-            // when a field future fails - in which case we propagate that failure.
-            CompletableFuture.anyOf(allOf, cancellationFuture).whenComplete((ignored, exception) -> {
-                if (exception != null) {
-                    overallResult.completeExceptionally(exception);
-                    return;
-                }
-                // Either every field future is done (allOf won) or cancellation won the race. In both
-                // cases we harvest whatever has completed; field futures that are not yet done become
-                // null. join() is safe here: if allOf is not done then no field future has failed (a
-                // failure would have completed allOf exceptionally and taken the branch above).
-                overallResult.complete(harvestResults(array));
-            });
-
-            return overallResult;
-        }
-
-        @SuppressWarnings("unchecked")
-        private List<T> harvestResults(Object[] array) {
-            List<T> results = new ArrayList<>(array.length);
-            for (Object object : array) {
-                if (object instanceof CompletableFuture) {
-                    CompletableFuture<T> cf = (CompletableFuture<T>) object;
-                    results.add(cf.isDone() ? cf.join() : null);
                 } else {
                     results.add((T) object);
                 }

--- a/src/main/java/graphql/execution/Async.java
+++ b/src/main/java/graphql/execution/Async.java
@@ -37,6 +37,24 @@ public class Async {
     public interface CombinedBuilder<T> {
 
         /**
+         * Controls how {@link #await(CompletableFuture, OnCancel)} treats tracked futures that are still
+         * pending when cancellation is signalled before they have all completed.
+         */
+        enum OnCancel {
+            /**
+             * Harvest immediately when cancellation is signalled; any still-pending future becomes {@code null}.
+             * Safe for futures that may block indefinitely on cancellation (for example raw data fetcher futures).
+             */
+            DROP_PENDING,
+            /**
+             * Wait for still-pending futures to settle before harvesting, so their own partial data is
+             * captured. Only safe for cancellation-aware futures that are guaranteed to complete promptly after
+             * cancellation (for example nested object or list results that capture their own partial data).
+             */
+            WAIT_FOR_PENDING
+        }
+
+        /**
          * This adds a {@link CompletableFuture} into the collection of results
          *
          * @param completableFuture the CF to add
@@ -58,18 +76,33 @@ public class Async {
         CompletableFuture<List<T>> await();
 
         /**
-         * Like {@link #await()} but races against the given cancellation future. If the cancellation future
-         * completes before all the tracked futures complete, the already-completed futures will have their
-         * values harvested and returned as partial results (with {@code null} for incomplete entries)
-         * rather than completing exceptionally.
+         * Like {@link #await()} but also waits on the given cancellation future. This waits on two things at
+         * once - all the tracked futures completing, and the cancellation future completing - and proceeds as
+         * soon as either happens. If cancellation is signalled before all the tracked futures have completed,
+         * the already-completed futures have their values harvested and returned as partial results rather than
+         * completing exceptionally.
+         *
+         * <p>The {@code onCancel} policy controls what happens to the tracked futures that are still pending
+         * when cancellation is signalled first:
+         * <ul>
+         *     <li>{@link OnCancel#DROP_PENDING} - harvest immediately, pending futures become {@code null}.
+         *     Use this when the tracked futures may block indefinitely on cancellation (for example raw data
+         *     fetcher futures).</li>
+         *     <li>{@link OnCancel#WAIT_FOR_PENDING} - wait for the still-pending futures to settle before
+         *     harvesting, so their own partial data is captured. Use this only when the tracked futures are
+         *     themselves cancellation-aware and therefore guaranteed to complete promptly after cancellation
+         *     (for example nested object or list results that capture their own partial data on cancel);
+         *     otherwise the returned future may never complete.</li>
+         * </ul>
          *
          * <p>If {@code cancellationFuture} is {@code null}, this behaves identically to {@link #await()}.
          *
          * @param cancellationFuture a future that, when completed, signals cancellation; may be {@code null}
+         * @param onCancel           how to treat still-pending tracked futures if cancellation is signalled first
          *
          * @return a CompletableFuture to a List of values (possibly partial on cancellation)
          */
-        CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture);
+        CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture, OnCancel onCancel);
 
         /**
          * This will return a {@code CompletableFuture<List<T>>} if ANY of the input values are async
@@ -119,7 +152,7 @@ public class Async {
         }
 
         @Override
-        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture) {
+        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture, OnCancel onCancel) {
             return await();
         }
 
@@ -168,7 +201,7 @@ public class Async {
         }
 
         @Override
-        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture) {
+        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture, OnCancel onCancel) {
             commonSizeAssert();
             if (cancellationFuture == null) {
                 return await();
@@ -181,6 +214,12 @@ public class Async {
                 CompletableFuture.anyOf(valueCF, cancellationFuture).whenComplete((ignored, exception) -> {
                     if (exception != null) {
                         overallResult.completeExceptionally(exception);
+                        return;
+                    }
+                    if (onCancel == OnCancel.WAIT_FOR_PENDING && !valueCF.isDone()) {
+                        // the tracked future is cancellation-aware and will complete promptly - wait for
+                        // its partial data rather than harvesting a null for it (see interface javadoc)
+                        valueCF.whenComplete((v, ex) -> overallResult.complete(Collections.singletonList(doneOrNull(valueCF))));
                         return;
                     }
                     overallResult.complete(Collections.singletonList(doneOrNull(valueCF)));
@@ -279,7 +318,7 @@ public class Async {
         }
 
         @Override
-        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture) {
+        public CompletableFuture<List<T>> await(@Nullable CompletableFuture<Void> cancellationFuture, OnCancel onCancel) {
             commonSizeAssert();
             if (cfCount == 0) {
                 return CompletableFuture.completedFuture(materialisedList(array));
@@ -291,18 +330,27 @@ public class Async {
             CompletableFuture<List<T>> overallResult = new CompletableFuture<>();
             CompletableFuture<Void> allOf = CompletableFuture.allOf(copyOnlyCFsToArray());
 
-            // Race "all field futures complete" against cancellation. The cancellation future always
-            // completes normally (see ExecutionInput#cancel), so anyOf can only complete exceptionally
-            // when a field future fails - in which case we propagate that failure.
+            // Wait for either "all field futures complete" (allOf) or cancellation, whichever happens
+            // first. The cancellation future always completes normally (see ExecutionInput#cancel), so
+            // anyOf can only complete exceptionally when a field future fails - which we propagate.
             CompletableFuture.anyOf(allOf, cancellationFuture).whenComplete((ignored, exception) -> {
                 if (exception != null) {
                     overallResult.completeExceptionally(exception);
                     return;
                 }
-                // Either every field future is done (allOf won) or cancellation won the race. In both
-                // cases we harvest whatever has completed; field futures that are not yet done become
-                // null. join() is safe here: if allOf is not done then no field future has failed (a
-                // failure would have completed allOf exceptionally and taken the branch above).
+                if (onCancel == OnCancel.WAIT_FOR_PENDING && !allOf.isDone()) {
+                    // Cancellation happened before all the field futures completed, but the caller knows
+                    // every tracked future is itself cancellation-aware and will complete promptly (e.g.
+                    // nested object/list results that harvest their own partial data on cancel). Wait for
+                    // them to settle so we capture that partial data instead of harvesting null for
+                    // entries that are just about to complete.
+                    allOf.whenComplete((ig, ex) -> overallResult.complete(harvestResults(array)));
+                    return;
+                }
+                // Either every field future is done (allOf completed first) or cancellation happened
+                // first. In both cases we harvest whatever has completed; field futures that are not yet
+                // done become null. join() is safe here: if allOf is not done then no field future has
+                // failed (a failure would have completed allOf exceptionally and taken the branch above).
                 overallResult.complete(harvestResults(array));
             });
 

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -74,7 +74,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             throwable = executionContext.possibleCancellation(throwable);
 
             if (throwable != null) {
-                if (capturePartialResults(executionContext) && completeValueInfos != null) {
+                if (completeValueInfos != null && capturePartialResults(executionContext)) {
                     // partial results: some FieldValueInfos completed before cancel - build with those
                     // null entries mean that FieldValueInfo CF wasn't done yet (field was cancelled)
                     Async.CombinedBuilder<Object> fieldValuesFutures = Async.ofExpectedSize(completeValueInfos.size());

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -1,7 +1,6 @@
 package graphql.execution;
 
 import graphql.ExecutionResult;
-import graphql.GraphQLContext;
 import graphql.PublicApi;
 import graphql.execution.incremental.DeferredExecutionSupport;
 import org.jspecify.annotations.NullMarked;
@@ -68,8 +67,8 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         executionStrategyCtx.onDispatched();
 
-        GraphQLContext graphQLContext = executionContext.getGraphQLContext();
-        futures.await(graphQLContext).whenComplete((completeValueInfos, throwable) -> {
+        CompletableFuture<Void> cancelCF = getCancellationFuture(executionContext);
+        futures.await(cancelCF).whenComplete((completeValueInfos, throwable) -> {
             List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);
 
             throwable = executionContext.possibleCancellation(throwable);
@@ -93,7 +92,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
                     executionStrategyCtx.onFieldValuesInfo(nonNullValueInfos);
                     // Let handleResultsWithPartialData add the error to avoid duplication
                     BiConsumer<List<Object>, Throwable> fieldValuesConsumer = handleResultsWithPartialData(executionContext, fieldsExecutedOnInitialResult, overallResult);
-                    fieldValuesFutures.await(graphQLContext).whenComplete(fieldValuesConsumer);
+                    fieldValuesFutures.await(cancelCF).whenComplete(fieldValuesConsumer);
                     return;
                 }
                 Throwable cause = throwable instanceof CompletionException ? throwable.getCause() : throwable;
@@ -109,7 +108,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             executionStrategyCtx.onFieldValuesInfo(completeValueInfos);
 
             BiConsumer<List<Object>, Throwable> fieldValuesConsumer = handleResultsWithPartialData(executionContext, fieldsExecutedOnInitialResult, overallResult);
-            fieldValuesFutures.await(graphQLContext).whenComplete(fieldValuesConsumer);
+            fieldValuesFutures.await(cancelCF).whenComplete(fieldValuesConsumer);
         }).exceptionally((ex) -> {
             // if there are any issues with combining/handling the field results,
             // complete the future at all costs and bubble up any thrown exception so

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -1,6 +1,7 @@
 package graphql.execution;
 
 import graphql.ExecutionResult;
+import graphql.GraphQLContext;
 import graphql.PublicApi;
 import graphql.execution.incremental.DeferredExecutionSupport;
 import org.jspecify.annotations.NullMarked;
@@ -10,9 +11,12 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionStra
 import graphql.introspection.Introspection;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 /**
  * The standard graphql execution strategy that runs fields asynchronously non-blocking.
@@ -64,14 +68,36 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         CompletableFuture<ExecutionResult> overallResult = new CompletableFuture<>();
         executionStrategyCtx.onDispatched();
 
-        futures.await().whenComplete((completeValueInfos, throwable) -> {
+        GraphQLContext graphQLContext = executionContext.getGraphQLContext();
+        futures.await(graphQLContext).whenComplete((completeValueInfos, throwable) -> {
             List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);
 
-            BiConsumer<List<Object>, Throwable> handleResultsConsumer = handleResults(executionContext, fieldsExecutedOnInitialResult, overallResult);
             throwable = executionContext.possibleCancellation(throwable);
 
             if (throwable != null) {
-                handleResultsConsumer.accept(null, throwable.getCause());
+                if (capturePartialResults(executionContext) && completeValueInfos != null) {
+                    // partial results: some FieldValueInfos completed before cancel - build with those
+                    // null entries mean that FieldValueInfo CF wasn't done yet (field was cancelled)
+                    Async.CombinedBuilder<Object> fieldValuesFutures = Async.ofExpectedSize(completeValueInfos.size());
+                    for (FieldValueInfo completeValueInfo : completeValueInfos) {
+                        if (completeValueInfo != null) {
+                            fieldValuesFutures.addObject(completeValueInfo.getFieldValueObject());
+                        } else {
+                            fieldValuesFutures.addObject((Object) null);
+                        }
+                    }
+                    List<FieldValueInfo> nonNullValueInfos = completeValueInfos.stream()
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList());
+                    dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(nonNullValueInfos, parameters);
+                    executionStrategyCtx.onFieldValuesInfo(nonNullValueInfos);
+                    // Let handleResultsWithPartialData add the error to avoid duplication
+                    BiConsumer<List<Object>, Throwable> fieldValuesConsumer = handleResultsWithPartialData(executionContext, fieldsExecutedOnInitialResult, overallResult);
+                    fieldValuesFutures.await(graphQLContext).whenComplete(fieldValuesConsumer);
+                    return;
+                }
+                Throwable cause = throwable instanceof CompletionException ? throwable.getCause() : throwable;
+                handleResults(executionContext, fieldsExecutedOnInitialResult, overallResult).accept(null, cause);
                 return;
             }
 
@@ -81,7 +107,9 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
             }
             dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(completeValueInfos, parameters);
             executionStrategyCtx.onFieldValuesInfo(completeValueInfos);
-            fieldValuesFutures.await().whenComplete(handleResultsConsumer);
+
+            BiConsumer<List<Object>, Throwable> fieldValuesConsumer = handleResultsWithPartialData(executionContext, fieldsExecutedOnInitialResult, overallResult);
+            fieldValuesFutures.await(graphQLContext).whenComplete(fieldValuesConsumer);
         }).exceptionally((ex) -> {
             // if there are any issues with combining/handling the field results,
             // complete the future at all costs and bubble up any thrown exception so

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -4,6 +4,7 @@ import graphql.ExecutionResult;
 import graphql.PublicApi;
 import graphql.execution.incremental.DeferredExecutionSupport;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import graphql.execution.instrumentation.ExecutionStrategyInstrumentationContext;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
@@ -13,8 +14,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 /**
@@ -73,42 +72,17 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
             throwable = executionContext.possibleCancellation(throwable);
 
-            if (throwable != null) {
-                if (completeValueInfos != null && capturePartialResults(executionContext)) {
-                    // partial results: some FieldValueInfos completed before cancel - build with those
-                    // null entries mean that FieldValueInfo CF wasn't done yet (field was cancelled)
-                    Async.CombinedBuilder<Object> fieldValuesFutures = Async.ofExpectedSize(completeValueInfos.size());
-                    for (FieldValueInfo completeValueInfo : completeValueInfos) {
-                        if (completeValueInfo != null) {
-                            fieldValuesFutures.addObject(completeValueInfo.getFieldValueObject());
-                        } else {
-                            fieldValuesFutures.addObject((Object) null);
-                        }
-                    }
-                    List<FieldValueInfo> nonNullValueInfos = completeValueInfos.stream()
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toList());
-                    dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(nonNullValueInfos, parameters);
-                    executionStrategyCtx.onFieldValuesInfo(nonNullValueInfos);
-                    // Let handleResultsWithPartialData add the error to avoid duplication
-                    BiConsumer<List<Object>, Throwable> fieldValuesConsumer = handleResultsWithPartialData(executionContext, fieldsExecutedOnInitialResult, overallResult);
-                    fieldValuesFutures.await(cancelCF).whenComplete(fieldValuesConsumer);
-                    return;
-                }
-                Throwable cause = throwable instanceof CompletionException ? throwable.getCause() : throwable;
-                handleResults(executionContext, fieldsExecutedOnInitialResult, overallResult).accept(null, cause);
+            if (throwable != null && !(completeValueInfos != null && capturePartialResults(executionContext))) {
+                // a genuine field failure, or a cancellation we cannot surface partial results for:
+                // there is nothing usable to return, so just report the error
+                handleResults(executionContext, fieldsExecutedOnInitialResult, overallResult).accept(null, throwable);
                 return;
             }
 
-            Async.CombinedBuilder<Object> fieldValuesFutures = Async.ofExpectedSize(completeValueInfos.size());
-            for (FieldValueInfo completeValueInfo : completeValueInfos) {
-                fieldValuesFutures.addObject(completeValueInfo.getFieldValueObject());
-            }
-            dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(completeValueInfos, parameters);
-            executionStrategyCtx.onFieldValuesInfo(completeValueInfos);
-
-            BiConsumer<List<Object>, Throwable> fieldValuesConsumer = handleResultsWithPartialData(executionContext, fieldsExecutedOnInitialResult, overallResult);
-            fieldValuesFutures.await(cancelCF).whenComplete(fieldValuesConsumer);
+            // normal completion, or partial-results-on-cancel: completeValueInfos holds the
+            // FieldValueInfos that completed (with null entries for any cancelled before completing)
+            completeFieldValues(executionContext, parameters, executionStrategyCtx, dataLoaderDispatcherStrategy,
+                    completeValueInfos, fieldsExecutedOnInitialResult, cancelCF, overallResult);
         }).exceptionally((ex) -> {
             // if there are any issues with combining/handling the field results,
             // complete the future at all costs and bubble up any thrown exception so
@@ -121,6 +95,42 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
 
         overallResult.whenComplete(executionStrategyCtx::onCompleted);
         return overallResult;
+    }
+
+    /**
+     * Turns the completed {@link FieldValueInfo}s into field values and completes the {@code overallResult}.
+     * <p>
+     * When partial-results-on-cancel is in play {@code completeValueInfos} may contain {@code null}
+     * entries for fields that were cancelled before they completed; those become {@code null} field
+     * values and are excluded from the instrumentation callbacks.
+     */
+    @SuppressWarnings("FutureReturnValueIgnored")
+    private void completeFieldValues(ExecutionContext executionContext,
+                                     ExecutionStrategyParameters parameters,
+                                     ExecutionStrategyInstrumentationContext executionStrategyCtx,
+                                     DataLoaderDispatchStrategy dataLoaderDispatcherStrategy,
+                                     List<FieldValueInfo> completeValueInfos,
+                                     List<String> fieldNames,
+                                     @Nullable CompletableFuture<Void> cancelCF,
+                                     CompletableFuture<ExecutionResult> overallResult) {
+        Async.CombinedBuilder<Object> fieldValuesFutures = Async.ofExpectedSize(completeValueInfos.size());
+        boolean hasNulls = false;
+        for (FieldValueInfo completeValueInfo : completeValueInfos) {
+            if (completeValueInfo != null) {
+                fieldValuesFutures.addObject(completeValueInfo.getFieldValueObject());
+            } else {
+                hasNulls = true;
+                fieldValuesFutures.addObject((Object) null);
+            }
+        }
+        // null entries only occur for partial-results-on-cancel; the instrumentation callbacks should
+        // not see them, so filter only when needed and otherwise pass the list straight through
+        List<FieldValueInfo> valueInfosForInstrumentation = hasNulls
+                ? completeValueInfos.stream().filter(Objects::nonNull).collect(Collectors.toList())
+                : completeValueInfos;
+        dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(valueInfosForInstrumentation, parameters);
+        executionStrategyCtx.onFieldValuesInfo(valueInfosForInstrumentation);
+        fieldValuesFutures.await(cancelCF).whenComplete(handleResults(executionContext, fieldNames, overallResult));
     }
 
 }

--- a/src/main/java/graphql/execution/AsyncExecutionStrategy.java
+++ b/src/main/java/graphql/execution/AsyncExecutionStrategy.java
@@ -11,10 +11,11 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionStra
 import graphql.introspection.Introspection;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
+
+import static graphql.execution.Async.CombinedBuilder.OnCancel.DROP_PENDING;
+import static graphql.execution.Async.CombinedBuilder.OnCancel.WAIT_FOR_PENDING;
 
 /**
  * The standard graphql execution strategy that runs fields asynchronously non-blocking.
@@ -67,7 +68,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
         executionStrategyCtx.onDispatched();
 
         CompletableFuture<Void> cancelCF = getCancellationFuture(executionContext);
-        futures.await(cancelCF).whenComplete((completeValueInfos, throwable) -> {
+        futures.await(cancelCF, DROP_PENDING).whenComplete((completeValueInfos, throwable) -> {
             List<String> fieldsExecutedOnInitialResult = deferredExecutionSupport.getNonDeferredFieldNames(fieldNames);
 
             throwable = executionContext.possibleCancellation(throwable);
@@ -79,7 +80,7 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
                 return;
             }
 
-            // normal completion, or partial-results-on-cancel: completeValueInfos holds the
+            // normal completion, or capturePartialResults(..) on cancel: completeValueInfos holds the
             // FieldValueInfos that completed (with null entries for any cancelled before completing)
             completeFieldValues(executionContext, parameters, executionStrategyCtx, dataLoaderDispatcherStrategy,
                     completeValueInfos, fieldsExecutedOnInitialResult, cancelCF, overallResult);
@@ -100,9 +101,9 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
     /**
      * Turns the completed {@link FieldValueInfo}s into field values and completes the {@code overallResult}.
      * <p>
-     * When partial-results-on-cancel is in play {@code completeValueInfos} may contain {@code null}
-     * entries for fields that were cancelled before they completed; those become {@code null} field
-     * values and are excluded from the instrumentation callbacks.
+     * When {@link #capturePartialResults(ExecutionContext)} is enabled {@code completeValueInfos} may
+     * contain {@code null} entries for fields that were cancelled before they completed; those become
+     * {@code null} field values and are excluded from the instrumentation callbacks.
      */
     @SuppressWarnings("FutureReturnValueIgnored")
     private void completeFieldValues(ExecutionContext executionContext,
@@ -113,24 +114,16 @@ public class AsyncExecutionStrategy extends AbstractAsyncExecutionStrategy {
                                      List<String> fieldNames,
                                      @Nullable CompletableFuture<Void> cancelCF,
                                      CompletableFuture<ExecutionResult> overallResult) {
-        Async.CombinedBuilder<Object> fieldValuesFutures = Async.ofExpectedSize(completeValueInfos.size());
-        boolean hasNulls = false;
-        for (FieldValueInfo completeValueInfo : completeValueInfos) {
-            if (completeValueInfo != null) {
-                fieldValuesFutures.addObject(completeValueInfo.getFieldValueObject());
-            } else {
-                hasNulls = true;
-                fieldValuesFutures.addObject((Object) null);
-            }
-        }
-        // null entries only occur for partial-results-on-cancel; the instrumentation callbacks should
-        // not see them, so filter only when needed and otherwise pass the list straight through
-        List<FieldValueInfo> valueInfosForInstrumentation = hasNulls
-                ? completeValueInfos.stream().filter(Objects::nonNull).collect(Collectors.toList())
-                : completeValueInfos;
+        Async.CombinedBuilder<Object> fieldValuesFutures = fieldValuesCombinedBuilder(completeValueInfos);
+        // null entries only occur when capturePartialResults(..) is enabled; the instrumentation callbacks
+        // should not see them, so filter them out (nonNullFieldValueInfos returns the list as-is if none)
+        List<FieldValueInfo> valueInfosForInstrumentation = nonNullFieldValueInfos(completeValueInfos);
         dataLoaderDispatcherStrategy.executionStrategyOnFieldValuesInfo(valueInfosForInstrumentation, parameters);
         executionStrategyCtx.onFieldValuesInfo(valueInfosForInstrumentation);
-        fieldValuesFutures.await(cancelCF).whenComplete(handleResults(executionContext, fieldNames, overallResult));
+        // value-phase futures are cancellation-aware (nested object/list results self-complete with
+        // their own partial data on cancel), so wait for them to settle rather than harvesting nulls
+        fieldValuesFutures.await(cancelCF, WAIT_FOR_PENDING)
+                .whenComplete(handleResults(executionContext, fieldNames, overallResult));
     }
 
 }

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -10,6 +10,7 @@ import graphql.ExecutionResultImpl;
 import graphql.GraphQL;
 import graphql.GraphQLContext;
 import graphql.GraphQLError;
+import graphql.GraphQLUnusualConfiguration;
 import graphql.GraphQLException;
 import graphql.Internal;
 import graphql.Profiler;
@@ -143,6 +144,13 @@ public class Execution {
                 .build();
 
         executionContext.getGraphQLContext().put(ResultNodesInfo.RESULT_NODES_INFO, executionContext.getResultNodesInfo());
+
+        // When partial results on cancel is enabled, store the cancellation future in the context
+        // so that Async.Many#await(GraphQLContext) can race against it
+        if (graphQLContext.getBoolean(GraphQLUnusualConfiguration.CancellationConfig.CAPTURE_PARTIAL_RESULTS_ON_CANCEL)) {
+            graphQLContext.put(GraphQLUnusualConfiguration.CancellationConfig.CANCELLATION_FUTURE_KEY,
+                    executionInput.getCancellationFuture());
+        }
 
         InstrumentationExecutionParameters parameters = new InstrumentationExecutionParameters(
                 executionInput, graphQLSchema

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -5,7 +5,6 @@ import graphql.DuckTyped;
 import graphql.EngineRunningState;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
-import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.PublicSpi;
@@ -62,6 +61,8 @@ import java.util.function.Supplier;
 
 import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CANCELLATION_FUTURE_KEY;
 import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CAPTURE_PARTIAL_RESULTS_ON_CANCEL;
+import static graphql.execution.Async.CombinedBuilder.OnCancel.DROP_PENDING;
+import static graphql.execution.Async.CombinedBuilder.OnCancel.WAIT_FOR_PENDING;
 import static graphql.execution.Async.exceptionallyCompletedFuture;
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.execution.FieldValueInfo.CompleteValueType.ENUM;
@@ -223,21 +224,38 @@ public abstract class ExecutionStrategy {
         resolveObjectCtx.onDispatched();
 
         CompletableFuture<Void> cancelCF = getCancellationFuture(executionContext);
-        Object fieldValueInfosResult = resolvedFieldFutures.awaitPolymorphic();
+        Object fieldValueInfosResult;
+        if (cancelCF == null) {
+            fieldValueInfosResult = resolvedFieldFutures.awaitPolymorphic();
+        } else {
+            // When capturePartialResults(..) is enabled we gather the field value infos but stop
+            // waiting as soon as cancellation is signalled. Otherwise a single slow sub-field (whose
+            // data fetcher returns a not-yet-complete future) would block this object from producing
+            // any partial result at all, since resolveFieldWithInfo folds the fetch into the
+            // FieldValueInfo future. On cancellation the list may contain null entries for the
+            // sub-fields that had not completed yet.
+            fieldValueInfosResult = resolvedFieldFutures.await(cancelCF, DROP_PENDING);
+        }
         if (fieldValueInfosResult instanceof CompletableFuture) {
             CompletableFuture<List<FieldValueInfo>> fieldValueInfos = (CompletableFuture<List<FieldValueInfo>>) fieldValueInfosResult;
             fieldValueInfos.whenComplete((completeValueInfos, throwable) -> {
                 throwable = executionContext.possibleCancellation(throwable);
 
-                if (throwable != null) {
+                if (throwable != null && !(completeValueInfos != null && capturePartialResults(executionContext))) {
+                    // a genuine field failure, or a cancellation we cannot surface partial results for
                     handleResultsConsumer.accept(null, throwable);
                     return;
                 }
 
+                // completeValueInfos may contain null entries for sub-fields that were cancelled
+                // before completing; the builder tolerates those and turns them into null values
                 Async.CombinedBuilder<Object> resultFutures = fieldValuesCombinedBuilder(completeValueInfos);
-                dataLoaderDispatcherStrategy.executeObjectOnFieldValuesInfo(completeValueInfos, parameters);
-                resolveObjectCtx.onFieldValuesInfo(completeValueInfos);
-                resultFutures.await(cancelCF).whenComplete(handleResultsConsumer);
+                List<FieldValueInfo> valueInfosForInstrumentation = nonNullFieldValueInfos(completeValueInfos);
+                dataLoaderDispatcherStrategy.executeObjectOnFieldValuesInfo(valueInfosForInstrumentation, parameters);
+                resolveObjectCtx.onFieldValuesInfo(valueInfosForInstrumentation);
+                // value-phase futures are cancellation-aware (nested object/list results self-complete
+                // with their own partial data on cancel), so wait for them to settle on cancel
+                resultFutures.await(cancelCF, WAIT_FOR_PENDING).whenComplete(handleResultsConsumer);
             }).exceptionally((ex) -> {
                 // if there are any issues with combining/handling the field results,
                 // complete the future at all costs and bubble up any thrown exception so
@@ -270,12 +288,42 @@ public abstract class ExecutionStrategy {
         }
     }
 
-    private static Async.@NonNull CombinedBuilder<Object> fieldValuesCombinedBuilder(List<FieldValueInfo> completeValueInfos) {
+    protected static Async.@NonNull CombinedBuilder<Object> fieldValuesCombinedBuilder(List<FieldValueInfo> completeValueInfos) {
         Async.CombinedBuilder<Object> resultFutures = Async.ofExpectedSize(completeValueInfos.size());
         for (FieldValueInfo completeValueInfo : completeValueInfos) {
-            resultFutures.addObject(completeValueInfo.getFieldValueObject());
+            // a null FieldValueInfo only happens when capturePartialResults(..) is enabled and a
+            // sub-field was cancelled before it completed - it becomes a null field value in the result
+            resultFutures.addObject(completeValueInfo != null ? completeValueInfo.getFieldValueObject() : null);
         }
         return resultFutures;
+    }
+
+    @DuckTyped(shape = "CompletableFuture<List<Object>> | List<Object>")
+    private static Object awaitListElementValues(List<FieldValueInfo> fieldValueInfos, @Nullable CompletableFuture<Void> cancelCF) {
+        if (cancelCF == null) {
+            // no cancellation in play - keep the existing (cheaper) path unchanged
+            return Async.eachPolymorphic(fieldValueInfos, FieldValueInfo::getFieldValueObject);
+        }
+        // Wait for the list element values, but stop waiting when cancellation is signalled. List
+        // elements are cancellation-aware (nested object/list elements self-complete with their own
+        // partial data on cancel, and scalar/enum elements are already materialised), so on cancel we
+        // wait for them to settle and harvest their partial data rather than blocking the whole list
+        // on one slow element.
+        return fieldValuesCombinedBuilder(fieldValueInfos).await(cancelCF, WAIT_FOR_PENDING);
+    }
+
+    protected static List<FieldValueInfo> nonNullFieldValueInfos(List<FieldValueInfo> completeValueInfos) {
+        boolean hasNulls = completeValueInfos.contains(null);
+        if (!hasNulls) {
+            return completeValueInfos;
+        }
+        List<FieldValueInfo> result = new ArrayList<>(completeValueInfos.size());
+        for (FieldValueInfo completeValueInfo : completeValueInfos) {
+            if (completeValueInfo != null) {
+                result.add(completeValueInfo);
+            }
+        }
+        return result;
     }
 
     protected boolean capturePartialResults(ExecutionContext executionContext) {
@@ -284,19 +332,19 @@ public abstract class ExecutionStrategy {
 
     /**
      * Returns the cancellation future from the execution context if partial result capture is enabled,
-     * or {@code null} otherwise. This is used to pass into {@link Async.CombinedBuilder#await(CompletableFuture)}
-     * so that the generic utility can race against cancellation without needing to know about GraphQL context.
+     * or {@code null} otherwise. This is passed into
+     * {@link Async.CombinedBuilder#await(CompletableFuture, Async.CombinedBuilder.OnCancel)} so that the generic
+     * utility can stop waiting when cancellation is signalled, without needing to know about GraphQL context.
      *
      * @param executionContext the execution context
      *
      * @return the cancellation future, or {@code null} if partial results on cancel is not enabled
      */
     protected @Nullable CompletableFuture<Void> getCancellationFuture(ExecutionContext executionContext) {
-        GraphQLContext graphQLContext = executionContext.getGraphQLContext();
-        if (!graphQLContext.getBoolean(CAPTURE_PARTIAL_RESULTS_ON_CANCEL)) {
+        if (!capturePartialResults(executionContext)) {
             return null;
         }
-        return graphQLContext.get(CANCELLATION_FUTURE_KEY);
+        return executionContext.getGraphQLContext().get(CANCELLATION_FUTURE_KEY);
     }
 
     private BiConsumer<List<Object>, Throwable> buildFieldValueMap(List<String> fieldNames, CompletableFuture<Map<String, Object>> overallResult, ExecutionContext executionContext) {
@@ -864,7 +912,8 @@ public abstract class ExecutionStrategy {
             index++;
         }
 
-        Object listResults = Async.eachPolymorphic(fieldValueInfos, FieldValueInfo::getFieldValueObject);
+        CompletableFuture<Void> cancelCF = getCancellationFuture(executionContext);
+        Object listResults = awaitListElementValues(fieldValueInfos, cancelCF);
         Object listOrPromiseToList;
         if (listResults instanceof CompletableFuture) {
             @SuppressWarnings("unchecked")
@@ -877,6 +926,18 @@ public abstract class ExecutionStrategy {
                 exception = executionContext.possibleCancellation(exception);
 
                 if (exception != null) {
+                    // On cancellation possibleCancellation(..) yields a bare AbortExecutionException on top of
+                    // a successful (non-null) results list; a genuine field failure completes exceptionally
+                    // with results == null and a non-abort exception, which falls through to handleValueException.
+                    if (exception instanceof AbortExecutionException && capturePartialResults(executionContext)) {
+                        // capturePartialResults(..) is enabled: results already holds the harvested
+                        // element values (with nulls for elements whose sub-fields were still pending on cancel)
+                        executionContext.addError((AbortExecutionException) exception);
+                        List<Object> partialResults = new ArrayList<>(results.size());
+                        partialResults.addAll(results);
+                        overallResult.complete(partialResults);
+                        return;
+                    }
                     handleValueException(overallResult, exception, executionContext);
                     return;
                 }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -47,6 +47,7 @@ import graphql.schema.GraphQLType;
 import graphql.schema.LightDataFetcher;
 import graphql.util.FpKit;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,6 +60,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CANCELLATION_FUTURE_KEY;
 import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CAPTURE_PARTIAL_RESULTS_ON_CANCEL;
 import static graphql.execution.Async.exceptionallyCompletedFuture;
 import static graphql.execution.FieldCollectorParameters.newParameters;
@@ -220,7 +222,7 @@ public abstract class ExecutionStrategy {
 
         resolveObjectCtx.onDispatched();
 
-        GraphQLContext graphQLContext = executionContext.getGraphQLContext();
+        CompletableFuture<Void> cancelCF = getCancellationFuture(executionContext);
         Object fieldValueInfosResult = resolvedFieldFutures.awaitPolymorphic();
         if (fieldValueInfosResult instanceof CompletableFuture) {
             CompletableFuture<List<FieldValueInfo>> fieldValueInfos = (CompletableFuture<List<FieldValueInfo>>) fieldValueInfosResult;
@@ -235,7 +237,7 @@ public abstract class ExecutionStrategy {
                 Async.CombinedBuilder<Object> resultFutures = fieldValuesCombinedBuilder(completeValueInfos);
                 dataLoaderDispatcherStrategy.executeObjectOnFieldValuesInfo(completeValueInfos, parameters);
                 resolveObjectCtx.onFieldValuesInfo(completeValueInfos);
-                resultFutures.await(graphQLContext).whenComplete(handleResultsConsumer);
+                resultFutures.await(cancelCF).whenComplete(handleResultsConsumer);
             }).exceptionally((ex) -> {
                 // if there are any issues with combining/handling the field results,
                 // complete the future at all costs and bubble up any thrown exception so
@@ -278,6 +280,23 @@ public abstract class ExecutionStrategy {
 
     protected boolean capturePartialResults(ExecutionContext executionContext) {
         return executionContext.getGraphQLContext().getBoolean(CAPTURE_PARTIAL_RESULTS_ON_CANCEL);
+    }
+
+    /**
+     * Returns the cancellation future from the execution context if partial result capture is enabled,
+     * or {@code null} otherwise. This is used to pass into {@link Async.CombinedBuilder#await(CompletableFuture)}
+     * so that the generic utility can race against cancellation without needing to know about GraphQL context.
+     *
+     * @param executionContext the execution context
+     *
+     * @return the cancellation future, or {@code null} if partial results on cancel is not enabled
+     */
+    protected @Nullable CompletableFuture<Void> getCancellationFuture(ExecutionContext executionContext) {
+        GraphQLContext graphQLContext = executionContext.getGraphQLContext();
+        if (!graphQLContext.getBoolean(CAPTURE_PARTIAL_RESULTS_ON_CANCEL)) {
+            return null;
+        }
+        return graphQLContext.get(CANCELLATION_FUTURE_KEY);
     }
 
     private BiConsumer<List<Object>, Throwable> buildFieldValueMap(List<String> fieldNames, CompletableFuture<Map<String, Object>> overallResult, ExecutionContext executionContext) {

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -5,6 +5,7 @@ import graphql.DuckTyped;
 import graphql.EngineRunningState;
 import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
+import graphql.GraphQLContext;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.PublicSpi;
@@ -58,6 +59,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static graphql.GraphQLUnusualConfiguration.CancellationConfig.CAPTURE_PARTIAL_RESULTS_ON_CANCEL;
 import static graphql.execution.Async.exceptionallyCompletedFuture;
 import static graphql.execution.FieldCollectorParameters.newParameters;
 import static graphql.execution.FieldValueInfo.CompleteValueType.ENUM;
@@ -218,6 +220,7 @@ public abstract class ExecutionStrategy {
 
         resolveObjectCtx.onDispatched();
 
+        GraphQLContext graphQLContext = executionContext.getGraphQLContext();
         Object fieldValueInfosResult = resolvedFieldFutures.awaitPolymorphic();
         if (fieldValueInfosResult instanceof CompletableFuture) {
             CompletableFuture<List<FieldValueInfo>> fieldValueInfos = (CompletableFuture<List<FieldValueInfo>>) fieldValueInfosResult;
@@ -232,7 +235,7 @@ public abstract class ExecutionStrategy {
                 Async.CombinedBuilder<Object> resultFutures = fieldValuesCombinedBuilder(completeValueInfos);
                 dataLoaderDispatcherStrategy.executeObjectOnFieldValuesInfo(completeValueInfos, parameters);
                 resolveObjectCtx.onFieldValuesInfo(completeValueInfos);
-                resultFutures.await().whenComplete(handleResultsConsumer);
+                resultFutures.await(graphQLContext).whenComplete(handleResultsConsumer);
             }).exceptionally((ex) -> {
                 // if there are any issues with combining/handling the field results,
                 // complete the future at all costs and bubble up any thrown exception so
@@ -273,17 +276,33 @@ public abstract class ExecutionStrategy {
         return resultFutures;
     }
 
+    protected boolean capturePartialResults(ExecutionContext executionContext) {
+        return executionContext.getGraphQLContext().getBoolean(CAPTURE_PARTIAL_RESULTS_ON_CANCEL);
+    }
+
     private BiConsumer<List<Object>, Throwable> buildFieldValueMap(List<String> fieldNames, CompletableFuture<Map<String, Object>> overallResult, ExecutionContext executionContext) {
         return (List<Object> results, Throwable exception) -> {
             exception = executionContext.possibleCancellation(exception);
 
             if (exception != null) {
+                Throwable cause = exception instanceof CompletionException ? exception.getCause() : exception;
+                if (cause instanceof AbortExecutionException && results != null
+                        && capturePartialResults(executionContext)) {
+                    // partial results mode: results already has harvested values from completed CFs
+                    executionContext.addError((AbortExecutionException) cause);
+                    completeFieldValueMap(overallResult, executionContext, fieldNames, results);
+                    return;
+                }
                 handleValueException(overallResult, exception, executionContext);
                 return;
             }
-            Map<String, Object> resolvedValuesByField = executionContext.getResponseMapFactory().createInsertionOrdered(fieldNames, results);
-            overallResult.complete(resolvedValuesByField);
+            completeFieldValueMap(overallResult, executionContext, fieldNames, results);
         };
+    }
+
+    protected void completeFieldValueMap(CompletableFuture<Map<String, Object>> overallResult, ExecutionContext executionContext, List<String> fieldNames, List<Object> results) {
+        Map<String, Object> resolvedValuesByField = executionContext.getResponseMapFactory().createInsertionOrdered(fieldNames, results);
+        overallResult.complete(resolvedValuesByField);
     }
 
     DeferredExecutionSupport createDeferredExecutionSupport(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -623,6 +623,60 @@ class ExecutionInputTest extends Specification {
         er.data == null
     }
 
+    def "without capturePartialResultsOnCancel a late cancel discards even fully gathered nested data"() {
+        // capture is OFF, so there is no cancellation race; the top-level 'outer' field value info
+        // completes quickly while its nested 'value' is still resolving. Cancelling at that point and
+        // then letting 'value' finish means the field values are fully gathered, but because capture
+        // is disabled the gathered data must be discarded and only the cancel error returned.
+        def sdl = '''
+            type Query {
+                outer : Inner
+            }
+            type Inner {
+                value : String
+            }
+        '''
+
+        CountDownLatch valueStarted = new CountDownLatch(1)
+        CountDownLatch valueRelease = new CountDownLatch(1)
+
+        DataFetcher outerDf = { DataFetchingEnvironment env -> [:] }
+        DataFetcher valueDf = { DataFetchingEnvironment env ->
+            return CompletableFuture.supplyAsync {
+                valueStarted.countDown()
+                valueRelease.await()
+                return "value"
+            }
+        }
+
+        def fetcherMap = ["Query": ["outer": outerDf], "Inner": ["value": valueDf]]
+        def schema = TestUtil.schema(sdl, fetcherMap)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{ outer { value } }")
+                .build() // capturePartialResultsOnCancel NOT enabled
+
+        def cf = graphQL.executeAsync(executionInput)
+
+        // the nested value DF has started, so 'outer' field value info is already done
+        valueStarted.await()
+        // cancel while the nested value is still resolving, then let it finish
+        executionInput.cancel()
+        valueRelease.countDown()
+
+        await().atMost(Duration.ofSeconds(10)).until({ -> cf.isDone() })
+        def er = cf.join()
+
+        then:
+        !cf.isCompletedExceptionally()
+        !er.errors.isEmpty()
+        er.errors[0]["message"] == "Execution has been asked to be cancelled"
+        // capture disabled - even though the data was fully gathered, it is discarded
+        er.data == null
+    }
+
     private static ExecutionResult awaitAsync(GraphQL graphQL, ExecutionInput executionInput) {
         def cf = graphQL.executeAsync(executionInput)
         await().atMost(Duration.ofSeconds(10)).until({ -> cf.isDone() })

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -623,6 +623,74 @@ class ExecutionInputTest extends Specification {
         er.data == null
     }
 
+    def "capturePartialResultsOnCancel returns partial data when nested object sub-field is cancelled"() {
+        // This exercises the buildFieldValueMap lambda inside ExecutionStrategy.executeObject()
+        // for a nested object type. The parent DF returns a map synchronously so the nested
+        // object's executeObject starts immediately. Inside the nested executeObject, 'fast'
+        // completes while 'slow' blocks. Cancellation fires at the await(cancelCF) inside
+        // executeObject for the nested Parent type, triggering the partial-results branch in
+        // buildFieldValueMap.
+        def sdl = '''
+            type Query {
+                parent : Parent
+            }
+            type Parent {
+                fast : String
+                slow : String
+            }
+        '''
+
+        CountDownLatch slowStarted = new CountDownLatch(1)
+        CompletableFuture<String> slowResult = new CompletableFuture<>()
+
+        DataFetcher parentDf = { DataFetchingEnvironment env -> [:] }
+        DataFetcher fastDf = { DataFetchingEnvironment env -> "fast-value" }
+        DataFetcher slowDf = { DataFetchingEnvironment env ->
+            slowStarted.countDown()
+            return slowResult
+        }
+
+        def fetcherMap = [
+                "Query" : ["parent": parentDf],
+                "Parent": ["fast": fastDf, "slow": slowDf]
+        ]
+        def schema = TestUtil.schema(sdl, fetcherMap)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{ parent { fast slow } }")
+                .graphQLContext({ c ->
+                    GraphQL.unusualConfiguration(c).cancellation().capturePartialResultsOnCancel(true)
+                })
+                .build()
+
+        def cf = graphQL.executeAsync(executionInput)
+
+        // wait for the slow DF to have been invoked — fast is already done synchronously
+        slowStarted.await()
+        // cancel while slow's CF is still pending; this completes the cancellation future
+        // which races against the pending slowResult inside await(cancelCF)
+        executionInput.cancel()
+
+        await().atMost(Duration.ofSeconds(10)).until({ -> cf.isDone() })
+        def er = cf.join()
+
+        then:
+        !cf.isCompletedExceptionally()
+        !er.errors.isEmpty()
+        er.errors.any { it["message"] == "Execution has been asked to be cancelled" }
+        // The top-level partial results capture sees parent's CF as still pending
+        // (because its nested sub-fields are being resolved), so parent is null.
+        // The nested buildFieldValueMap lambda also fires on the same cancellation.
+        er.data != null
+        er.data.containsKey("parent")
+
+        cleanup:
+        // release slow so any background threads can finish
+        slowResult.complete("slow-value")
+    }
+
     def "without capturePartialResultsOnCancel a late cancel discards even fully gathered nested data"() {
         // capture is OFF, so there is no cancellation race; the top-level 'outer' field value info
         // completes quickly while its nested 'value' is still resolving. Cancelling at that point and

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -451,6 +451,178 @@ class ExecutionInputTest extends Specification {
 
     }
 
+    def "capturePartialResultsOnCancel configuration is accessible via unusualConfiguration"() {
+        // Smoke test: verify the configuration API works correctly
+
+        def sdl = '''
+            type Query {
+                field1 : String
+                field2 : String
+            }
+        '''
+
+        DataFetcher df = { DataFetchingEnvironment env -> "value" }
+
+        def fetcherMap = ["Query": ["field1": df, "field2": df]]
+        def schema = TestUtil.schema(sdl, fetcherMap)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when: "capturePartialResultsOnCancel is enabled and execution completes normally"
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{ field1 field2 }")
+                .graphQLContext({ c ->
+                    GraphQL.unusualConfiguration(c).cancellation().capturePartialResultsOnCancel(true)
+                })
+                .build()
+
+        def er = graphQL.execute(executionInput)
+
+        then: "normal results are returned unchanged"
+        er.errors.isEmpty()
+        er.data == [field1: "value", field2: "value"]
+
+        when: "capturePartialResultsOnCancel is enabled but cancel is called before execution"
+        ExecutionInput cancelledInput = ExecutionInput.newExecutionInput()
+                .query("{ field1 field2 }")
+                .graphQLContext({ c ->
+                    GraphQL.unusualConfiguration(c).cancellation().capturePartialResultsOnCancel(true)
+                })
+                .build()
+        cancelledInput.cancel()
+
+        er = graphQL.execute(cancelledInput)
+
+        then: "cancel error is returned"
+        !er.errors.isEmpty()
+        er.errors.any { it["message"].contains("Execution has been asked to be cancelled") }
+    }
+
+    def "capturePartialResultsOnCancel returns fast field value when slow field is cancelled"() {
+        // The partial-results harvest happens at the fieldValuesFutures.await(graphQLContext) level.
+        // FieldValueInfo.getFieldValueObject() for async object fields is a CompletableFuture<Map>.
+        // When the slow object's CF hasn't completed yet and cancel fires, await(graphQLContext)
+        // harvests the already-done fast CF and returns partial data.
+        def sdl = '''
+            type Query {
+                fast : Inner
+                slow : Inner
+            }
+            type Inner {
+                value : String
+            }
+        '''
+
+        CountDownLatch slowStarted = new CountDownLatch(1)
+        CountDownLatch slowRelease = new CountDownLatch(1)
+
+        DataFetcher fastInnerDf = { DataFetchingEnvironment env ->
+            return CompletableFuture.completedFuture([value: "fast-value"])
+        }
+
+        DataFetcher slowInnerDf = { DataFetchingEnvironment env ->
+            return CompletableFuture.supplyAsync {
+                slowStarted.countDown()
+                slowRelease.await()
+                return [value: "slow-value"]
+            }
+        }
+
+        DataFetcher innerValueDf = { DataFetchingEnvironment env ->
+            return env.source["value"]
+        }
+
+        def fetcherMap = [
+                "Query": ["fast": fastInnerDf, "slow": slowInnerDf],
+                "Inner": ["value": innerValueDf]
+        ]
+        def schema = TestUtil.schema(sdl, fetcherMap)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{ fast { value } slow { value } }")
+                .graphQLContext({ c ->
+                    GraphQL.unusualConfiguration(c).cancellation().capturePartialResultsOnCancel(true)
+                })
+                .build()
+
+        def cf = graphQL.executeAsync(executionInput)
+
+        // wait for slow DF to have started; by this point fast has already completed
+        slowStarted.await()
+
+        // cancel while slow is still blocked; fast's fieldValue CF is already done
+        executionInput.cancel()
+
+        // unblock slow so it doesn't hang forever
+        slowRelease.countDown()
+
+        await().atMost(Duration.ofSeconds(10)).until({ -> cf.isDone() })
+        def er = cf.join()
+
+        then:
+        !cf.isCompletedExceptionally()
+        !er.errors.isEmpty()
+        er.errors.any { it["message"].contains("Execution has been asked to be cancelled") }
+        // fast field completed before cancel — its data should be present
+        er.data != null
+        er.data["fast"] != null
+        er.data["fast"]["value"] == "fast-value"
+        // slow field was cancelled — should be null
+        er.data["slow"] == null
+    }
+
+    def "without capturePartialResultsOnCancel only the cancel error is returned"() {
+        def sdl = '''
+            type Query {
+                fast : String
+                slow : String
+            }
+        '''
+
+        CountDownLatch fastDone = new CountDownLatch(1)
+        CountDownLatch slowLatch = new CountDownLatch(1)
+
+        DataFetcher fastDf = { DataFetchingEnvironment env ->
+            return CompletableFuture.supplyAsync {
+                fastDone.countDown()
+                return "fast-value"
+            }
+        }
+
+        DataFetcher slowDf = { DataFetchingEnvironment env ->
+            return CompletableFuture.supplyAsync {
+                slowLatch.await()
+                return "slow-value"
+            }
+        }
+
+        def fetcherMap = ["Query": ["fast": fastDf, "slow": slowDf]]
+        def schema = TestUtil.schema(sdl, fetcherMap)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{ fast slow }")
+                .build()
+
+        def cf = graphQL.executeAsync(executionInput)
+
+        fastDone.await()
+        executionInput.cancel()
+        slowLatch.countDown()
+
+        await().atMost(Duration.ofSeconds(10)).until({ -> cf.isDone() })
+        def er = cf.join()
+
+        then:
+        !cf.isCompletedExceptionally()
+        !er.errors.isEmpty()
+        er.errors[0]["message"] == "Execution has been asked to be cancelled"
+        // no partial data - old behaviour
+        er.data == null
+    }
+
     private static ExecutionResult awaitAsync(GraphQL graphQL, ExecutionInput executionInput) {
         def cf = graphQL.executeAsync(executionInput)
         await().atMost(Duration.ofSeconds(10)).until({ -> cf.isDone() })

--- a/src/test/groovy/graphql/ExecutionInputTest.groovy
+++ b/src/test/groovy/graphql/ExecutionInputTest.groovy
@@ -680,15 +680,91 @@ class ExecutionInputTest extends Specification {
         !cf.isCompletedExceptionally()
         !er.errors.isEmpty()
         er.errors.any { it["message"] == "Execution has been asked to be cancelled" }
-        // The top-level partial results capture sees parent's CF as still pending
-        // (because its nested sub-fields are being resolved), so parent is null.
-        // The nested buildFieldValueMap lambda also fires on the same cancellation.
+        // The nested object's already-completed sub-field ('fast') is captured as partial data,
+        // and the top-level value harvest waits for that cancellation-aware nested CF to settle
+        // rather than discarding it as null. The still-pending 'slow' sub-field becomes null.
         er.data != null
-        er.data.containsKey("parent")
+        er.data["parent"] != null
+        er.data["parent"]["fast"] == "fast-value"
+        er.data["parent"]["slow"] == null
 
         cleanup:
         // release slow so any background threads can finish
         slowResult.complete("slow-value")
+    }
+
+    def "capturePartialResultsOnCancel returns partial data when a list element sub-field is cancelled"() {
+        // A list of objects where one element has a fast sub-field (completed) and one element has a
+        // slow sub-field (still pending on cancel). Without racing cancellation while awaiting the list
+        // element values, one slow element would block the whole list and produce no partial data.
+        // We expect the completed element to be captured and the pending one's field to be null.
+        def sdl = '''
+            type Query {
+                items : [Item]
+            }
+            type Item {
+                fast : String
+                slow : String
+            }
+        '''
+
+        // we depend on three sub-fields completing before we cancel: item0.fast, item0.slow, item1.fast
+        CountDownLatch shouldCompleteDone = new CountDownLatch(3)
+        CompletableFuture<String> slowResult = new CompletableFuture<>()
+
+        DataFetcher itemsDf = { DataFetchingEnvironment env -> [[id: "0"], [id: "1"]] }
+        DataFetcher fastDf = { DataFetchingEnvironment env ->
+            return CompletableFuture.completedFuture("fast-value")
+                    .whenComplete { r, t -> shouldCompleteDone.countDown() }
+        }
+        // element 0's slow completes immediately; element 1's slow stays pending until after cancel
+        DataFetcher slowDf = { DataFetchingEnvironment env ->
+            def id = (env.getSource() as Map)["id"]
+            return id == "0"
+                    ? CompletableFuture.completedFuture("slow-value-0").whenComplete { r, t -> shouldCompleteDone.countDown() }
+                    : slowResult
+        }
+
+        def fetcherMap = [
+                "Query": ["items": itemsDf],
+                "Item" : ["fast": fastDf, "slow": slowDf]
+        ]
+        def schema = TestUtil.schema(sdl, fetcherMap)
+        def graphQL = GraphQL.newGraphQL(schema).build()
+
+        when:
+        ExecutionInput executionInput = ExecutionInput.newExecutionInput()
+                .query("{ items { fast slow } }")
+                .graphQLContext({ c ->
+                    GraphQL.unusualConfiguration(c).cancellation().capturePartialResultsOnCancel(true)
+                })
+                .build()
+
+        def cf = graphQL.executeAsync(executionInput)
+
+        // all the sub-fields we assert on are done; cancel while element 1's slow is still pending
+        shouldCompleteDone.await()
+        executionInput.cancel()
+
+        await().atMost(Duration.ofSeconds(10)).until({ -> cf.isDone() })
+        def er = cf.join()
+
+        then:
+        !cf.isCompletedExceptionally()
+        !er.errors.isEmpty()
+        er.errors.any { it["message"] == "Execution has been asked to be cancelled" }
+        er.data != null
+        er.data["items"] != null
+        er.data["items"].size() == 2
+        // both elements' fast sub-field completed
+        er.data["items"][0]["fast"] == "fast-value"
+        er.data["items"][1]["fast"] == "fast-value"
+        // element 0's slow completed, element 1's slow was still pending -> null
+        er.data["items"][0]["slow"] == "slow-value-0"
+        er.data["items"][1]["slow"] == null
+
+        cleanup:
+        slowResult.complete("slow-value-1")
     }
 
     def "without capturePartialResultsOnCancel a late cancel discards even fully gathered nested data"() {

--- a/src/test/groovy/graphql/execution/AsyncTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncTest.groovy
@@ -548,6 +548,17 @@ class AsyncTest extends Specification {
         list == ["A", "B", "C"]
     }
 
+    def "await with null cancelCF delegates to plain await"() {
+        when: "a many builder is awaited with a null cancellation future"
+        def asyncBuilder = Async.ofExpectedSize(2)
+        asyncBuilder.add(completedFuture("A"))
+        asyncBuilder.add(completedFuture("B"))
+        def list = asyncBuilder.await((CompletableFuture<Void>) null).join()
+
+        then: "it behaves identically to await() and returns all results"
+        list == ["A", "B"]
+    }
+
     def "await with cancelCF on empty builder returns empty list"() {
         when:
         def cancelCF = new CompletableFuture<Void>()

--- a/src/test/groovy/graphql/execution/AsyncTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncTest.groovy
@@ -508,8 +508,14 @@ class AsyncTest extends Specification {
 
         def list = resultCF.join()
 
-        then:
+        then: "full results returned despite cancel firing after"
         list == ["X", "Y"]
+
+        when: "cancelCF completes after all CFs - should not affect result"
+        cancelCF.complete(null)
+
+        then: "result is unchanged"
+        resultCF.join() == ["X", "Y"]
     }
 
     def "await with cancelCF propagates exception if a CF fails before cancellation"() {
@@ -553,10 +559,21 @@ class AsyncTest extends Specification {
     }
 
     def "await with cancelCF on single builder delegates to plain await"() {
-        when:
+        when: "single builder with a completed CF"
         def cancelCF = new CompletableFuture<Void>()
         def asyncBuilder = Async.ofExpectedSize(1)
         asyncBuilder.add(completedFuture("A"))
+        def list = asyncBuilder.await(cancelCF).join()
+
+        then: "result is returned normally - cancellation is not raced for single elements"
+        list == ["A"]
+    }
+
+    def "await with cancelCF on single builder with materialised value delegates to plain await"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def asyncBuilder = Async.ofExpectedSize(1)
+        asyncBuilder.addObject("A")
         def list = asyncBuilder.await(cancelCF).join()
 
         then:

--- a/src/test/groovy/graphql/execution/AsyncTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncTest.groovy
@@ -421,4 +421,145 @@ class AsyncTest extends Specification {
             return awaited
         }
     }
+
+    def "await with null cancelCF behaves like plain await"() {
+        when:
+        def asyncBuilder = Async.ofExpectedSize(3)
+        asyncBuilder.add(completedFuture("A"))
+        asyncBuilder.add(completedFuture("B"))
+        asyncBuilder.add(completedFuture("C"))
+        def list = asyncBuilder.await((CompletableFuture) null).join()
+
+        then:
+        list == ["A", "B", "C"]
+    }
+
+    def "await with cancelCF returns all results when all CFs complete before cancellation"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def asyncBuilder = Async.ofExpectedSize(3)
+        asyncBuilder.add(completedFuture("A"))
+        asyncBuilder.add(completedFuture("B"))
+        asyncBuilder.add(completedFuture("C"))
+        def list = asyncBuilder.await(cancelCF).join()
+
+        then:
+        list == ["A", "B", "C"]
+    }
+
+    def "await with cancelCF returns partial results when cancellation fires before all CFs complete"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def pending1 = new CompletableFuture<String>()
+        def pending2 = new CompletableFuture<String>()
+
+        def asyncBuilder = Async.ofExpectedSize(4)
+        asyncBuilder.add(completedFuture("A"))
+        asyncBuilder.add(pending1)
+        asyncBuilder.add(completedFuture("C"))
+        asyncBuilder.add(pending2)
+
+        def resultCF = asyncBuilder.await(cancelCF)
+
+        // cancel before pending CFs complete
+        cancelCF.complete(null)
+
+        def list = resultCF.join()
+
+        then:
+        list == ["A", null, "C", null]
+    }
+
+    def "await with cancelCF returns partial results with mixed objects and CFs"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def pending = new CompletableFuture<String>()
+
+        def asyncBuilder = Async.ofExpectedSize(4)
+        asyncBuilder.addObject("A")
+        asyncBuilder.add(completedFuture("B"))
+        asyncBuilder.add(pending)
+        asyncBuilder.addObject("D")
+
+        def resultCF = asyncBuilder.await(cancelCF)
+
+        cancelCF.complete(null)
+        def list = resultCF.join()
+
+        then:
+        list == ["A", "B", null, "D"]
+    }
+
+    def "await with cancelCF returns full results when all CFs complete even if cancelCF completes later"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def cf1 = new CompletableFuture<String>()
+        def cf2 = new CompletableFuture<String>()
+
+        def asyncBuilder = Async.ofExpectedSize(2)
+        asyncBuilder.add(cf1)
+        asyncBuilder.add(cf2)
+
+        def resultCF = asyncBuilder.await(cancelCF)
+
+        // complete all CFs before cancellation
+        cf1.complete("X")
+        cf2.complete("Y")
+
+        def list = resultCF.join()
+
+        then:
+        list == ["X", "Y"]
+    }
+
+    def "await with cancelCF propagates exception if a CF fails before cancellation"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def failing = new CompletableFuture<String>()
+        failing.completeExceptionally(new RuntimeException("boom"))
+
+        def asyncBuilder = Async.ofExpectedSize(2)
+        asyncBuilder.add(completedFuture("A"))
+        asyncBuilder.add(failing)
+
+        def resultCF = asyncBuilder.await(cancelCF)
+        resultCF.join()
+
+        then:
+        thrown(CompletionException)
+    }
+
+    def "await with cancelCF works with all materialised values"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def asyncBuilder = Async.ofExpectedSize(3)
+        asyncBuilder.addObject("A")
+        asyncBuilder.addObject("B")
+        asyncBuilder.addObject("C")
+        def list = asyncBuilder.await(cancelCF).join()
+
+        then:
+        list == ["A", "B", "C"]
+    }
+
+    def "await with cancelCF on empty builder returns empty list"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def asyncBuilder = Async.ofExpectedSize(0)
+        def list = asyncBuilder.await(cancelCF).join()
+
+        then:
+        list == []
+    }
+
+    def "await with cancelCF on single builder delegates to plain await"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def asyncBuilder = Async.ofExpectedSize(1)
+        asyncBuilder.add(completedFuture("A"))
+        def list = asyncBuilder.await(cancelCF).join()
+
+        then:
+        list == ["A"]
+    }
 }

--- a/src/test/groovy/graphql/execution/AsyncTest.groovy
+++ b/src/test/groovy/graphql/execution/AsyncTest.groovy
@@ -8,6 +8,8 @@ import java.util.concurrent.CompletionException
 import java.util.function.BiFunction
 import java.util.function.Function
 
+import static graphql.execution.Async.CombinedBuilder.OnCancel.DROP_PENDING
+import static graphql.execution.Async.CombinedBuilder.OnCancel.WAIT_FOR_PENDING
 import static java.util.concurrent.CompletableFuture.completedFuture
 import static java.util.concurrent.CompletableFuture.runAsync
 
@@ -429,7 +431,7 @@ class AsyncTest extends Specification {
         asyncBuilder.add(completedFuture("A"))
         asyncBuilder.add(completedFuture("B"))
         asyncBuilder.add(completedFuture("C"))
-        def list = asyncBuilder.await((CompletableFuture) null).join()
+        def list = asyncBuilder.await((CompletableFuture) null, DROP_PENDING).join()
 
         then:
         list == ["A", "B", "C"]
@@ -442,7 +444,7 @@ class AsyncTest extends Specification {
         asyncBuilder.add(completedFuture("A"))
         asyncBuilder.add(completedFuture("B"))
         asyncBuilder.add(completedFuture("C"))
-        def list = asyncBuilder.await(cancelCF).join()
+        def list = asyncBuilder.await(cancelCF, DROP_PENDING).join()
 
         then:
         list == ["A", "B", "C"]
@@ -460,7 +462,7 @@ class AsyncTest extends Specification {
         asyncBuilder.add(completedFuture("C"))
         asyncBuilder.add(pending2)
 
-        def resultCF = asyncBuilder.await(cancelCF)
+        def resultCF = asyncBuilder.await(cancelCF, DROP_PENDING)
 
         // cancel before pending CFs complete
         cancelCF.complete(null)
@@ -469,6 +471,75 @@ class AsyncTest extends Specification {
 
         then:
         list == ["A", null, "C", null]
+    }
+
+    def "await with WAIT_FOR_PENDING waits for pending CFs to settle before harvesting"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def pending1 = new CompletableFuture<String>()
+        def pending2 = new CompletableFuture<String>()
+
+        def asyncBuilder = Async.ofExpectedSize(4)
+        asyncBuilder.add(completedFuture("A"))
+        asyncBuilder.add(pending1)
+        asyncBuilder.add(completedFuture("C"))
+        asyncBuilder.add(pending2)
+
+        def resultCF = asyncBuilder.await(cancelCF, WAIT_FOR_PENDING)
+
+        // cancellation fires while pending CFs are still incomplete
+        cancelCF.complete(null)
+
+        then: "the result does not complete until the pending CFs settle"
+        !resultCF.isDone()
+
+        when: "the pending CFs settle (as cancellation-aware futures would)"
+        pending1.complete("B")
+        pending2.complete("D")
+        def list = resultCF.join()
+
+        then: "their settled values are captured rather than harvested as null"
+        list == ["A", "B", "C", "D"]
+    }
+
+    def "await with WAIT_FOR_PENDING on single builder waits for the pending CF to settle"() {
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def pending = new CompletableFuture<String>()
+
+        def asyncBuilder = Async.ofExpectedSize(1)
+        asyncBuilder.add(pending)
+
+        def resultCF = asyncBuilder.await(cancelCF, WAIT_FOR_PENDING)
+        cancelCF.complete(null)
+
+        then: "not done until the pending CF settles"
+        !resultCF.isDone()
+
+        when:
+        pending.complete("A")
+        def list = resultCF.join()
+
+        then:
+        list == ["A"]
+    }
+
+    def "await with WAIT_FOR_PENDING on single builder harvests an already-completed CF"() {
+        // covers the WAIT_FOR_PENDING branch when the single value has already completed by the time
+        // cancellation is observed - it should just harvest the completed value (no waiting needed)
+        when:
+        def cancelCF = new CompletableFuture<Void>()
+        def valueCF = completedFuture("A")
+
+        def asyncBuilder = Async.ofExpectedSize(1)
+        asyncBuilder.add(valueCF)
+
+        // value is already done; cancellation is also signalled
+        cancelCF.complete(null)
+        def list = asyncBuilder.await(cancelCF, WAIT_FOR_PENDING).join()
+
+        then:
+        list == ["A"]
     }
 
     def "await with cancelCF returns partial results with mixed objects and CFs"() {
@@ -482,7 +553,7 @@ class AsyncTest extends Specification {
         asyncBuilder.add(pending)
         asyncBuilder.addObject("D")
 
-        def resultCF = asyncBuilder.await(cancelCF)
+        def resultCF = asyncBuilder.await(cancelCF, DROP_PENDING)
 
         cancelCF.complete(null)
         def list = resultCF.join()
@@ -501,7 +572,7 @@ class AsyncTest extends Specification {
         asyncBuilder.add(cf1)
         asyncBuilder.add(cf2)
 
-        def resultCF = asyncBuilder.await(cancelCF)
+        def resultCF = asyncBuilder.await(cancelCF, DROP_PENDING)
 
         // complete all CFs before cancellation
         cf1.complete("X")
@@ -529,7 +600,7 @@ class AsyncTest extends Specification {
         asyncBuilder.add(completedFuture("A"))
         asyncBuilder.add(failing)
 
-        def resultCF = asyncBuilder.await(cancelCF)
+        def resultCF = asyncBuilder.await(cancelCF, DROP_PENDING)
         resultCF.join()
 
         then:
@@ -545,7 +616,7 @@ class AsyncTest extends Specification {
         asyncBuilder.addObject("C")
         // make cancel happen soon but off thread
         runAsync({ -> cancelCF.complete(null) })
-        def list = asyncBuilder.await(cancelCF).join()
+        def list = asyncBuilder.await(cancelCF, DROP_PENDING).join()
 
         then:
         list == ["A", "B", "C"]
@@ -556,7 +627,7 @@ class AsyncTest extends Specification {
         def asyncBuilder = Async.ofExpectedSize(2)
         asyncBuilder.add(completedFuture("A"))
         asyncBuilder.add(completedFuture("B"))
-        def list = asyncBuilder.await((CompletableFuture<Void>) null).join()
+        def list = asyncBuilder.await((CompletableFuture<Void>) null, DROP_PENDING).join()
 
         then: "it behaves identically to await() and returns all results"
         list == ["A", "B"]
@@ -566,7 +637,7 @@ class AsyncTest extends Specification {
         when:
         def cancelCF = new CompletableFuture<Void>()
         def asyncBuilder = Async.ofExpectedSize(0)
-        def list = asyncBuilder.await(cancelCF).join()
+        def list = asyncBuilder.await(cancelCF, DROP_PENDING).join()
 
         then:
         list == []
@@ -579,7 +650,7 @@ class AsyncTest extends Specification {
         asyncBuilder.add(completedFuture("A"))
         // make cancel happen soon but off thread
         runAsync({ -> cancelCF.complete(null) })
-        def list = asyncBuilder.await(cancelCF).join()
+        def list = asyncBuilder.await(cancelCF, DROP_PENDING).join()
 
         then: "result is returned normally"
         list == ["A"]
@@ -596,7 +667,7 @@ class AsyncTest extends Specification {
 
         // make cancel happen soon but off thread
         runAsync({ -> cancelCF.complete(null) })
-        def list = asyncBuilder.await(cancelCF).join()
+        def list = asyncBuilder.await(cancelCF, DROP_PENDING).join()
 
         then: "result is exceptional"
         thrown(CompletionException)
@@ -606,7 +677,7 @@ class AsyncTest extends Specification {
         when: "single builder with a completed CF"
         def asyncBuilder = Async.ofExpectedSize(1)
         asyncBuilder.add(completedFuture("A"))
-        def list = asyncBuilder.await(null).join()
+        def list = asyncBuilder.await(null, DROP_PENDING).join()
 
         then: "result is returned normally"
         list == ["A"]
@@ -616,7 +687,7 @@ class AsyncTest extends Specification {
         when: "single builder with a completed CF"
         def asyncBuilder = Async.ofExpectedSize(1)
         asyncBuilder.addObject("A")
-        def list = asyncBuilder.await(null).join()
+        def list = asyncBuilder.await(null, DROP_PENDING).join()
 
         then: "result is returned normally"
         list == ["A"]
@@ -631,7 +702,7 @@ class AsyncTest extends Specification {
         // make cancel happen soon but off thread
         runAsync({ -> cancelCF.complete(null) })
 
-        def list = asyncBuilder.await(cancelCF).join()
+        def list = asyncBuilder.await(cancelCF, DROP_PENDING).join()
 
         then: "the single value is null since it never completed"
         list == [null]
@@ -646,7 +717,7 @@ class AsyncTest extends Specification {
         // make cancel happen soon but off thread
         runAsync({ -> cancelCF.complete(null) })
 
-        def list = asyncBuilder.await(cancelCF).join()
+        def list = asyncBuilder.await(cancelCF, DROP_PENDING).join()
 
         then:
         list == ["A"]
@@ -657,7 +728,7 @@ class AsyncTest extends Specification {
         def asyncBuilder = Async.ofExpectedSize(1)
         asyncBuilder.addObject("A")
 
-        def list = asyncBuilder.await(null).join()
+        def list = asyncBuilder.await(null, DROP_PENDING).join()
 
         then:
         list == ["A"]


### PR DESCRIPTION
Web clients can often impose request timeouts. If a GraphQL server takes too long to respond, then nothing is returned. While we can call `ExecutionInput.cancel()` in order to slide under a web client's timeout, there are no usable results for the client to handle.

This change improves upon this - if we set `#capturePartialResultsOnCancel`, then calling `.cancel` will save all the evaluated `DataFetcher` results so that something potentially usable can be returned to the client.

Full disclosure: almost all of this was generated with [Rovo](https://www.atlassian.com/software/rovo), with a preliminary review from @bbakerman before submitting here.