### PR TITLE
Allow field visibility transformation to remove interface relationships

### DIFF
--- a/src/main/java/graphql/schema/transform/FieldVisibilitySchemaTransformation.java
+++ b/src/main/java/graphql/schema/transform/FieldVisibilitySchemaTransformation.java
@@ -8,8 +8,10 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLImplementingType;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLNamedType;
+import graphql.schema.GraphQLNamedOutputType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
@@ -33,17 +35,38 @@ import java.util.stream.Stream;
 import static graphql.schema.SchemaTransformer.transformSchemaWithDeletes;
 
 /**
- * Transforms a schema by applying a visibility predicate to every field.
+ * Transforms a schema by applying visibility predicates to fields and interface implementation relationships.
+ * <p>
+ * Field and interface implementation visibility are independent. Callers are responsible for ensuring that their
+ * combined visibility decisions produce a valid schema. An invalid transformed schema causes schema construction to
+ * fail with an {@link graphql.schema.validation.InvalidSchemaException}.
  */
 @PublicApi
 public class FieldVisibilitySchemaTransformation {
 
+    private static final VisibleInterfaceImplementationPredicate ALL_INTERFACE_IMPLEMENTATIONS_VISIBLE = environment -> true;
+
     private final VisibleFieldPredicate visibleFieldPredicate;
+    private final VisibleInterfaceImplementationPredicate visibleInterfaceImplementationPredicate;
     private final Runnable beforeTransformationHook;
     private final Runnable afterTransformationHook;
 
     public FieldVisibilitySchemaTransformation(VisibleFieldPredicate visibleFieldPredicate) {
-        this(visibleFieldPredicate, () -> {
+        this(visibleFieldPredicate, ALL_INTERFACE_IMPLEMENTATIONS_VISIBLE, () -> {
+        }, () -> {
+        });
+    }
+
+    /**
+     * Creates a schema transformation with independent visibility predicates for fields and interface implementation
+     * relationships.
+     *
+     * @param visibleFieldPredicate                   controls field visibility
+     * @param visibleInterfaceImplementationPredicate controls interface implementation relationship visibility
+     */
+    public FieldVisibilitySchemaTransformation(VisibleFieldPredicate visibleFieldPredicate,
+                                               VisibleInterfaceImplementationPredicate visibleInterfaceImplementationPredicate) {
+        this(visibleFieldPredicate, visibleInterfaceImplementationPredicate, () -> {
         }, () -> {
         });
     }
@@ -51,7 +74,23 @@ public class FieldVisibilitySchemaTransformation {
     public FieldVisibilitySchemaTransformation(VisibleFieldPredicate visibleFieldPredicate,
                                                Runnable beforeTransformationHook,
                                                Runnable afterTransformationHook) {
+        this(visibleFieldPredicate, ALL_INTERFACE_IMPLEMENTATIONS_VISIBLE, beforeTransformationHook, afterTransformationHook);
+    }
+
+    /**
+     * Creates a schema transformation with independent visibility predicates and lifecycle hooks.
+     *
+     * @param visibleFieldPredicate                   controls field visibility
+     * @param visibleInterfaceImplementationPredicate controls interface implementation relationship visibility
+     * @param beforeTransformationHook                runs before transformation
+     * @param afterTransformationHook                 runs after transformation
+     */
+    public FieldVisibilitySchemaTransformation(VisibleFieldPredicate visibleFieldPredicate,
+                                               VisibleInterfaceImplementationPredicate visibleInterfaceImplementationPredicate,
+                                               Runnable beforeTransformationHook,
+                                               Runnable afterTransformationHook) {
         this.visibleFieldPredicate = visibleFieldPredicate;
+        this.visibleInterfaceImplementationPredicate = visibleInterfaceImplementationPredicate;
         this.beforeTransformationHook = beforeTransformationHook;
         this.afterTransformationHook = afterTransformationHook;
     }
@@ -64,10 +103,10 @@ public class FieldVisibilitySchemaTransformation {
         // These are types that exist in the schema but are NOT reachable from operation types + directives
         Set<String> rootUnusedTypes = findRootUnusedTypes(schema);
 
-        // we delete all fields that should be deleted
-        // this assumes the field remove itself is semantically valid
+        // we delete all fields and interface implementation relationships that should be deleted
+        // this assumes the combined removals are semantically valid
         GraphQLSchema interimSchema = transformSchemaWithDeletes(schema,
-                new FieldRemovalVisitor(visibleFieldPredicate));
+                new ElementRemovalVisitor(visibleFieldPredicate, visibleInterfaceImplementationPredicate));
 
 
         // cleanup schema
@@ -174,44 +213,71 @@ public class FieldVisibilitySchemaTransformation {
         }
     }
 
-    private static class FieldRemovalVisitor extends GraphQLTypeVisitorStub {
+    private static class ElementRemovalVisitor extends GraphQLTypeVisitorStub {
 
-        private final VisibleFieldPredicate visibilityPredicate;
+        private final VisibleFieldPredicate fieldVisibilityPredicate;
+        private final VisibleInterfaceImplementationPredicate interfaceImplementationPredicate;
 
         private final Set<GraphQLFieldDefinition> fieldDefinitionsToActuallyRemove = new LinkedHashSet<>();
         private final Set<GraphQLInputObjectField> inputObjectFieldsToDelete = new LinkedHashSet<>();
 
-        private FieldRemovalVisitor(VisibleFieldPredicate visibilityPredicate) {
-            this.visibilityPredicate = visibilityPredicate;
+        private ElementRemovalVisitor(VisibleFieldPredicate fieldVisibilityPredicate,
+                                      VisibleInterfaceImplementationPredicate interfaceImplementationPredicate) {
+            this.fieldVisibilityPredicate = fieldVisibilityPredicate;
+            this.interfaceImplementationPredicate = interfaceImplementationPredicate;
         }
 
         @Override
         public TraversalControl visitGraphQLObjectType(GraphQLObjectType objectType, TraverserContext<GraphQLSchemaElement> context) {
-            return visitFieldsContainer(objectType, context);
+            if (markInvisibleFields(objectType)) {
+                return deleteNode(context);
+            }
+            List<GraphQLInterfaceType> visibleInterfaces = getVisibleInterfaces(objectType);
+            if (visibleInterfaces.size() == objectType.getInterfaces().size()) {
+                return TraversalControl.CONTINUE;
+            }
+            GraphQLObjectType changedObjectType = objectType.transform(builder -> builder.replaceInterfaces(visibleInterfaces));
+            return changeNode(context, changedObjectType);
         }
 
         @Override
-        public TraversalControl visitGraphQLInterfaceType(GraphQLInterfaceType objectType, TraverserContext<GraphQLSchemaElement> context) {
-            return visitFieldsContainer(objectType, context);
+        public TraversalControl visitGraphQLInterfaceType(GraphQLInterfaceType interfaceType, TraverserContext<GraphQLSchemaElement> context) {
+            if (markInvisibleFields(interfaceType)) {
+                return deleteNode(context);
+            }
+            List<GraphQLInterfaceType> visibleInterfaces = getVisibleInterfaces(interfaceType);
+            if (visibleInterfaces.size() == interfaceType.getInterfaces().size()) {
+                return TraversalControl.CONTINUE;
+            }
+            GraphQLInterfaceType changedInterfaceType = interfaceType.transform(builder -> builder.replaceInterfaces(visibleInterfaces));
+            return changeNode(context, changedInterfaceType);
         }
 
-        private TraversalControl visitFieldsContainer(GraphQLFieldsContainer fieldsContainer, TraverserContext<GraphQLSchemaElement> context) {
+        private boolean markInvisibleFields(GraphQLFieldsContainer fieldsContainer) {
             boolean allFieldsDeleted = true;
             for (GraphQLFieldDefinition fieldDefinition : fieldsContainer.getFieldDefinitions()) {
                 VisibleFieldPredicateEnvironment environment = new VisibleFieldPredicateEnvironmentImpl(
                         fieldDefinition, fieldsContainer);
-                if (!visibilityPredicate.isVisible(environment)) {
+                if (!fieldVisibilityPredicate.isVisible(environment)) {
                     fieldDefinitionsToActuallyRemove.add(fieldDefinition);
                 } else {
                     allFieldsDeleted = false;
                 }
             }
-            if (allFieldsDeleted) {
-                // we are deleting the whole interface type because all fields are supposed to be deleted
-                return deleteNode(context);
-            } else {
-                return TraversalControl.CONTINUE;
+            return allFieldsDeleted;
+        }
+
+        private List<GraphQLInterfaceType> getVisibleInterfaces(GraphQLImplementingType implementingType) {
+            List<GraphQLInterfaceType> visibleInterfaces = new ArrayList<>();
+            for (GraphQLNamedOutputType namedInterface : implementingType.getInterfaces()) {
+                GraphQLInterfaceType interfaceType = (GraphQLInterfaceType) namedInterface;
+                VisibleInterfaceImplementationPredicateEnvironment environment =
+                        new VisibleInterfaceImplementationPredicateEnvironmentImpl(implementingType, interfaceType);
+                if (interfaceImplementationPredicate.isVisible(environment)) {
+                    visibleInterfaces.add(interfaceType);
+                }
             }
+            return visibleInterfaces;
         }
 
         @Override
@@ -220,7 +286,7 @@ public class FieldVisibilitySchemaTransformation {
             for (GraphQLInputObjectField inputField : inputObjectType.getFieldDefinitions()) {
                 VisibleFieldPredicateEnvironment environment = new VisibleFieldPredicateEnvironmentImpl(
                         inputField, inputObjectType);
-                if (!visibilityPredicate.isVisible(environment)) {
+                if (!fieldVisibilityPredicate.isVisible(environment)) {
                     inputObjectFieldsToDelete.add(inputField);
                 } else {
                     allFieldsDeleted = false;

--- a/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicate.java
+++ b/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicate.java
@@ -1,7 +1,6 @@
 package graphql.schema.transform;
 
 import graphql.PublicSpi;
-import org.jspecify.annotations.NullMarked;
 
 /**
  * Predicate used during a {@link FieldVisibilitySchemaTransformation} to test whether an interface implementation
@@ -12,7 +11,6 @@ import org.jspecify.annotations.NullMarked;
  */
 @PublicSpi
 @FunctionalInterface
-@NullMarked
 public interface VisibleInterfaceImplementationPredicate {
 
     /**

--- a/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicate.java
+++ b/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicate.java
@@ -1,0 +1,26 @@
+package graphql.schema.transform;
+
+import graphql.PublicSpi;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Predicate used during a {@link FieldVisibilitySchemaTransformation} to test whether an interface implementation
+ * relationship should be visible.
+ * <p>
+ * This predicate controls the relationship only. Field visibility is controlled independently by
+ * {@link VisibleFieldPredicate}.
+ */
+@PublicSpi
+@FunctionalInterface
+@NullMarked
+public interface VisibleInterfaceImplementationPredicate {
+
+    /**
+     * Tests whether an interface implementation relationship should be visible.
+     *
+     * @param environment the interface implementation relationship
+     *
+     * @return true if the relationship should remain visible
+     */
+    boolean isVisible(VisibleInterfaceImplementationPredicateEnvironment environment);
+}

--- a/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicateEnvironment.java
+++ b/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicateEnvironment.java
@@ -1,0 +1,24 @@
+package graphql.schema.transform;
+
+import graphql.PublicApi;
+import graphql.schema.GraphQLImplementingType;
+import graphql.schema.GraphQLInterfaceType;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Provides the two types participating in an interface implementation relationship.
+ */
+@PublicApi
+@NullMarked
+public interface VisibleInterfaceImplementationPredicateEnvironment {
+
+    /**
+     * @return the object or interface that implements another interface
+     */
+    GraphQLImplementingType getImplementingType();
+
+    /**
+     * @return the implemented interface
+     */
+    GraphQLInterfaceType getInterfaceType();
+}

--- a/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicateEnvironment.java
+++ b/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicateEnvironment.java
@@ -3,13 +3,11 @@ package graphql.schema.transform;
 import graphql.PublicApi;
 import graphql.schema.GraphQLImplementingType;
 import graphql.schema.GraphQLInterfaceType;
-import org.jspecify.annotations.NullMarked;
 
 /**
  * Provides the two types participating in an interface implementation relationship.
  */
 @PublicApi
-@NullMarked
 public interface VisibleInterfaceImplementationPredicateEnvironment {
 
     /**

--- a/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicateEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicateEnvironmentImpl.java
@@ -1,0 +1,32 @@
+package graphql.schema.transform;
+
+import graphql.Internal;
+import graphql.schema.GraphQLImplementingType;
+import graphql.schema.GraphQLInterfaceType;
+import org.jspecify.annotations.NullMarked;
+
+import static graphql.Assert.assertNotNull;
+
+@Internal
+@NullMarked
+public final class VisibleInterfaceImplementationPredicateEnvironmentImpl implements VisibleInterfaceImplementationPredicateEnvironment {
+
+    private final GraphQLImplementingType implementingType;
+    private final GraphQLInterfaceType interfaceType;
+
+    public VisibleInterfaceImplementationPredicateEnvironmentImpl(GraphQLImplementingType implementingType,
+                                                                   GraphQLInterfaceType interfaceType) {
+        this.implementingType = assertNotNull(implementingType);
+        this.interfaceType = assertNotNull(interfaceType);
+    }
+
+    @Override
+    public GraphQLImplementingType getImplementingType() {
+        return implementingType;
+    }
+
+    @Override
+    public GraphQLInterfaceType getInterfaceType() {
+        return interfaceType;
+    }
+}

--- a/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicateEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/transform/VisibleInterfaceImplementationPredicateEnvironmentImpl.java
@@ -3,12 +3,10 @@ package graphql.schema.transform;
 import graphql.Internal;
 import graphql.schema.GraphQLImplementingType;
 import graphql.schema.GraphQLInterfaceType;
-import org.jspecify.annotations.NullMarked;
 
 import static graphql.Assert.assertNotNull;
 
 @Internal
-@NullMarked
 public final class VisibleInterfaceImplementationPredicateEnvironmentImpl implements VisibleInterfaceImplementationPredicateEnvironment {
 
     private final GraphQLImplementingType implementingType;

--- a/src/main/java/graphql/schema/transform/package-info.java
+++ b/src/main/java/graphql/schema/transform/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * APIs for transforming a GraphQL schema based on visibility rules.
+ */
+@NullMarked
+package graphql.schema.transform;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/groovy/graphql/archunit/JSpecifyAnnotationsCheck.groovy
+++ b/src/test/groovy/graphql/archunit/JSpecifyAnnotationsCheck.groovy
@@ -1,5 +1,6 @@
 package graphql.archunit
 
+import com.tngtech.archunit.core.domain.JavaClass
 import com.tngtech.archunit.core.importer.ClassFileImporter
 import com.tngtech.archunit.core.importer.ImportOption
 import spock.lang.Specification
@@ -122,8 +123,6 @@ class JSpecifyAnnotationsCheck extends Specification {
             "graphql.schema.idl.TypeRuntimeWiring",
             "graphql.schema.idl.errors.SchemaProblem",
             "graphql.schema.idl.errors.StrictModeWiringException",
-            "graphql.schema.transform.FieldVisibilitySchemaTransformation",
-            "graphql.schema.transform.VisibleFieldPredicateEnvironment",
             "graphql.schema.usage.SchemaUsage",
             "graphql.schema.usage.SchemaUsageSupport",
             "graphql.schema.validation.OneOfInputObjectRules",
@@ -160,7 +159,7 @@ class JSpecifyAnnotationsCheck extends Specification {
         when:
         def classesMissingAnnotation = classes
                 .stream()
-                .filter { !it.isAnnotatedWith("org.jspecify.annotations.NullMarked") && !it.isAnnotatedWith("org.jspecify.annotations.NullUnmarked") }
+                .filter { !isJSpecifyAnnotated(it) }
                 .map { it.name }
                 .filter { it -> !JSPECIFY_EXEMPTION_LIST.contains(it) }
                 .collect()
@@ -183,7 +182,7 @@ Add @NullMarked or @NullUnmarked to these public API classes. See documentation 
         when:
         def annotatedButExempted = classes.stream()
                 .filter { JSPECIFY_EXEMPTION_LIST.contains(it.name) }
-                .filter { it.isAnnotatedWith("org.jspecify.annotations.NullMarked") || it.isAnnotatedWith("org.jspecify.annotations.NullUnmarked") }
+                .filter { isJSpecifyAnnotated(it) }
                 .map { it.name }
                 .collect()
 
@@ -194,5 +193,12 @@ ${annotatedButExempted.sort().join("\n")}
 
 Please remove them from the exemption list in ${JSpecifyAnnotationsCheck.class.simpleName}.groovy.""")
         }
+    }
+
+    private static boolean isJSpecifyAnnotated(JavaClass javaClass) {
+        return javaClass.isAnnotatedWith("org.jspecify.annotations.NullMarked") ||
+                javaClass.isAnnotatedWith("org.jspecify.annotations.NullUnmarked") ||
+                javaClass.package.isAnnotatedWith("org.jspecify.annotations.NullMarked") ||
+                javaClass.package.isAnnotatedWith("org.jspecify.annotations.NullUnmarked")
     }
 }

--- a/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationInterfaceImplementationTest.groovy
+++ b/src/test/groovy/graphql/schema/transform/FieldVisibilitySchemaTransformationInterfaceImplementationTest.groovy
@@ -1,0 +1,289 @@
+package graphql.schema.transform
+
+import graphql.TestUtil
+import graphql.schema.GraphQLDirectiveContainer
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import graphql.schema.validation.InvalidSchemaException
+import spock.lang.Specification
+
+class FieldVisibilitySchemaTransformationInterfaceImplementationTest extends Specification {
+
+    def "existing constructor retains interface implementation relationships"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            type Query {
+                node: Node
+            }
+
+            interface Node {
+                id: ID!
+            }
+
+            type Account implements Node {
+                id: ID!
+            }
+        ''')
+        def transformation = new FieldVisibilitySchemaTransformation({ true })
+
+        when:
+        GraphQLSchema transformedSchema = transformation.apply(schema)
+
+        then:
+        def account = transformedSchema.getType("Account") as GraphQLObjectType
+        def node = transformedSchema.getType("Node") as GraphQLInterfaceType
+        account.interfaces*.name == ["Node"]
+        transformedSchema.getImplementations(node)*.name == ["Account"]
+    }
+
+    def "removes an interface and its relationship when all interface fields are hidden"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            directive @private on FIELD_DEFINITION
+
+            type Query {
+                account: Account
+            }
+
+            interface Node {
+                id: ID! @private
+            }
+
+            type Account implements Node {
+                id: ID!
+            }
+        ''')
+        VisibleFieldPredicate fieldPredicate = { environment ->
+            def field = environment.schemaElement as GraphQLDirectiveContainer
+            field.getAppliedDirective("private") == null
+        }
+        def transformation = new FieldVisibilitySchemaTransformation(fieldPredicate)
+
+        when:
+        GraphQLSchema transformedSchema = transformation.apply(schema)
+
+        then:
+        def account = transformedSchema.getType("Account") as GraphQLObjectType
+        account.interfaces.empty
+        transformedSchema.getType("Node") == null
+    }
+
+    def "removes an object interface relationship independently of field visibility"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            type Query {
+                account: Account
+                node: Node
+            }
+
+            interface Node {
+                id: ID!
+            }
+
+            type Account implements Node {
+                id: ID!
+                name: String
+            }
+        ''')
+        def transformation = transformationWith({ environment ->
+            environment.implementingType.name != "Account" || environment.interfaceType.name != "Node"
+        })
+
+        when:
+        GraphQLSchema transformedSchema = transformation.apply(schema)
+
+        then:
+        def account = transformedSchema.getType("Account") as GraphQLObjectType
+        def node = transformedSchema.getType("Node") as GraphQLInterfaceType
+        account.interfaces.empty
+        account.fieldDefinitions*.name as Set == ["id", "name"] as Set
+        transformedSchema.getImplementations(node).empty
+    }
+
+    def "removes one object interface relationship while retaining another"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            type Query {
+                account: Account
+                restricted: Restricted
+            }
+
+            interface Public {
+                id: ID!
+            }
+
+            interface Restricted {
+                secret: String
+            }
+
+            type Account implements Public & Restricted {
+                id: ID!
+                secret: String
+            }
+        ''')
+        def transformation = transformationWith({ environment ->
+            environment.interfaceType.name != "Restricted"
+        })
+
+        when:
+        GraphQLSchema transformedSchema = transformation.apply(schema)
+
+        then:
+        def account = transformedSchema.getType("Account") as GraphQLObjectType
+        def restricted = transformedSchema.getType("Restricted") as GraphQLInterfaceType
+        account.interfaces*.name == ["Public"]
+        transformedSchema.getImplementations(restricted).empty
+    }
+
+    def "removes an interface interface relationship"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            type Query {
+                child: Child
+            }
+
+            interface Parent {
+                id: ID!
+            }
+
+            interface Child implements Parent {
+                id: ID!
+            }
+
+            type Item implements Child & Parent {
+                id: ID!
+            }
+        ''')
+        def transformation = transformationWith({ environment ->
+            environment.implementingType.name != "Child" || environment.interfaceType.name != "Parent"
+        })
+
+        when:
+        GraphQLSchema transformedSchema = transformation.apply(schema)
+
+        then:
+        def child = transformedSchema.getType("Child") as GraphQLInterfaceType
+        def item = transformedSchema.getType("Item") as GraphQLObjectType
+        child.interfaces.empty
+        item.interfaces*.name as Set == ["Child", "Parent"] as Set
+    }
+
+    def "removes a field and its interface relationship atomically"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            directive @private on FIELD_DEFINITION
+
+            type Query {
+                account: Account
+            }
+
+            interface Node {
+                id: ID!
+            }
+
+            type Account implements Node {
+                id: ID! @private
+                name: String
+            }
+        ''')
+        VisibleFieldPredicate fieldPredicate = { environment ->
+            def field = environment.schemaElement as GraphQLDirectiveContainer
+            field.getAppliedDirective("private") == null
+        }
+        VisibleInterfaceImplementationPredicate relationshipPredicate = { environment ->
+            environment.implementingType.name != "Account" || environment.interfaceType.name != "Node"
+        }
+        def transformation = new FieldVisibilitySchemaTransformation(fieldPredicate, relationshipPredicate)
+
+        when:
+        GraphQLSchema transformedSchema = transformation.apply(schema)
+
+        then:
+        def account = transformedSchema.getType("Account") as GraphQLObjectType
+        account.interfaces.empty
+        account.fieldDefinitions*.name == ["name"]
+        transformedSchema.getType("Node") == null
+    }
+
+    def "removes an interface type when its removed relationship was the only path to it"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            type Query {
+                account: Account
+            }
+
+            interface Node {
+                id: ID!
+            }
+
+            type Account implements Node {
+                id: ID!
+            }
+        ''')
+        def transformation = transformationWith({ false })
+
+        when:
+        GraphQLSchema transformedSchema = transformation.apply(schema)
+
+        then:
+        (transformedSchema.getType("Account") as GraphQLObjectType).interfaces.empty
+        transformedSchema.getType("Node") == null
+    }
+
+    def "rejects removal required by a retained transitive relationship"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            type Query {
+                item: Item
+            }
+
+            interface Parent {
+                id: ID!
+            }
+
+            interface Child implements Parent {
+                id: ID!
+            }
+
+            type Item implements Child & Parent {
+                id: ID!
+            }
+        ''')
+        def transformation = transformationWith({ environment ->
+            environment.implementingType.name != "Item" || environment.interfaceType.name != "Parent"
+        })
+
+        when:
+        transformation.apply(schema)
+
+        then:
+        def exception = thrown(InvalidSchemaException)
+        exception.message.contains("object type 'Item' must implement 'Parent' because it is implemented by 'Child'")
+    }
+
+    def "runs lifecycle hooks with interface relationship visibility"() {
+        given:
+        GraphQLSchema schema = TestUtil.schema('''
+            type Query {
+                value: String
+            }
+        ''')
+        def events = []
+        def transformation = new FieldVisibilitySchemaTransformation(
+                { true } as VisibleFieldPredicate,
+                { true } as VisibleInterfaceImplementationPredicate,
+                { events.add("before") },
+                { events.add("after") })
+
+        when:
+        transformation.apply(schema)
+
+        then:
+        events == ["before", "after"]
+    }
+
+    private FieldVisibilitySchemaTransformation transformationWith(VisibleInterfaceImplementationPredicate predicate) {
+        return new FieldVisibilitySchemaTransformation({ true } as VisibleFieldPredicate, predicate)
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated predicate and environment for controlling individual interface implementation relationships
- apply field and relationship visibility in the same schema transformation so related removals are validated atomically
- preserve existing constructor behavior by retaining all interface relationships unless the new predicate is supplied
- retain the existing reachability cleanup and fail schema construction for invalid transitive interface removals
- mark `graphql.schema.transform` as `@NullMarked` and enforce package-level JSpecify annotations in the architecture test

## Testing

- `./gradlew test --tests graphql.schema.transform.FieldVisibilitySchemaTransformationInterfaceImplementationTest`
- `./gradlew test --tests graphql.schema.transform.FieldVisibilitySchemaTransformationTest`
- `./gradlew test --tests graphql.archunit.JSpecifyAnnotationsCheck --tests graphql.schema.transform.FieldVisibilitySchemaTransformationInterfaceImplementationTest --tests graphql.schema.transform.FieldVisibilitySchemaTransformationTest` (63 tests)
- `./gradlew test` (5,700 tests)
- `./gradlew jacocoTestReport`
- `./gradlew javadoc --info --stacktrace`

The changed transformer and relationship-removal visitor have 100% line, branch, and method coverage.