### PR TITLE
Support directives on directive definitions

### DIFF
--- a/src/main/antlr/GraphqlSDL.g4
+++ b/src/main/antlr/GraphqlSDL.g4
@@ -9,7 +9,8 @@ directiveDefinition
 
 typeSystemExtension :
 schemaExtension |
-typeExtension
+typeExtension |
+directiveExtension
 ;
 
 schemaDefinition : description? SCHEMA directives? '{' operationTypeDefinition+ '}';
@@ -121,7 +122,9 @@ inputObjectValueDefinitions : '{' inputValueDefinition* '}';
 extensionInputObjectValueDefinitions : '{' inputValueDefinition+ '}';
 
 
-directiveDefinition : description? DIRECTIVE '@' name argumentsDefinition? REPEATABLE? ON_KEYWORD directiveLocations;
+directiveDefinition : description? DIRECTIVE '@' name argumentsDefinition? directives? REPEATABLE? ON_KEYWORD directiveLocations;
+
+directiveExtension : EXTEND DIRECTIVE '@' name directives;
 
 directiveLocation : name;
 

--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLString;
 import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
+import static graphql.introspection.Introspection.DirectiveLocation.DIRECTIVE_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
@@ -73,6 +74,7 @@ public class Directives {
                 .directiveLocation(newDirectiveLocation().name(ENUM_VALUE.name()).build())
                 .directiveLocation(newDirectiveLocation().name(ARGUMENT_DEFINITION.name()).build())
                 .directiveLocation(newDirectiveLocation().name(INPUT_FIELD_DEFINITION.name()).build())
+                .directiveLocation(newDirectiveLocation().name(DIRECTIVE_DEFINITION.name()).build())
                 .description(createDescription("Marks the field, argument, input field or enum value as deprecated"))
                 .inputValueDefinition(
                         newInputValueDefinition()
@@ -222,7 +224,7 @@ public class Directives {
                     .type(nonNull(GraphQLString))
                     .defaultValueProgrammatic(NO_LONGER_SUPPORTED)
                     .description("The reason for the deprecation"))
-            .validLocations(FIELD_DEFINITION, ENUM_VALUE, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION)
+            .validLocations(FIELD_DEFINITION, ENUM_VALUE, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION, DIRECTIVE_DEFINITION)
             .definition(DEPRECATED_DIRECTIVE_DEFINITION)
             .build();
 

--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -75,7 +75,7 @@ public class Directives {
                 .directiveLocation(newDirectiveLocation().name(ARGUMENT_DEFINITION.name()).build())
                 .directiveLocation(newDirectiveLocation().name(INPUT_FIELD_DEFINITION.name()).build())
                 .directiveLocation(newDirectiveLocation().name(DIRECTIVE_DEFINITION.name()).build())
-                .description(createDescription("Marks the field, argument, input field or enum value as deprecated"))
+                .description(createDescription("Marks an element of a GraphQL schema as no longer supported."))
                 .inputValueDefinition(
                         newInputValueDefinition()
                                 .name("reason")
@@ -218,7 +218,7 @@ public class Directives {
      */
     public static final GraphQLDirective DeprecatedDirective = GraphQLDirective.newDirective()
             .name(DEPRECATED)
-            .description("Marks the field, argument, input field or enum value as deprecated")
+            .description("Marks an element of a GraphQL schema as no longer supported.")
             .argument(newArgument()
                     .name("reason")
                     .type(nonNull(GraphQLString))

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -578,7 +578,8 @@ public class Introspection {
         ENUM,
         ENUM_VALUE,
         INPUT_OBJECT,
-        INPUT_FIELD_DEFINITION
+        INPUT_FIELD_DEFINITION,
+        DIRECTIVE_DEFINITION
     }
 
     public static final GraphQLEnumType __DirectiveLocation = GraphQLEnumType.newEnum()
@@ -606,6 +607,7 @@ public class Introspection {
             .value("ENUM_VALUE", DirectiveLocation.ENUM_VALUE, "Indicates the directive is valid on an enum value SDL definition.")
             .value("INPUT_OBJECT", DirectiveLocation.INPUT_OBJECT, "Indicates the directive is valid on an input object SDL definition.")
             .value("INPUT_FIELD_DEFINITION", DirectiveLocation.INPUT_FIELD_DEFINITION, "Indicates the directive is valid on an input object field SDL definition.")
+            .value("DIRECTIVE_DEFINITION", DirectiveLocation.DIRECTIVE_DEFINITION, "Indicates the directive is valid on a directive SDL definition.")
             .build();
 
 
@@ -631,6 +633,12 @@ public class Introspection {
                             .name("includeDeprecated")
                             .type(nonNull(GraphQLBoolean))
                             .defaultValueProgrammatic(false)))
+            .field(newFieldDefinition()
+                    .name("isDeprecated")
+                    .type(nonNull(GraphQLBoolean)))
+            .field(newFieldDefinition()
+                    .name("deprecationReason")
+                    .type(GraphQLString))
             .build();
 
     static {
@@ -649,6 +657,8 @@ public class Introspection {
         register(__Directive, "isRepeatable", GraphQLDirective.class, GraphQLDirective::isRepeatable);
         register(__Directive, "locations", locationsDataFetcher);
         register(__Directive, "args", argsDataFetcher);
+        register(__Directive, "isDeprecated", GraphQLDirective.class, GraphQLDirective::isDeprecated);
+        register(__Directive, "deprecationReason", GraphQLDirective.class, GraphQLDirective::getDeprecationReason);
     }
 
     public static final GraphQLObjectType __Schema = newObject()
@@ -674,7 +684,11 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("directives")
                     .description("A list of all directives supported by this server.")
-                    .type(nonNull(list(nonNull(__Directive)))))
+                    .type(nonNull(list(nonNull(__Directive))))
+                    .argument(newArgument()
+                            .name("includeDeprecated")
+                            .type(nonNull(GraphQLBoolean))
+                            .defaultValueProgrammatic(false)))
             .field(newFieldDefinition()
                     .name("subscriptionType")
                     .description("If this server support subscription, the type that subscription operations will be rooted at.")
@@ -688,7 +702,12 @@ public class Introspection {
         register(__Schema, "types", GraphQLSchema.class, GraphQLSchema::getAllTypesAsList);
         register(__Schema, "queryType", GraphQLSchema.class, GraphQLSchema::getQueryType);
         register(__Schema, "mutationType", GraphQLSchema.class, GraphQLSchema::getMutationType);
-        register(__Schema, "directives", GraphQLSchema.class, GraphQLSchema::getDirectives);
+        IntrospectionDataFetcher<?> directivesDataFetcher = environment -> {
+            Boolean includeDeprecated = environment.getArgument("includeDeprecated");
+            return ImmutableKit.filter(environment.getGraphQLSchema().getDirectives(),
+                    directive -> includeDeprecated || !directive.isDeprecated());
+        };
+        register(__Schema, "directives", directivesDataFetcher);
         register(__Schema, "subscriptionType", GraphQLSchema.class, GraphQLSchema::getSubscriptionType);
     }
 

--- a/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
+++ b/src/main/java/graphql/introspection/IntrospectionQueryBuilder.java
@@ -40,6 +40,8 @@ public class IntrospectionQueryBuilder {
 
         private final boolean inputValueDeprecation;
 
+        private final boolean directiveDeprecation;
+
         private final int typeRefFragmentDepth;
 
         private Options(boolean descriptions,
@@ -48,6 +50,7 @@ public class IntrospectionQueryBuilder {
                         boolean directiveIsRepeatable,
                         boolean schemaDescription,
                         boolean inputValueDeprecation,
+                        boolean directiveDeprecation,
                         int typeRefFragmentDepth) {
             this.descriptions = descriptions;
             this.specifiedByUrl = specifiedByUrl;
@@ -55,6 +58,7 @@ public class IntrospectionQueryBuilder {
             this.directiveIsRepeatable = directiveIsRepeatable;
             this.schemaDescription = schemaDescription;
             this.inputValueDeprecation = inputValueDeprecation;
+            this.directiveDeprecation = directiveDeprecation;
             this.typeRefFragmentDepth = typeRefFragmentDepth;
         }
 
@@ -82,6 +86,10 @@ public class IntrospectionQueryBuilder {
             return inputValueDeprecation;
         }
 
+        public boolean isDirectiveDeprecation() {
+            return directiveDeprecation;
+        }
+
         public int getTypeRefFragmentDepth() {
             return typeRefFragmentDepth;
         }
@@ -93,6 +101,7 @@ public class IntrospectionQueryBuilder {
                     true,
                     true,
                     false,
+                    true,
                     true,
                     7
             );
@@ -112,6 +121,7 @@ public class IntrospectionQueryBuilder {
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
+                    this.directiveDeprecation,
                     this.typeRefFragmentDepth);
         }
 
@@ -129,6 +139,7 @@ public class IntrospectionQueryBuilder {
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
+                    this.directiveDeprecation,
                     this.typeRefFragmentDepth);
         }
 
@@ -149,6 +160,7 @@ public class IntrospectionQueryBuilder {
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
+                    this.directiveDeprecation,
                     this.typeRefFragmentDepth);
         }
 
@@ -166,6 +178,7 @@ public class IntrospectionQueryBuilder {
                     flag,
                     this.schemaDescription,
                     this.inputValueDeprecation,
+                    this.directiveDeprecation,
                     this.typeRefFragmentDepth);
         }
 
@@ -183,6 +196,7 @@ public class IntrospectionQueryBuilder {
                     this.directiveIsRepeatable,
                     flag,
                     this.inputValueDeprecation,
+                    this.directiveDeprecation,
                     this.typeRefFragmentDepth);
         }
 
@@ -199,6 +213,25 @@ public class IntrospectionQueryBuilder {
                     this.isOneOf,
                     this.directiveIsRepeatable,
                     this.schemaDescription,
+                    flag,
+                    this.directiveDeprecation,
+                    this.typeRefFragmentDepth);
+        }
+
+        /**
+         * This will allow you to include deprecated directives in the introspection query.
+         *
+         * @param flag whether to include them
+         *
+         * @return options
+         */
+        public Options directiveDeprecation(boolean flag) {
+            return new Options(this.descriptions,
+                    this.specifiedByUrl,
+                    this.isOneOf,
+                    this.directiveIsRepeatable,
+                    this.schemaDescription,
+                    this.inputValueDeprecation,
                     flag,
                     this.typeRefFragmentDepth);
         }
@@ -217,6 +250,7 @@ public class IntrospectionQueryBuilder {
                     this.directiveIsRepeatable,
                     this.schemaDescription,
                     this.inputValueDeprecation,
+                    this.directiveDeprecation,
                     typeRefFragmentDepth);
         }
     }
@@ -269,11 +303,14 @@ public class IntrospectionQueryBuilder {
                                                                 .build()
                                                         )
                                                         .build(),
-                                                options.directiveIsRepeatable ? newField("isRepeatable").build() : null
+                                                options.directiveIsRepeatable ? newField("isRepeatable").build() : null,
+                                                options.directiveDeprecation ? newField("isDeprecated").build() : null,
+                                                options.directiveDeprecation ? newField("deprecationReason").build() : null
+                                        )).build())
+                                        .arguments(filter(
+                                                options.directiveDeprecation ? newArgument("includeDeprecated", BooleanValue.of(true)).build() : null
                                         ))
                                         .build()
-                        )
-                                .build()
                 )
         ).build();
 

--- a/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
+++ b/src/main/java/graphql/introspection/IntrospectionResultToSchema.java
@@ -149,6 +149,7 @@ public class IntrospectionResultToSchema {
         List<InputValueDefinition> inputValueDefinitions = createInputValueDefinitions(args);
         directiveDefBuilder.inputValueDefinitions(inputValueDefinitions);
         Optional.ofNullable((Boolean) input.get("isRepeatable")).ifPresent(value -> directiveDefBuilder.repeatable(value));
+        createDeprecatedDirective(input, directiveDefBuilder);
 
         return directiveDefBuilder.build();
     }

--- a/src/main/java/graphql/introspection/IntrospectionWithDirectivesSupport.java
+++ b/src/main/java/graphql/introspection/IntrospectionWithDirectivesSupport.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertShouldNeverHappen;
 import static graphql.Scalars.GraphQLString;
+import static graphql.introspection.Introspection.__Directive;
 import static graphql.introspection.Introspection.__EnumValue;
 import static graphql.introspection.Introspection.__Field;
 import static graphql.introspection.Introspection.__InputValue;
@@ -82,7 +83,7 @@ public class IntrospectionWithDirectivesSupport {
     private final String typePrefix;
 
     private final Set<String> INTROSPECTION_ELEMENTS = ImmutableSet.of(
-            __Schema.getName(), __Type.getName(), __Field.getName(), __EnumValue.getName(), __InputValue.getName()
+            __Schema.getName(), __Type.getName(), __Field.getName(), __EnumValue.getName(), __InputValue.getName(), __Directive.getName()
     );
 
 
@@ -172,8 +173,10 @@ public class IntrospectionWithDirectivesSupport {
 
     private GraphQLSchema addDirectiveDefinitionFilter(GraphQLSchema schema) {
         DataFetcher<?> df = env -> {
-            List<GraphQLDirective> definedDirectives = env.getGraphQLSchema().getDirectives();
-            return filterDirectives(schema, true, null, definedDirectives);
+            GraphQLSchema graphQLSchema = env.getGraphQLSchema();
+            Boolean includeDeprecated = env.getArgument("includeDeprecated");
+            List<GraphQLDirective> definedDirectives = graphQLSchema.getDirectives();
+            return filterDirectives(graphQLSchema, true, null, definedDirectives, Boolean.TRUE.equals(includeDeprecated));
         };
         GraphQLCodeRegistry codeRegistry = schema.getCodeRegistry().transform(bld ->
                 bld.dataFetcher(coordinates(__Schema, "directives"), df));
@@ -224,9 +227,12 @@ public class IntrospectionWithDirectivesSupport {
         return objectType;
     }
 
-    private List<GraphQLDirective> filterDirectives(GraphQLSchema schema, boolean isDefinedDirective, GraphQLDirectiveContainer container, List<GraphQLDirective> directives) {
+    private List<GraphQLDirective> filterDirectives(GraphQLSchema schema, boolean isDefinedDirective, GraphQLDirectiveContainer container, List<GraphQLDirective> directives, boolean includeDeprecated) {
         return ImmutableKit.filter(directives,
                 directive -> {
+                    if (!includeDeprecated && directive.isDeprecated()) {
+                        return false;
+                    }
                     DirectivePredicateEnvironment env = buildDirectivePredicateEnv(schema, isDefinedDirective, container, directive.getName());
                     return directivePredicate.isDirectiveIncluded(env);
                 });

--- a/src/main/java/graphql/language/AstPrinter.java
+++ b/src/main/java/graphql/language/AstPrinter.java
@@ -50,6 +50,7 @@ public class AstPrinter {
         printers.put(BooleanValue.class, value());
         printers.put(NullValue.class, value());
         printers.put(Directive.class, directive());
+        printers.put(DirectiveExtensionDefinition.class, directiveExtensionDefinition());
         printers.put(DirectiveDefinition.class, directiveDefinition());
         printers.put(DirectiveLocation.class, directiveLocation());
         printers.put(Document.class, document());
@@ -137,12 +138,25 @@ public class AstPrinter {
                 join(out, node.getInputValueDefinitions(), argSep);
                 out.append(')');
             }
-            out.append(" ");
+            if (!isEmpty(node.getDirectives())) {
+                out.append(' ');
+                directives(out, node.getDirectives());
+            }
+            out.append(' ');
             if (node.isRepeatable()) {
                 out.append("repeatable ");
             }
             out.append("on ");
             join(out, node.getDirectiveLocations(), " | ");
+        };
+    }
+
+    private NodePrinter<DirectiveExtensionDefinition> directiveExtensionDefinition() {
+        return (out, node) -> {
+            out.append("extend directive @");
+            out.append(node.getName());
+            out.append(' ');
+            directives(out, node.getDirectives());
         };
     }
 

--- a/src/main/java/graphql/language/AstSorter.java
+++ b/src/main/java/graphql/language/AstSorter.java
@@ -216,7 +216,14 @@ public class AstSorter {
 
             @Override
             public TraversalControl visitDirectiveDefinition(DirectiveDefinition node, TraverserContext<Node> context) {
+                if (node instanceof DirectiveExtensionDefinition) {
+                    DirectiveExtensionDefinition extension = (DirectiveExtensionDefinition) node;
+                    DirectiveExtensionDefinition changedExtension = extension.transformExtension(builder ->
+                            builder.directives(sort(node.getDirectives(), comparing(Directive::getName))));
+                    return changeNode(context, changedExtension);
+                }
                 DirectiveDefinition changedNode = node.transform(builder -> {
+                    builder.directives(sort(node.getDirectives(), comparing(Directive::getName)));
                     builder.inputValueDefinitions(sort(node.getInputValueDefinitions(), comparing(InputValueDefinition::getName)));
                     builder.directiveLocations(sort(node.getDirectiveLocations(), comparing(DirectiveLocation::getName)));
                 });

--- a/src/main/java/graphql/language/DirectiveDefinition.java
+++ b/src/main/java/graphql/language/DirectiveDefinition.java
@@ -25,13 +25,15 @@ import static graphql.language.NodeChildrenContainer.newNodeChildrenContainer;
 
 @PublicApi
 @NullMarked
-public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefinition> implements SDLNamedDefinition<DirectiveDefinition>, NamedNode<DirectiveDefinition> {
+public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefinition> implements SDLNamedDefinition<DirectiveDefinition>, DirectivesContainer<DirectiveDefinition>, NamedNode<DirectiveDefinition> {
     private final String name;
     private final boolean repeatable;
     private final ImmutableList<InputValueDefinition> inputValueDefinitions;
+    private final NodeUtil.DirectivesHolder directives;
     private final ImmutableList<DirectiveLocation> directiveLocations;
 
     public static final String CHILD_INPUT_VALUE_DEFINITIONS = "inputValueDefinitions";
+    public static final String CHILD_DIRECTIVES = "directives";
     public static final String CHILD_DIRECTIVE_LOCATION = "directiveLocation";
 
     @Internal
@@ -39,6 +41,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
                                   boolean repeatable,
                                   @Nullable Description description,
                                   List<InputValueDefinition> inputValueDefinitions,
+                                  List<Directive> directives,
                                   List<DirectiveLocation> directiveLocations,
                                   @Nullable SourceLocation sourceLocation,
                                   List<Comment> comments,
@@ -48,6 +51,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
         this.name = name;
         this.repeatable = repeatable;
         this.inputValueDefinitions = ImmutableList.copyOf(inputValueDefinitions);
+        this.directives = NodeUtil.DirectivesHolder.of(directives);
         this.directiveLocations = ImmutableList.copyOf(directiveLocations);
     }
 
@@ -57,7 +61,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
      * @param name of the directive definition
      */
     public DirectiveDefinition(String name) {
-        this(name, false, null, emptyList(), emptyList(), null, emptyList(), IgnoredChars.EMPTY, ImmutableKit.emptyMap());
+        this(name, false, null, emptyList(), emptyList(), emptyList(), null, emptyList(), IgnoredChars.EMPTY, ImmutableKit.emptyMap());
     }
 
     @Override
@@ -79,6 +83,26 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
         return inputValueDefinitions;
     }
 
+    @Override
+    public List<Directive> getDirectives() {
+        return directives.getDirectives();
+    }
+
+    @Override
+    public Map<String, List<Directive>> getDirectivesByName() {
+        return directives.getDirectivesByName();
+    }
+
+    @Override
+    public List<Directive> getDirectives(String directiveName) {
+        return directives.getDirectives(directiveName);
+    }
+
+    @Override
+    public boolean hasDirective(String directiveName) {
+        return directives.hasDirective(directiveName);
+    }
+
     public List<DirectiveLocation> getDirectiveLocations() {
         return directiveLocations;
     }
@@ -87,6 +111,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
         result.addAll(inputValueDefinitions);
+        result.addAll(directives.getDirectives());
         result.addAll(directiveLocations);
         return result;
     }
@@ -95,6 +120,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
     public NodeChildrenContainer getNamedChildren() {
         return newNodeChildrenContainer()
                 .children(CHILD_INPUT_VALUE_DEFINITIONS, inputValueDefinitions)
+                .children(CHILD_DIRECTIVES, directives.getDirectives())
                 .children(CHILD_DIRECTIVE_LOCATION, directiveLocations)
                 .build();
     }
@@ -103,6 +129,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
     public DirectiveDefinition withNewChildren(NodeChildrenContainer newChildren) {
         return transform(builder -> builder
                 .inputValueDefinitions(newChildren.getChildren(CHILD_INPUT_VALUE_DEFINITIONS))
+                .directives(newChildren.getChildren(CHILD_DIRECTIVES))
                 .directiveLocations(newChildren.getChildren(CHILD_DIRECTIVE_LOCATION))
         );
     }
@@ -127,6 +154,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
                 repeatable,
                 description,
                 assertNotNull(deepCopy(inputValueDefinitions), "inputValueDefinitions cannot be null"),
+                assertNotNull(deepCopy(directives.getDirectives()), "directives cannot be null"),
                 assertNotNull(deepCopy(directiveLocations), "directiveLocations cannot be null"),
                 getSourceLocation(),
                 getComments(),
@@ -139,6 +167,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
         return "DirectiveDefinition{" +
                 "name='" + name + "'" +
                 ", inputValueDefinitions=" + inputValueDefinitions +
+                ", directives=" + directives +
                 ", directiveLocations=" + directiveLocations +
                 "}";
     }
@@ -159,13 +188,14 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
     }
 
     @NullUnmarked
-    public static final class Builder implements NodeBuilder {
+    public static final class Builder implements NodeDirectivesBuilder {
         private SourceLocation sourceLocation;
         private ImmutableList<Comment> comments = emptyList();
         private String name;
         private boolean repeatable = false;
         private Description description;
         private ImmutableList<InputValueDefinition> inputValueDefinitions = emptyList();
+        private ImmutableList<Directive> directives = emptyList();
         private ImmutableList<DirectiveLocation> directiveLocations = emptyList();
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
         private Map<String, String> additionalData = new LinkedHashMap<>();
@@ -180,6 +210,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
             this.repeatable = existing.isRepeatable();
             this.description = existing.getDescription();
             this.inputValueDefinitions = ImmutableList.copyOf(existing.getInputValueDefinitions());
+            this.directives = ImmutableList.copyOf(existing.getDirectives());
             this.directiveLocations = ImmutableList.copyOf(existing.getDirectiveLocations());
             this.ignoredChars = existing.getIgnoredChars();
             this.additionalData = new LinkedHashMap<>(existing.getAdditionalData());
@@ -220,6 +251,17 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
             return this;
         }
 
+        @Override
+        public Builder directives(List<Directive> directives) {
+            this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        @Override
+        public Builder directive(Directive directive) {
+            this.directives = addToList(directives, directive);
+            return this;
+        }
 
         public Builder directiveLocations(List<DirectiveLocation> directiveLocations) {
             this.directiveLocations = ImmutableList.copyOf(directiveLocations);
@@ -248,7 +290,7 @@ public class DirectiveDefinition extends AbstractDescribedNode<DirectiveDefiniti
 
 
         public DirectiveDefinition build() {
-            return new DirectiveDefinition(name, repeatable, description, inputValueDefinitions, directiveLocations, sourceLocation, comments, ignoredChars, additionalData);
+            return new DirectiveDefinition(name, repeatable, description, inputValueDefinitions, directives, directiveLocations, sourceLocation, comments, ignoredChars, additionalData);
         }
     }
 }

--- a/src/main/java/graphql/language/DirectiveExtensionDefinition.java
+++ b/src/main/java/graphql/language/DirectiveExtensionDefinition.java
@@ -1,0 +1,134 @@
+package graphql.language;
+
+import com.google.common.collect.ImmutableList;
+import graphql.Internal;
+import graphql.PublicApi;
+import graphql.collect.ImmutableKit;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static graphql.Assert.assertNotNull;
+import static graphql.collect.ImmutableKit.emptyList;
+
+@PublicApi
+@NullMarked
+public class DirectiveExtensionDefinition extends DirectiveDefinition implements SDLExtensionDefinition {
+
+    @Internal
+    protected DirectiveExtensionDefinition(String name,
+                                           List<Directive> directives,
+                                           @Nullable SourceLocation sourceLocation,
+                                           List<Comment> comments,
+                                           IgnoredChars ignoredChars,
+                                           Map<String, String> additionalData) {
+        super(name, false, null, emptyList(), directives, emptyList(), sourceLocation, comments, ignoredChars, additionalData);
+    }
+
+    @Override
+    public DirectiveExtensionDefinition deepCopy() {
+        return new DirectiveExtensionDefinition(
+                getName(),
+                assertNotNull(deepCopy(getDirectives())),
+                getSourceLocation(),
+                getComments(),
+                getIgnoredChars(),
+                getAdditionalData());
+    }
+
+    @Override
+    public DirectiveExtensionDefinition withNewChildren(NodeChildrenContainer newChildren) {
+        return transformExtension(builder -> builder.directives(newChildren.getChildren(CHILD_DIRECTIVES)));
+    }
+
+    public static Builder newDirectiveExtensionDefinition() {
+        return new Builder();
+    }
+
+    public DirectiveExtensionDefinition transformExtension(Consumer<Builder> builderConsumer) {
+        Builder builder = new Builder(this);
+        builderConsumer.accept(builder);
+        return builder.build();
+    }
+
+    @Override
+    public String toString() {
+        return "DirectiveExtensionDefinition{" +
+                "name='" + getName() + '\'' +
+                ", directives=" + getDirectives() +
+                '}';
+    }
+
+    @NullUnmarked
+    public static final class Builder implements NodeDirectivesBuilder {
+        private SourceLocation sourceLocation;
+        private ImmutableList<Comment> comments = emptyList();
+        private String name;
+        private ImmutableList<Directive> directives = emptyList();
+        private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
+        private Map<String, String> additionalData = new LinkedHashMap<>();
+
+        private Builder() {
+        }
+
+        private Builder(DirectiveExtensionDefinition existing) {
+            sourceLocation = existing.getSourceLocation();
+            comments = ImmutableList.copyOf(existing.getComments());
+            name = existing.getName();
+            directives = ImmutableList.copyOf(existing.getDirectives());
+            ignoredChars = existing.getIgnoredChars();
+            additionalData = new LinkedHashMap<>(existing.getAdditionalData());
+        }
+
+        public Builder sourceLocation(SourceLocation sourceLocation) {
+            this.sourceLocation = sourceLocation;
+            return this;
+        }
+
+        public Builder comments(List<Comment> comments) {
+            this.comments = ImmutableList.copyOf(comments);
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        @Override
+        public Builder directives(List<Directive> directives) {
+            this.directives = ImmutableList.copyOf(directives);
+            return this;
+        }
+
+        @Override
+        public Builder directive(Directive directive) {
+            directives = ImmutableKit.addToList(directives, directive);
+            return this;
+        }
+
+        public Builder ignoredChars(IgnoredChars ignoredChars) {
+            this.ignoredChars = ignoredChars;
+            return this;
+        }
+
+        public Builder additionalData(Map<String, String> additionalData) {
+            this.additionalData = assertNotNull(additionalData);
+            return this;
+        }
+
+        public Builder additionalData(String key, String value) {
+            additionalData.put(key, value);
+            return this;
+        }
+
+        public DirectiveExtensionDefinition build() {
+            return new DirectiveExtensionDefinition(name, directives, sourceLocation, comments, ignoredChars, additionalData);
+        }
+    }
+}

--- a/src/main/java/graphql/language/PrettyAstPrinter.java
+++ b/src/main/java/graphql/language/PrettyAstPrinter.java
@@ -43,6 +43,7 @@ public class PrettyAstPrinter extends AstPrinter {
         this.commentParser = new CommentParser(parserContext);
         this.options = options;
 
+        this.replacePrinter(DirectiveExtensionDefinition.class, directiveExtensionDefinition());
         this.replacePrinter(DirectiveDefinition.class, directiveDefinition());
         this.replacePrinter(Document.class, document());
         this.replacePrinter(EnumTypeDefinition.class, enumTypeDefinition("enum"));
@@ -102,11 +103,25 @@ public class PrettyAstPrinter extends AstPrinter {
             String repeatable = node.isRepeatable() ? "repeatable " : "";
             out.append("directive @")
                     .append(node.getName())
-                    .append(block(node.getInputValueDefinitions(), node, "(", ")", "\n", ", ", ""))
-                    .append(" ")
+                    .append(block(node.getInputValueDefinitions(), node, "(", ")", "\n", ", ", ""));
+            if (!node.getDirectives().isEmpty()) {
+                out.append(" ").append(directives(node.getDirectives()));
+            }
+            out.append(" ")
                     .append(repeatable)
                     .append("on ")
                     .append(locations);
+        };
+    }
+
+    private NodePrinter<DirectiveExtensionDefinition> directiveExtensionDefinition() {
+        return (out, node) -> {
+            out.append(outset(node));
+            out.append(spaced(
+                    "extend directive",
+                    "@" + node.getName(),
+                    directives(node.getDirectives())
+            ));
         };
     }
 

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -13,6 +13,7 @@ import graphql.language.Definition;
 import graphql.language.Description;
 import graphql.language.Directive;
 import graphql.language.DirectiveDefinition;
+import graphql.language.DirectiveExtensionDefinition;
 import graphql.language.DirectiveLocation;
 import graphql.language.Document;
 import graphql.language.EnumTypeDefinition;
@@ -272,6 +273,8 @@ public class GraphqlAntlrToLanguage {
             return createTypeExtension(ctx.typeExtension());
         } else if (ctx.schemaExtension() != null) {
             return creationSchemaExtension(ctx.schemaExtension());
+        } else if (ctx.directiveExtension() != null) {
+            return createDirectiveExtensionDefinition(ctx.directiveExtension());
         } else {
             return assertShouldNeverHappen();
         }
@@ -643,6 +646,7 @@ public class GraphqlAntlrToLanguage {
         def.name(ctx.name().getText());
         addCommonData(def, ctx);
         def.description(newDescription(ctx.description()));
+        def.directives(createDirectives(ctx.directives()));
 
         def.repeatable(ctx.REPEATABLE() != null);
 
@@ -656,6 +660,14 @@ public class GraphqlAntlrToLanguage {
         if (ctx.argumentsDefinition() != null) {
             def.inputValueDefinitions(createInputValueDefinitions(ctx.argumentsDefinition().inputValueDefinition()));
         }
+        return captureRuleContext(def.build(), ctx);
+    }
+
+    protected DirectiveExtensionDefinition createDirectiveExtensionDefinition(GraphqlParser.DirectiveExtensionContext ctx) {
+        DirectiveExtensionDefinition.Builder def = DirectiveExtensionDefinition.newDirectiveExtensionDefinition();
+        def.name(ctx.name().getText());
+        addCommonData(def, ctx);
+        def.directives(createDirectives(ctx.directives()));
         return captureRuleContext(def.build(), ctx);
     }
 

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -2,11 +2,17 @@ package graphql.schema;
 
 
 import com.google.common.collect.ImmutableList;
+import graphql.DirectivesUtil;
 import graphql.PublicApi;
 import graphql.language.DirectiveDefinition;
+import graphql.language.DirectiveExtensionDefinition;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
@@ -18,7 +24,9 @@ import java.util.function.UnaryOperator;
 import static graphql.Assert.assertNotEmpty;
 import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertValidName;
+import static graphql.collect.ImmutableKit.emptyList;
 import static graphql.introspection.Introspection.DirectiveLocation;
+import static graphql.schema.SchemaElementChildrenContainer.newSchemaElementChildrenContainer;
 import static graphql.util.FpKit.getByName;
 
 /**
@@ -33,24 +41,32 @@ import static graphql.util.FpKit.getByName;
  * as opposed to its schema definition itself.
  */
 @PublicApi
-public class GraphQLDirective implements GraphQLNamedSchemaElement {
+@NullMarked
+public class GraphQLDirective implements GraphQLNamedSchemaElement, GraphQLDirectiveContainer {
 
     private final String name;
     private final boolean repeatable;
-    private final String description;
+    private final @Nullable String description;
     private final EnumSet<DirectiveLocation> locations;
     private final ImmutableList<GraphQLArgument> arguments;
-    private final DirectiveDefinition definition;
+    private final @Nullable DirectiveDefinition definition;
+    private final ImmutableList<DirectiveExtensionDefinition> extensionDefinitions;
+    private final DirectivesUtil.DirectivesHolder directivesHolder;
+    private final @Nullable String deprecationReason;
 
 
     public static final String CHILD_ARGUMENTS = "arguments";
 
     private GraphQLDirective(String name,
-                             String description,
+                             @Nullable String description,
                              boolean repeatable,
                              EnumSet<DirectiveLocation> locations,
                              List<GraphQLArgument> arguments,
-                             DirectiveDefinition definition) {
+                             List<GraphQLDirective> directives,
+                             List<GraphQLAppliedDirective> appliedDirectives,
+                             @Nullable DirectiveDefinition definition,
+                             List<DirectiveExtensionDefinition> extensionDefinitions,
+                             @Nullable String deprecationReason) {
         assertValidName(name);
         assertNotNull(arguments, "arguments can't be null");
         assertNotEmpty(locations, "locations can't be empty");
@@ -60,6 +76,9 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         this.locations = locations;
         this.arguments = ImmutableList.copyOf(arguments);
         this.definition = definition;
+        this.extensionDefinitions = ImmutableList.copyOf(extensionDefinitions);
+        this.directivesHolder = DirectivesUtil.DirectivesHolder.create(directives, appliedDirectives);
+        this.deprecationReason = deprecationReason;
     }
 
     @Override
@@ -79,7 +98,7 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         return arguments;
     }
 
-    public GraphQLArgument getArgument(String name) {
+    public @Nullable GraphQLArgument getArgument(String name) {
         for (GraphQLArgument argument : arguments) {
             if (argument.getName().equals(name)) {
                 return argument;
@@ -92,12 +111,59 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         return EnumSet.copyOf(locations);
     }
 
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return description;
     }
 
-    public DirectiveDefinition getDefinition() {
+    public @Nullable DirectiveDefinition getDefinition() {
         return definition;
+    }
+
+    public List<DirectiveExtensionDefinition> getExtensionDefinitions() {
+        return extensionDefinitions;
+    }
+
+    public boolean isDeprecated() {
+        return deprecationReason != null;
+    }
+
+    public @Nullable String getDeprecationReason() {
+        return deprecationReason;
+    }
+
+    @Override
+    public List<GraphQLDirective> getDirectives() {
+        return directivesHolder.getDirectives();
+    }
+
+    @Override
+    public Map<String, GraphQLDirective> getDirectivesByName() {
+        return directivesHolder.getDirectivesByName();
+    }
+
+    @Override
+    public Map<String, List<GraphQLDirective>> getAllDirectivesByName() {
+        return directivesHolder.getAllDirectivesByName();
+    }
+
+    @Override
+    public @Nullable GraphQLDirective getDirective(String directiveName) {
+        return directivesHolder.getDirective(directiveName);
+    }
+
+    @Override
+    public List<GraphQLAppliedDirective> getAppliedDirectives() {
+        return directivesHolder.getAppliedDirectives();
+    }
+
+    @Override
+    public Map<String, List<GraphQLAppliedDirective>> getAllAppliedDirectivesByName() {
+        return directivesHolder.getAllAppliedDirectivesByName();
+    }
+
+    @Override
+    public @Nullable GraphQLAppliedDirective getAppliedDirective(String directiveName) {
+        return directivesHolder.getAppliedDirective(directiveName);
     }
 
     @Override
@@ -137,13 +203,18 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
 
     @Override
     public List<GraphQLSchemaElement> getChildren() {
-        return ImmutableList.copyOf(arguments);
+        List<GraphQLSchemaElement> children = new ArrayList<>(arguments);
+        children.addAll(directivesHolder.getDirectives());
+        children.addAll(directivesHolder.getAppliedDirectives());
+        return children;
     }
 
     @Override
     public SchemaElementChildrenContainer getChildrenWithTypeReferences() {
-        return SchemaElementChildrenContainer.newSchemaElementChildrenContainer()
+        return newSchemaElementChildrenContainer()
                 .children(CHILD_ARGUMENTS, arguments)
+                .children(CHILD_DIRECTIVES, directivesHolder.getDirectives())
+                .children(CHILD_APPLIED_DIRECTIVES, directivesHolder.getAppliedDirectives())
                 .build();
     }
 
@@ -151,6 +222,8 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
     public GraphQLDirective withNewChildren(SchemaElementChildrenContainer newChildren) {
         return transform(builder ->
                 builder.replaceArguments(newChildren.getChildren(CHILD_ARGUMENTS))
+                        .replaceDirectives(newChildren.getChildren(CHILD_DIRECTIVES))
+                        .replaceAppliedDirectives(newChildren.getChildren(CHILD_APPLIED_DIRECTIVES))
         );
     }
 
@@ -192,11 +265,14 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
         return new Builder(existing);
     }
 
-    public static class Builder extends GraphqlTypeBuilder<Builder> {
+    @NullUnmarked
+    public static class Builder extends GraphqlDirectivesContainerTypeBuilder<Builder, Builder> {
 
         private EnumSet<DirectiveLocation> locations = EnumSet.noneOf(DirectiveLocation.class);
         private final Map<String, GraphQLArgument> arguments = new LinkedHashMap<>();
         private DirectiveDefinition definition;
+        private List<DirectiveExtensionDefinition> extensionDefinitions = emptyList();
+        private String deprecationReason;
         private boolean repeatable = false;
 
         public Builder() {
@@ -208,6 +284,10 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
             this.repeatable = existing.isRepeatable();
             this.locations = existing.validLocations();
             this.arguments.putAll(getByName(existing.getArguments(), GraphQLArgument::getName));
+            this.definition = existing.getDefinition();
+            this.extensionDefinitions = existing.getExtensionDefinitions();
+            this.deprecationReason = existing.getDeprecationReason();
+            copyExistingDirectives(existing);
         }
 
         public Builder repeatable(boolean repeatable) {
@@ -292,7 +372,62 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
             return this;
         }
 
+        public Builder extensionDefinitions(List<DirectiveExtensionDefinition> extensionDefinitions) {
+            this.extensionDefinitions = extensionDefinitions;
+            return this;
+        }
+
+        public Builder deprecate(String deprecationReason) {
+            this.deprecationReason = deprecationReason;
+            return this;
+        }
+
         // -- the following are repeated to avoid a binary incompatibility problem --
+
+        @Override
+        public Builder replaceDirectives(List<GraphQLDirective> directives) {
+            return super.replaceDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirectives(GraphQLDirective... directives) {
+            return super.withDirectives(directives);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective directive) {
+            return super.withDirective(directive);
+        }
+
+        @Override
+        public Builder withDirective(GraphQLDirective.Builder builder) {
+            return super.withDirective(builder);
+        }
+
+        @Override
+        public Builder replaceAppliedDirectives(List<GraphQLAppliedDirective> directives) {
+            return super.replaceAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirectives(GraphQLAppliedDirective... directives) {
+            return super.withAppliedDirectives(directives);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective directive) {
+            return super.withAppliedDirective(directive);
+        }
+
+        @Override
+        public Builder withAppliedDirective(GraphQLAppliedDirective.Builder builder) {
+            return super.withAppliedDirective(builder);
+        }
+
+        @Override
+        public Builder clearDirectives() {
+            return super.clearDirectives();
+        }
 
         @Override
         public Builder name(String name) {
@@ -311,7 +446,11 @@ public class GraphQLDirective implements GraphQLNamedSchemaElement {
                     repeatable,
                     locations,
                     sort(arguments, GraphQLDirective.class, GraphQLArgument.class),
-                    definition);
+                    sort(directives, GraphQLDirective.class, GraphQLDirective.class),
+                    sort(appliedDirectives, GraphQLDirective.class, GraphQLAppliedDirective.class),
+                    definition,
+                    extensionDefinitions,
+                    deprecationReason);
         }
 
 

--- a/src/main/java/graphql/schema/ShallowTypeRefCollector.java
+++ b/src/main/java/graphql/schema/ShallowTypeRefCollector.java
@@ -50,7 +50,7 @@ public class ShallowTypeRefCollector {
         }
         // Scan applied directives on all directive container types
         if (type instanceof GraphQLDirectiveContainer) {
-            scanAppliedDirectives(((GraphQLDirectiveContainer) type).getAppliedDirectives());
+            scanDirectiveContainer((GraphQLDirectiveContainer) type);
         }
         if (type instanceof GraphQLUnionType) {
             handleUnionType((GraphQLUnionType) type);
@@ -192,9 +192,24 @@ public class ShallowTypeRefCollector {
      * @param directive the directive definition to scan
      */
     public void handleDirective(GraphQLDirective directive) {
+        scanDirectiveContainer(directive);
         for (GraphQLArgument argument : directive.getArguments()) {
             scanArgumentType(argument);
             scanAppliedDirectives(argument.getAppliedDirectives());
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private void scanDirectiveContainer(GraphQLDirectiveContainer directiveContainer) {
+        scanAppliedDirectives(directiveContainer.getAppliedDirectives());
+        scanDirectives(directiveContainer.getDirectives());
+    }
+
+    private void scanDirectives(List<GraphQLDirective> directives) {
+        for (GraphQLDirective directive : directives) {
+            for (GraphQLArgument argument : directive.getArguments()) {
+                scanArgumentType(argument);
+            }
         }
     }
 

--- a/src/main/java/graphql/schema/diffing/PossibleMappingsCalculator.java
+++ b/src/main/java/graphql/schema/diffing/PossibleMappingsCalculator.java
@@ -417,6 +417,8 @@ public class PossibleMappingsCalculator {
                     case ARGUMENT:
                         Vertex fieldOrDirective = schemaGraph.getFieldOrDirectiveForArgument(container);
                         return fieldOrDirective.getType() + "." + fieldOrDirective.getName();
+                    case DIRECTIVE:
+                        return DIRECTIVE;
                     case INPUT_OBJECT:
                         return INPUT_OBJECT;
                     case ENUM:
@@ -454,6 +456,7 @@ public class PossibleMappingsCalculator {
                     case ENUM_VALUE:
                     case UNION:
                     case SCALAR:
+                    case DIRECTIVE:
                         return "";
                     case ARGUMENT:
                         Vertex fieldOrDirective = schemaGraph.getFieldOrDirectiveForArgument(container);
@@ -550,6 +553,8 @@ public class PossibleMappingsCalculator {
                     case ARGUMENT:
                         Vertex fieldOrDirective = schemaGraph.getFieldOrDirectiveForArgument(container);
                         return fieldOrDirective.getType() + "." + fieldOrDirective.getName();
+                    case DIRECTIVE:
+                        return DIRECTIVE;
                     case INPUT_OBJECT:
                         return INPUT_OBJECT;
                     case ENUM:
@@ -588,6 +593,7 @@ public class PossibleMappingsCalculator {
                     case ENUM_VALUE:
                     case UNION:
                     case SCALAR:
+                    case DIRECTIVE:
                         return "";
                     case ARGUMENT:
                         Vertex fieldOrDirective = schemaGraph.getFieldOrDirectiveForArgument(container);

--- a/src/main/java/graphql/schema/diffing/SchemaGraphFactory.java
+++ b/src/main/java/graphql/schema/diffing/SchemaGraphFactory.java
@@ -398,6 +398,7 @@ public class SchemaGraphFactory {
             schemaGraph.addVertex(argumentVertex);
             schemaGraph.addEdge(new Edge(directiveVertex, argumentVertex));
         }
+        createAppliedDirectives(directiveVertex, directive.getDirectives(), schemaGraph);
         schemaGraph.addDirective(directive.getName(), directiveVertex);
         schemaGraph.addVertex(directiveVertex);
     }

--- a/src/main/java/graphql/schema/diffing/ana/EditOperationAnalyzer.java
+++ b/src/main/java/graphql/schema/diffing/ana/EditOperationAnalyzer.java
@@ -26,6 +26,7 @@ import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveArgume
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveArgumentRename;
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveArgumentValueModification;
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveDeletion;
+import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveDirectiveLocation;
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveDirectiveArgumentLocation;
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveEnumLocation;
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveEnumValueLocation;
@@ -260,6 +261,14 @@ public class EditOperationAnalyzer {
             appliedDirectiveDeletedFromField(appliedDirective, container);
         } else if (container.isOfType(SchemaGraph.ARGUMENT)) {
             appliedDirectiveDeletedFromArgument(appliedDirective, container);
+        } else if (container.isOfType(SchemaGraph.DIRECTIVE)) {
+            Vertex directive = container;
+            if (isDirectiveDeleted(directive.getName())) {
+                return;
+            }
+            AppliedDirectiveDirectiveLocation location = new AppliedDirectiveDirectiveLocation(directive.getName(), appliedDirective.getName());
+            AppliedDirectiveDeletion appliedDirectiveDeletion = new AppliedDirectiveDeletion(location, appliedDirective.getName());
+            getDirectiveModification(directive.getName()).getDetails().add(appliedDirectiveDeletion);
         } else if (container.isOfType(SchemaGraph.OBJECT)) {
             Vertex object = container;
             if (isObjectDeleted(object.getName())) {
@@ -393,6 +402,16 @@ public class EditOperationAnalyzer {
                 AppliedDirectiveDirectiveArgumentLocation location = new AppliedDirectiveDirectiveArgumentLocation(directive.getName(), argument.getName(), appliedDirective.getName());
                 getDirectiveModification(directive.getName()).getDetails().add(new AppliedDirectiveArgumentDeletion(location, deletedArgument.getName()));
             }
+        } else if (container.isOfType(SchemaGraph.DIRECTIVE)) {
+            Vertex directive = container;
+            if (isDirectiveDeleted(directive.getName())) {
+                return;
+            }
+            if (isAppliedDirectiveDeleted(directive, appliedDirective.getName())) {
+                return;
+            }
+            AppliedDirectiveDirectiveLocation location = new AppliedDirectiveDirectiveLocation(directive.getName(), appliedDirective.getName());
+            getDirectiveModification(directive.getName()).getDetails().add(new AppliedDirectiveArgumentDeletion(location, deletedArgument.getName()));
         } else if (container.isOfType(SchemaGraph.FIELD)) {
             Vertex field = container;
             Vertex interfaceOrObjective = oldSchemaGraph.getFieldsContainerForField(field);
@@ -573,6 +592,16 @@ public class EditOperationAnalyzer {
                 AppliedDirectiveDirectiveArgumentLocation location = new AppliedDirectiveDirectiveArgumentLocation(directive.getName(), argument.getName(), appliedDirective.getName());
                 getDirectiveModification(directive.getName()).getDetails().add(new AppliedDirectiveArgumentAddition(location, addedArgument.getName()));
             }
+        } else if (container.isOfType(SchemaGraph.DIRECTIVE)) {
+            Vertex directive = container;
+            if (isDirectiveAdded(directive.getName())) {
+                return;
+            }
+            if (isAppliedDirectiveAdded(directive, appliedDirective.getName())) {
+                return;
+            }
+            AppliedDirectiveDirectiveLocation location = new AppliedDirectiveDirectiveLocation(directive.getName(), appliedDirective.getName());
+            getDirectiveModification(directive.getName()).getDetails().add(new AppliedDirectiveArgumentAddition(location, addedArgument.getName()));
         } else if (container.isOfType(SchemaGraph.FIELD)) {
             Vertex field = container;
             Vertex interfaceOrObjective = newSchemaGraph.getFieldsContainerForField(field);
@@ -777,6 +806,13 @@ public class EditOperationAnalyzer {
                 }
 
             }
+        } else if (container.isOfType(SchemaGraph.DIRECTIVE)) {
+            Vertex directive = container;
+            AppliedDirectiveDirectiveLocation location = new AppliedDirectiveDirectiveLocation(directive.getName(), appliedDirective.getName());
+            if (valueChanged) {
+                AppliedDirectiveArgumentValueModification argumentValueModification = new AppliedDirectiveArgumentValueModification(location, newArgumentName, oldValue, newValue);
+                getDirectiveModification(directive.getName()).getDetails().add(argumentValueModification);
+            }
         } else if (container.isOfType(SchemaGraph.INPUT_FIELD)) {
             Vertex inputField = container;
             Vertex inputObject = newSchemaGraph.getInputObjectForInputField(inputField);
@@ -874,7 +910,14 @@ public class EditOperationAnalyzer {
             appliedDirectiveAddedToField(appliedDirective, container);
         } else if (container.isOfType(SchemaGraph.ARGUMENT)) {
             appliedDirectiveAddedToArgument(appliedDirective, container);
-
+        } else if (container.isOfType(SchemaGraph.DIRECTIVE)) {
+            Vertex directive = container;
+            if (isDirectiveAdded(directive.getName())) {
+                return;
+            }
+            AppliedDirectiveDirectiveLocation location = new AppliedDirectiveDirectiveLocation(directive.getName(), appliedDirective.getName());
+            AppliedDirectiveAddition appliedDirectiveAddition = new AppliedDirectiveAddition(location, appliedDirective.getName());
+            getDirectiveModification(directive.getName()).getDetails().add(appliedDirectiveAddition);
         } else if (container.isOfType(SchemaGraph.OBJECT)) {
             Vertex object = container;
             if (isObjectAdded(object.getName())) {

--- a/src/main/java/graphql/schema/diffing/ana/SchemaDifference.java
+++ b/src/main/java/graphql/schema/diffing/ana/SchemaDifference.java
@@ -1388,6 +1388,24 @@ public interface SchemaDifference {
         }
     }
 
+    class AppliedDirectiveDirectiveLocation implements AppliedDirectiveLocationDetail {
+        private final String directiveDefinitionName;
+        private final String directiveName;
+
+        public AppliedDirectiveDirectiveLocation(String directiveDefinitionName, String directiveName) {
+            this.directiveDefinitionName = directiveDefinitionName;
+            this.directiveName = directiveName;
+        }
+
+        public String getDirectiveDefinitionName() {
+            return directiveDefinitionName;
+        }
+
+        public String getDirectiveName() {
+            return directiveName;
+        }
+    }
+
     class AppliedDirectiveDirectiveArgumentLocation implements AppliedDirectiveLocationDetail {
         // this is the applied directive name
         private final String directiveName;

--- a/src/main/java/graphql/schema/idl/ImmutableTypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/ImmutableTypeDefinitionRegistry.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.language.DirectiveDefinition;
+import graphql.language.DirectiveExtensionDefinition;
 import graphql.language.EnumTypeExtensionDefinition;
 import graphql.language.InputObjectTypeExtensionDefinition;
 import graphql.language.InterfaceTypeExtensionDefinition;
@@ -43,6 +44,7 @@ public class ImmutableTypeDefinitionRegistry extends TypeDefinitionRegistry {
                 copyOf(registry.enumTypeExtensions),
                 copyOf(registry.scalarTypeExtensions),
                 copyOf(registry.inputObjectTypeExtensions),
+                copyOf(registry.directiveExtensions),
                 copyOf(registry.types),
                 copyOf(registry.scalars()), // has an extra side effect
                 copyOf(registry.directiveDefinitions),
@@ -120,6 +122,11 @@ public class ImmutableTypeDefinitionRegistry extends TypeDefinitionRegistry {
     @Override
     public Map<String, List<InputObjectTypeExtensionDefinition>> inputObjectTypeExtensions() {
         return inputObjectTypeExtensions;
+    }
+
+    @Override
+    public Map<String, List<DirectiveExtensionDefinition>> directiveExtensions() {
+        return directiveExtensions;
     }
 
     @Override

--- a/src/main/java/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelper.java
+++ b/src/main/java/graphql/schema/idl/SchemaGeneratorAppliedDirectiveHelper.java
@@ -5,6 +5,7 @@ import graphql.introspection.Introspection;
 import graphql.language.Argument;
 import graphql.language.Directive;
 import graphql.language.DirectiveDefinition;
+import graphql.language.DirectiveExtensionDefinition;
 import graphql.language.InputValueDefinition;
 import graphql.language.StringValue;
 import graphql.language.Type;
@@ -32,6 +33,7 @@ import static graphql.collect.ImmutableKit.map;
 import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
 import static graphql.schema.idl.SchemaGeneratorHelper.buildDescription;
 import static graphql.util.Pair.pair;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -226,11 +228,20 @@ class SchemaGeneratorAppliedDirectiveHelper {
     }
 
     static GraphQLDirective buildDirectiveDefinitionFromAst(SchemaGeneratorHelper.BuildContext buildCtx, DirectiveDefinition directiveDefinition, Function<Type<?>, GraphQLInputType> inputTypeFactory) {
+        List<DirectiveExtensionDefinition> extensions = buildCtx.getTypeRegistry()
+                .directiveExtensions()
+                .getOrDefault(directiveDefinition.getName(), emptyList());
+        List<Directive> extensionDirectives = extensions.stream()
+                .flatMap(extension -> extension.getDirectives().stream())
+                .collect(toList());
 
         GraphQLDirective.Builder builder = GraphQLDirective.newDirective()
                 .name(directiveDefinition.getName())
                 .definition(buildCtx.isCaptureAstDefinitions() ? directiveDefinition : null)
+                .extensionDefinitions(buildCtx.isCaptureAstDefinitions() ? extensions : emptyList())
                 .repeatable(directiveDefinition.isRepeatable())
+                .deprecate(buildDeprecationReason(combineDirectives(directiveDefinition.getDirectives(), extensionDirectives)))
+                .comparatorRegistry(buildCtx.getComparatorRegistry())
                 .description(buildDescription(buildCtx, directiveDefinition, directiveDefinition.getDescription()));
 
 
@@ -240,7 +251,23 @@ class SchemaGeneratorAppliedDirectiveHelper {
         List<GraphQLArgument> arguments = map(directiveDefinition.getInputValueDefinitions(),
                 arg -> buildDirectiveArgumentDefinitionFromAst(buildCtx, arg, inputTypeFactory));
         arguments.forEach(builder::argument);
+
+        Pair<List<GraphQLDirective>, List<GraphQLAppliedDirective>> appliedDirectives = buildAppliedDirectives(
+                buildCtx,
+                inputTypeFactory,
+                directiveDefinition.getDirectives(),
+                extensionDirectives,
+                Introspection.DirectiveLocation.DIRECTIVE_DEFINITION,
+                buildCtx.getDirectives(),
+                buildCtx.getComparatorRegistry());
+        buildAppliedDirectives(buildCtx, builder, appliedDirectives);
         return builder.build();
+    }
+
+    private static List<Directive> combineDirectives(List<Directive> directives, List<Directive> extensionDirectives) {
+        List<Directive> combined = new ArrayList<>(directives);
+        combined.addAll(extensionDirectives);
+        return combined;
     }
 
     private static List<Introspection.DirectiveLocation> buildLocations(DirectiveDefinition directiveDefinition) {

--- a/src/main/java/graphql/schema/idl/SchemaPrinter.java
+++ b/src/main/java/graphql/schema/idl/SchemaPrinter.java
@@ -1105,6 +1105,9 @@ public class SchemaPrinter {
         } else if (directiveContainer instanceof GraphQLArgument) {
             GraphQLArgument type = (GraphQLArgument) directiveContainer;
             return type.getDeprecationReason();
+        } else if (directiveContainer instanceof GraphQLDirective) {
+            GraphQLDirective type = (GraphQLDirective) directiveContainer;
+            return type.getDeprecationReason();
         } else {
             return Assert.assertShouldNeverHappen();
         }
@@ -1138,6 +1141,7 @@ public class SchemaPrinter {
                 .collect(toList());
 
         sb.append(argsString(GraphQLDirective.class, args));
+        sb.append(directivesString(GraphQLDirective.class, directive.isDeprecated(), directive));
 
         if (directive.isRepeatable()) {
             sb.append(" repeatable");

--- a/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeDirectivesChecker.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.introspection.Introspection.DirectiveLocation.ARGUMENT_DEFINITION;
+import static graphql.introspection.Introspection.DirectiveLocation.DIRECTIVE_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM;
 import static graphql.introspection.Introspection.DirectiveLocation.ENUM_VALUE;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
@@ -53,6 +54,7 @@ import static graphql.introspection.Introspection.DirectiveLocation.SCALAR;
 import static graphql.introspection.Introspection.DirectiveLocation.UNION;
 import static graphql.util.FpKit.getByName;
 import static graphql.util.FpKit.mergeFirst;
+import static java.util.stream.Collectors.joining;
 
 /**
  * This is responsible for traversing EVERY type and field in the registry and ensuring that
@@ -105,6 +107,14 @@ class SchemaTypeDirectivesChecker {
         checkDirectives(DirectiveLocation.SCHEMA, errors, typeRegistry, schemaDefinition, "schema", schemaDirectives);
 
         Collection<DirectiveDefinition> directiveDefinitions = typeRegistry.getDirectiveDefinitions().values();
+        directiveDefinitions.forEach(definition -> {
+            checkDirectives(DIRECTIVE_DEFINITION, errors, typeRegistry, definition, definition.getName(), definition.getDirectives());
+            definition.getInputValueDefinitions().forEach(argument ->
+                    checkDirectives(ARGUMENT_DEFINITION, errors, typeRegistry, argument, argument.getName(), argument.getDirectives()));
+        });
+        typeRegistry.directiveExtensions().values().forEach(extensions ->
+                extensions.forEach(extension ->
+                        checkDirectives(DIRECTIVE_DEFINITION, errors, typeRegistry, extension, extension.getName(), extension.getDirectives())));
         commonCheck(directiveDefinitions, errors);
     }
 
@@ -190,118 +200,199 @@ class SchemaTypeDirectivesChecker {
     private void commonCheck(Collection<DirectiveDefinition> directiveDefinitions, List<GraphQLError> errors) {
         List<DirectiveDefinition> directiveDefinitionsList = new ArrayList<>(directiveDefinitions);
         Map<String, DirectiveDefinition> directiveDefinitionsByName = getByName(directiveDefinitionsList, DirectiveDefinition::getName, mergeFirst());
-        Map<String, Map<String, InputValueDefinition>> directiveReferencesByName = directiveReferencesByName(directiveDefinitionsByName);
+        Map<String, Map<String, NamedNode<?>>> referencesByName = referencesByName(directiveDefinitionsByName);
 
         directiveDefinitions.forEach(directiveDefinition -> {
             assertTypeName(directiveDefinition, errors);
+            checkDirectReference(directiveDefinition, directiveDefinition, directiveDefinition.getDirectives(), errors);
             directiveDefinition.getInputValueDefinitions().forEach(inputValueDefinition -> {
                 assertTypeName(inputValueDefinition, errors);
                 assertExistAndIsInputType(inputValueDefinition, errors);
-                if (inputValueDefinition.hasDirective(directiveDefinition.getName())) {
-                    errors.add(new DirectiveIllegalReferenceError(directiveDefinition, inputValueDefinition));
-                }
+                checkDirectReference(directiveDefinition, inputValueDefinition, inputValueDefinition.getDirectives(), errors);
             });
+            typeRegistry.directiveExtensions()
+                    .getOrDefault(directiveDefinition.getName(), Collections.emptyList())
+                    .forEach(extension ->
+                            checkDirectReference(directiveDefinition, extension, extension.getDirectives(), errors));
         });
-        checkIndirectDirectiveCycles(directiveDefinitionsByName, directiveReferencesByName, errors);
+        checkIndirectDirectiveCycles(directiveDefinitionsByName, referencesByName, errors);
     }
 
-    private static Map<String, Map<String, InputValueDefinition>> directiveReferencesByName(
+    private static void checkDirectReference(DirectiveDefinition definition,
+                                             NamedNode<?> location,
+                                             List<Directive> directives,
+                                             List<GraphQLError> errors) {
+        if (directives.stream().noneMatch(directive -> directive.getName().equals(definition.getName()))) {
+            return;
+        }
+        errors.add(new DirectiveIllegalReferenceError(definition, location));
+    }
+
+    private Map<String, Map<String, NamedNode<?>>> referencesByName(
             Map<String, DirectiveDefinition> directiveDefinitionsByName) {
-        Map<String, Map<String, InputValueDefinition>> result = new LinkedHashMap<>();
-        directiveDefinitionsByName.forEach((name, directiveDefinition) -> result.put(name, directiveReferences(directiveDefinition)));
+        Map<String, Map<String, NamedNode<?>>> result = new LinkedHashMap<>();
+        directiveDefinitionsByName.values().forEach(definition ->
+                recordDirectiveDefinitionReferences(result, definition));
+        recordInputTypeReferences(result);
         return result;
     }
 
-    private static Map<String, InputValueDefinition> directiveReferences(DirectiveDefinition directiveDefinition) {
-        Map<String, InputValueDefinition> result = new LinkedHashMap<>();
-        for (InputValueDefinition inputValueDefinition : directiveDefinition.getInputValueDefinitions()) {
-            recordDirectiveReferences(directiveDefinition, result, inputValueDefinition);
-        }
-        return result;
+    private void recordDirectiveDefinitionReferences(Map<String, Map<String, NamedNode<?>>> references,
+                                                     DirectiveDefinition definition) {
+        String source = definition.getName();
+        recordAppliedDirectiveReferences(references, source, definition, definition.getDirectives());
+        definition.getInputValueDefinitions().forEach(argument -> {
+            recordAppliedDirectiveReferences(references, source, argument, argument.getDirectives());
+            recordReference(references, source, typeKey(TypeUtil.unwrapAll(argument.getType()).getName()), argument);
+        });
+        typeRegistry.directiveExtensions()
+                .getOrDefault(source, Collections.emptyList())
+                .forEach(extension ->
+                        recordAppliedDirectiveReferences(references, source, extension, extension.getDirectives()));
     }
 
-    private static void recordDirectiveReferences(DirectiveDefinition directiveDefinition,
-                                                  Map<String, InputValueDefinition> result,
-                                                  InputValueDefinition inputValueDefinition) {
-        for (Directive directive : inputValueDefinition.getDirectives()) {
-            if (directive.getName().equals(directiveDefinition.getName())) {
-                continue;
+    private void recordInputTypeReferences(Map<String, Map<String, NamedNode<?>>> references) {
+        typeRegistry.getTypes(InputObjectTypeDefinition.class)
+                .forEach(definition -> recordInputObjectReferences(references, definition));
+        typeRegistry.inputObjectTypeExtensions().values()
+                .forEach(extensions -> extensions.forEach(extension -> recordInputObjectReferences(references, extension)));
+        typeRegistry.getTypes(EnumTypeDefinition.class)
+                .forEach(definition -> recordEnumReferences(references, definition));
+        typeRegistry.enumTypeExtensions().values()
+                .forEach(extensions -> extensions.forEach(extension -> recordEnumReferences(references, extension)));
+        typeRegistry.scalars().values()
+                .forEach(definition -> recordScalarReferences(references, definition));
+        typeRegistry.scalarTypeExtensions().values()
+                .forEach(extensions -> extensions.forEach(extension -> recordScalarReferences(references, extension)));
+    }
+
+    private static void recordInputObjectReferences(Map<String, Map<String, NamedNode<?>>> references,
+                                                    InputObjectTypeDefinition definition) {
+        String source = typeKey(definition.getName());
+        recordAppliedDirectiveReferences(references, source, definition, definition.getDirectives());
+        definition.getInputValueDefinitions().forEach(field -> {
+            recordAppliedDirectiveReferences(references, source, field, field.getDirectives());
+            recordReference(references, source, typeKey(TypeUtil.unwrapAll(field.getType()).getName()), field);
+        });
+    }
+
+    private static void recordEnumReferences(Map<String, Map<String, NamedNode<?>>> references,
+                                             EnumTypeDefinition definition) {
+        String source = typeKey(definition.getName());
+        recordAppliedDirectiveReferences(references, source, definition, definition.getDirectives());
+        definition.getEnumValueDefinitions().forEach(value ->
+                recordAppliedDirectiveReferences(references, source, value, value.getDirectives()));
+    }
+
+    private static void recordScalarReferences(Map<String, Map<String, NamedNode<?>>> references,
+                                               ScalarTypeDefinition definition) {
+        recordAppliedDirectiveReferences(references, typeKey(definition.getName()), definition, definition.getDirectives());
+    }
+
+    private static void recordAppliedDirectiveReferences(Map<String, Map<String, NamedNode<?>>> references,
+                                                         String source,
+                                                         NamedNode<?> location,
+                                                         List<Directive> directives) {
+        directives.forEach(directive -> {
+            if (!directive.getName().equals(source)) {
+                recordReference(references, source, directive.getName(), location);
             }
-            result.putIfAbsent(directive.getName(), inputValueDefinition);
-        }
+        });
+    }
+
+    private static void recordReference(Map<String, Map<String, NamedNode<?>>> references,
+                                        String source,
+                                        String target,
+                                        NamedNode<?> location) {
+        references.computeIfAbsent(source, key -> new LinkedHashMap<>())
+                .putIfAbsent(target, location);
+    }
+
+    private static String typeKey(String typeName) {
+        return "type:" + typeName;
     }
 
     private static void checkIndirectDirectiveCycles(
             Map<String, DirectiveDefinition> directiveDefinitionsByName,
-            Map<String, Map<String, InputValueDefinition>> directiveReferencesByName,
+            Map<String, Map<String, NamedNode<?>>> referencesByName,
             List<GraphQLError> errors) {
         Set<String> checked = new LinkedHashSet<>();
         Set<String> visiting = new LinkedHashSet<>();
         List<String> path = new ArrayList<>();
         for (String directiveName : directiveDefinitionsByName.keySet()) {
-            checkIndirectDirectiveCycles(directiveName, directiveDefinitionsByName, directiveReferencesByName, checked, visiting, path, errors);
+            checkIndirectDirectiveCycles(directiveName, directiveDefinitionsByName, referencesByName, checked, visiting, path, errors);
         }
     }
 
-    private static void checkIndirectDirectiveCycles(String directiveName,
+    private static void checkIndirectDirectiveCycles(String nodeName,
                                                      Map<String, DirectiveDefinition> directiveDefinitionsByName,
-                                                     Map<String, Map<String, InputValueDefinition>> directiveReferencesByName,
+                                                     Map<String, Map<String, NamedNode<?>>> referencesByName,
                                                      Set<String> checked,
                                                      Set<String> visiting,
                                                      List<String> path,
                                                      List<GraphQLError> errors) {
-        if (checked.contains(directiveName)) {
+        if (checked.contains(nodeName)) {
             return;
         }
 
-        visiting.add(directiveName);
-        path.add(directiveName);
-        checkIndirectDirectiveCycleReferences(directiveName, directiveDefinitionsByName, directiveReferencesByName, checked, visiting, path, errors);
+        visiting.add(nodeName);
+        path.add(nodeName);
+        checkIndirectDirectiveCycleReferences(nodeName, directiveDefinitionsByName, referencesByName, checked, visiting, path, errors);
         path.remove(path.size() - 1);
-        visiting.remove(directiveName);
-        checked.add(directiveName);
+        visiting.remove(nodeName);
+        checked.add(nodeName);
     }
 
-    private static void checkIndirectDirectiveCycleReferences(String directiveName,
+    private static void checkIndirectDirectiveCycleReferences(String nodeName,
                                                              Map<String, DirectiveDefinition> directiveDefinitionsByName,
-                                                             Map<String, Map<String, InputValueDefinition>> directiveReferencesByName,
+                                                             Map<String, Map<String, NamedNode<?>>> referencesByName,
                                                              Set<String> checked,
                                                              Set<String> visiting,
                                                              List<String> path,
                                                              List<GraphQLError> errors) {
-        Map<String, InputValueDefinition> references = directiveReferencesByName.getOrDefault(directiveName, Collections.emptyMap());
-        for (Map.Entry<String, InputValueDefinition> entry : references.entrySet()) {
-            checkIndirectDirectiveCycleReference(entry.getKey(), entry.getValue(), directiveDefinitionsByName, directiveReferencesByName, checked, visiting, path, errors);
+        Map<String, NamedNode<?>> references = referencesByName.getOrDefault(nodeName, Collections.emptyMap());
+        for (Map.Entry<String, NamedNode<?>> entry : references.entrySet()) {
+            checkIndirectDirectiveCycleReference(entry.getKey(), entry.getValue(), directiveDefinitionsByName, referencesByName, checked, visiting, path, errors);
         }
     }
 
-    private static void checkIndirectDirectiveCycleReference(String referencedDirectiveName,
-                                                            InputValueDefinition inputValueDefinition,
+    private static void checkIndirectDirectiveCycleReference(String referencedNodeName,
+                                                            NamedNode<?> location,
                                                             Map<String, DirectiveDefinition> directiveDefinitionsByName,
-                                                            Map<String, Map<String, InputValueDefinition>> directiveReferencesByName,
+                                                            Map<String, Map<String, NamedNode<?>>> referencesByName,
                                                             Set<String> checked,
                                                             Set<String> visiting,
                                                             List<String> path,
                                                             List<GraphQLError> errors) {
-        if (visiting.contains(referencedDirectiveName)) {
-            addIndirectDirectiveCycleError(referencedDirectiveName, inputValueDefinition, directiveDefinitionsByName, path, errors);
+        if (visiting.contains(referencedNodeName)) {
+            addIndirectDirectiveCycleError(referencedNodeName, location, directiveDefinitionsByName, path, errors);
             return;
         }
-        if (!checked.contains(referencedDirectiveName)) {
-            checkIndirectDirectiveCycles(referencedDirectiveName, directiveDefinitionsByName, directiveReferencesByName, checked, visiting, path, errors);
+        if (!checked.contains(referencedNodeName)) {
+            checkIndirectDirectiveCycles(referencedNodeName, directiveDefinitionsByName, referencesByName, checked, visiting, path, errors);
         }
     }
 
-    private static void addIndirectDirectiveCycleError(String repeatedDirectiveName,
-                                                       InputValueDefinition inputValueDefinition,
+    private static void addIndirectDirectiveCycleError(String repeatedNodeName,
+                                                       NamedNode<?> location,
                                                        Map<String, DirectiveDefinition> directiveDefinitionsByName,
                                                        List<String> path,
                                                        List<GraphQLError> errors) {
-        List<String> cyclePath = directiveCyclePath(repeatedDirectiveName, path);
-        String cyclePathString = String.join(" -> ", cyclePath);
+        List<String> cyclePath = directiveCyclePath(repeatedNodeName, path);
+        String directiveName = cyclePath.stream()
+                .filter(directiveDefinitionsByName::containsKey)
+                .findFirst()
+                .orElse(null);
+        if (directiveName == null) {
+            return;
+        }
+        cyclePath = rotateCyclePath(cyclePath, directiveName);
+        String cyclePathString = cyclePath.stream()
+                .map(SchemaTypeDirectivesChecker::displayNodeName)
+                .collect(joining(" -> "));
 
-        DirectiveDefinition directiveDefinition = assertNotNull(directiveDefinitionsByName.get(repeatedDirectiveName));
-        errors.add(new DirectiveIllegalReferenceError(directiveDefinition, inputValueDefinition, cyclePathString));
+        DirectiveDefinition directiveDefinition = assertNotNull(directiveDefinitionsByName.get(directiveName));
+        errors.add(new DirectiveIllegalReferenceError(directiveDefinition, location, cyclePathString));
     }
 
     private static List<String> directiveCyclePath(String repeatedDirectiveName, List<String> path) {
@@ -309,6 +400,23 @@ class SchemaTypeDirectivesChecker {
         List<String> cyclePath = new ArrayList<>(path.subList(cycleStart, path.size()));
         cyclePath.add(repeatedDirectiveName);
         return cyclePath;
+    }
+
+    private static List<String> rotateCyclePath(List<String> cyclePath, String firstNode) {
+        List<String> nodes = cyclePath.subList(0, cyclePath.size() - 1);
+        int firstNodeIndex = nodes.indexOf(firstNode);
+        List<String> result = new ArrayList<>(nodes.size() + 1);
+        result.addAll(nodes.subList(firstNodeIndex, nodes.size()));
+        result.addAll(nodes.subList(0, firstNodeIndex));
+        result.add(firstNode);
+        return result;
+    }
+
+    private static String displayNodeName(String nodeName) {
+        if (nodeName.startsWith("type:")) {
+            return nodeName.substring("type:".length());
+        }
+        return nodeName;
     }
 
     private static void assertTypeName(NamedNode<?> node, List<GraphQLError> errors) {

--- a/src/main/java/graphql/schema/idl/SchemaTypeExtensionsChecker.java
+++ b/src/main/java/graphql/schema/idl/SchemaTypeExtensionsChecker.java
@@ -3,7 +3,9 @@ package graphql.schema.idl;
 import graphql.GraphQLError;
 import graphql.Internal;
 import graphql.language.Argument;
+import graphql.language.Directive;
 import graphql.language.DirectiveDefinition;
+import graphql.language.DirectiveExtensionDefinition;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.EnumValueDefinition;
 import graphql.language.FieldDefinition;
@@ -17,6 +19,8 @@ import graphql.language.TypeDefinition;
 import graphql.language.TypeName;
 import graphql.language.UnionTypeDefinition;
 import graphql.language.UnionTypeExtensionDefinition;
+import graphql.schema.idl.errors.DirectiveExtensionDirectiveRedefinitionError;
+import graphql.schema.idl.errors.DirectiveExtensionMissingBaseError;
 import graphql.schema.idl.errors.MissingTypeError;
 import graphql.schema.idl.errors.NonUniqueArgumentError;
 import graphql.schema.idl.errors.NonUniqueNameError;
@@ -44,12 +48,51 @@ class SchemaTypeExtensionsChecker {
 
     void checkTypeExtensions(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry) {
         Map<String, DirectiveDefinition> directiveDefinitionMap = typeRegistry.getDirectiveDefinitions();
+        checkDirectiveExtensions(errors, typeRegistry, directiveDefinitionMap);
         checkObjectTypeExtensions(errors, typeRegistry, directiveDefinitionMap);
         checkInterfaceTypeExtensions(errors, typeRegistry, directiveDefinitionMap);
         checkUnionTypeExtensions(errors, typeRegistry, directiveDefinitionMap);
         checkEnumTypeExtensions(errors, typeRegistry, directiveDefinitionMap);
         checkScalarTypeExtensions(errors, typeRegistry, directiveDefinitionMap);
         checkInputObjectTypeExtensions(errors, typeRegistry, directiveDefinitionMap);
+    }
+
+    private void checkDirectiveExtensions(List<GraphQLError> errors, TypeDefinitionRegistry typeRegistry, Map<String, DirectiveDefinition> directiveDefinitions) {
+        typeRegistry.directiveExtensions().forEach((name, extensions) -> {
+            if (!directiveDefinitions.containsKey(name)) {
+                errors.add(new DirectiveExtensionMissingBaseError(extensions.get(0)));
+            }
+        });
+
+        directiveDefinitions.values().forEach(definition ->
+                checkDirectiveApplicationsAreUnique(errors, definition, typeRegistry.directiveExtensions()
+                        .getOrDefault(definition.getName(), List.of()), directiveDefinitions));
+    }
+
+    private void checkDirectiveApplicationsAreUnique(List<GraphQLError> errors,
+                                                     DirectiveDefinition definition,
+                                                     List<DirectiveExtensionDefinition> extensions,
+                                                     Map<String, DirectiveDefinition> directiveDefinitions) {
+        Set<String> seen = new HashSet<>();
+        checkDirectiveApplicationsAreUnique(errors, definition, definition.getDirectives(), directiveDefinitions, seen);
+        extensions.forEach(extension ->
+                checkDirectiveApplicationsAreUnique(errors, extension, extension.getDirectives(), directiveDefinitions, seen));
+    }
+
+    private void checkDirectiveApplicationsAreUnique(List<GraphQLError> errors,
+                                                     DirectiveDefinition owner,
+                                                     List<Directive> directives,
+                                                     Map<String, DirectiveDefinition> directiveDefinitions,
+                                                     Set<String> seen) {
+        directives.forEach(directive -> {
+            DirectiveDefinition appliedDefinition = directiveDefinitions.get(directive.getName());
+            if (appliedDefinition == null || appliedDefinition.isRepeatable()) {
+                return;
+            }
+            if (!seen.add(directive.getName())) {
+                errors.add(new DirectiveExtensionDirectiveRedefinitionError(owner, directive));
+            }
+        });
     }
 
 

--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -5,6 +5,7 @@ import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.collect.ImmutableKit;
 import graphql.language.DirectiveDefinition;
+import graphql.language.DirectiveExtensionDefinition;
 import graphql.language.EnumTypeExtensionDefinition;
 import graphql.language.ImplementingTypeDefinition;
 import graphql.language.InputObjectTypeExtensionDefinition;
@@ -62,6 +63,7 @@ public class TypeDefinitionRegistry implements Serializable {
     protected final Map<String, List<EnumTypeExtensionDefinition>> enumTypeExtensions;
     protected final Map<String, List<ScalarTypeExtensionDefinition>> scalarTypeExtensions;
     protected final Map<String, List<InputObjectTypeExtensionDefinition>> inputObjectTypeExtensions;
+    protected final Map<String, List<DirectiveExtensionDefinition>> directiveExtensions;
 
     protected final Map<String, TypeDefinition> types;
     protected final Map<String, ScalarTypeDefinition> scalarTypes;
@@ -77,6 +79,7 @@ public class TypeDefinitionRegistry implements Serializable {
         enumTypeExtensions = new LinkedHashMap<>();
         scalarTypeExtensions = new LinkedHashMap<>();
         inputObjectTypeExtensions = new LinkedHashMap<>();
+        directiveExtensions = new LinkedHashMap<>();
         types = new LinkedHashMap<>();
         scalarTypes = new LinkedHashMap<>();
         directiveDefinitions = new LinkedHashMap<>();
@@ -90,6 +93,7 @@ public class TypeDefinitionRegistry implements Serializable {
                                      Map<String, List<EnumTypeExtensionDefinition>> enumTypeExtensions,
                                      Map<String, List<ScalarTypeExtensionDefinition>> scalarTypeExtensions,
                                      Map<String, List<InputObjectTypeExtensionDefinition>> inputObjectTypeExtensions,
+                                     Map<String, List<DirectiveExtensionDefinition>> directiveExtensions,
                                      Map<String, TypeDefinition> types,
                                      Map<String, ScalarTypeDefinition> scalarTypes,
                                      Map<String, DirectiveDefinition> directiveDefinitions,
@@ -102,6 +106,7 @@ public class TypeDefinitionRegistry implements Serializable {
         this.enumTypeExtensions = enumTypeExtensions;
         this.scalarTypeExtensions = scalarTypeExtensions;
         this.inputObjectTypeExtensions = inputObjectTypeExtensions;
+        this.directiveExtensions = directiveExtensions;
         this.types = types;
         this.scalarTypes = scalarTypes;
         this.directiveDefinitions = directiveDefinitions;
@@ -205,6 +210,12 @@ public class TypeDefinitionRegistry implements Serializable {
                     .computeIfAbsent(key, k -> new ArrayList<>());
             currentList.addAll(value);
         });
+        typeRegistry.directiveExtensions.forEach((key, value) -> {
+            List<DirectiveExtensionDefinition> currentList = this.directiveExtensions
+                    .computeIfAbsent(key, k -> new ArrayList<>());
+            currentList.addAll(value);
+            value.forEach(schemaParseOrder::addDefinition);
+        });
 
         return this;
     }
@@ -276,6 +287,9 @@ public class TypeDefinitionRegistry implements Serializable {
         } else if (definition instanceof InputObjectTypeExtensionDefinition) {
             InputObjectTypeExtensionDefinition newEntry = (InputObjectTypeExtensionDefinition) definition;
             return defineExt(inputObjectTypeExtensions, newEntry, InputObjectTypeExtensionDefinition::getName);
+        } else if (definition instanceof DirectiveExtensionDefinition) {
+            DirectiveExtensionDefinition newEntry = (DirectiveExtensionDefinition) definition;
+            return defineDirectiveExt(newEntry);
         } else if (definition instanceof SchemaExtensionDefinition) {
             schemaExtensionDefinitions.add((SchemaExtensionDefinition) definition);
             schemaParseOrder.addDefinition(definition);
@@ -330,6 +344,8 @@ public class TypeDefinitionRegistry implements Serializable {
             removeFromList(scalarTypeExtensions, (TypeDefinition) definition);
         } else if (definition instanceof InputObjectTypeExtensionDefinition) {
             removeFromList(inputObjectTypeExtensions, (TypeDefinition) definition);
+        } else if (definition instanceof DirectiveExtensionDefinition) {
+            removeDirectiveExtension((DirectiveExtensionDefinition) definition);
         } else if (definition instanceof ScalarTypeDefinition) {
             scalarTypes.remove(((ScalarTypeDefinition) definition).getName());
         } else if (definition instanceof TypeDefinition) {
@@ -379,6 +395,8 @@ public class TypeDefinitionRegistry implements Serializable {
             removeFromMap(scalarTypeExtensions, key);
         } else if (definition instanceof InputObjectTypeExtensionDefinition) {
             removeFromMap(inputObjectTypeExtensions, key);
+        } else if (definition instanceof DirectiveExtensionDefinition) {
+            removeFromMap(directiveExtensions, key);
         } else if (definition instanceof ScalarTypeDefinition) {
             removeFromMap(scalarTypes, key);
         } else if (definition instanceof TypeDefinition) {
@@ -399,6 +417,17 @@ public class TypeDefinitionRegistry implements Serializable {
             return;
         }
         source.remove(key);
+    }
+
+    private void removeDirectiveExtension(DirectiveExtensionDefinition extension) {
+        List<DirectiveExtensionDefinition> extensions = directiveExtensions.get(extension.getName());
+        if (extensions == null) {
+            return;
+        }
+        extensions.remove(extension);
+        if (extensions.isEmpty()) {
+            directiveExtensions.remove(extension.getName());
+        }
     }
 
 
@@ -430,6 +459,13 @@ public class TypeDefinitionRegistry implements Serializable {
 
     private <T extends TypeDefinition> Optional<GraphQLError> defineExt(Map<String, List<T>> typeExtensions, T newEntry, Function<T, String> namerFunc) {
         List<T> currentList = typeExtensions.computeIfAbsent(namerFunc.apply(newEntry), k -> new ArrayList<>());
+        currentList.add(newEntry);
+        schemaParseOrder.addDefinition(newEntry);
+        return Optional.empty();
+    }
+
+    private Optional<GraphQLError> defineDirectiveExt(DirectiveExtensionDefinition newEntry) {
+        List<DirectiveExtensionDefinition> currentList = directiveExtensions.computeIfAbsent(newEntry.getName(), key -> new ArrayList<>());
         currentList.add(newEntry);
         schemaParseOrder.addDefinition(newEntry);
         return Optional.empty();
@@ -467,6 +503,10 @@ public class TypeDefinitionRegistry implements Serializable {
 
     public Map<String, List<InputObjectTypeExtensionDefinition>> inputObjectTypeExtensions() {
         return new LinkedHashMap<>(inputObjectTypeExtensions);
+    }
+
+    public Map<String, List<DirectiveExtensionDefinition>> directiveExtensions() {
+        return new LinkedHashMap<>(directiveExtensions);
     }
 
     public Optional<SchemaDefinition> schemaDefinition() {

--- a/src/main/java/graphql/schema/idl/errors/DirectiveExtensionDirectiveRedefinitionError.java
+++ b/src/main/java/graphql/schema/idl/errors/DirectiveExtensionDirectiveRedefinitionError.java
@@ -1,0 +1,17 @@
+package graphql.schema.idl.errors;
+
+import graphql.Internal;
+import graphql.language.Directive;
+import graphql.language.DirectiveDefinition;
+
+import static java.lang.String.format;
+
+@Internal
+public class DirectiveExtensionDirectiveRedefinitionError extends BaseError {
+
+    public DirectiveExtensionDirectiveRedefinitionError(DirectiveDefinition definition, Directive directive) {
+        super(definition,
+                format("The directive '@%s' %s has redefined the non-repeatable directive '@%s'",
+                        definition.getName(), lineCol(definition), directive.getName()));
+    }
+}

--- a/src/main/java/graphql/schema/idl/errors/DirectiveExtensionMissingBaseError.java
+++ b/src/main/java/graphql/schema/idl/errors/DirectiveExtensionMissingBaseError.java
@@ -1,0 +1,16 @@
+package graphql.schema.idl.errors;
+
+import graphql.Internal;
+import graphql.language.DirectiveExtensionDefinition;
+
+import static java.lang.String.format;
+
+@Internal
+public class DirectiveExtensionMissingBaseError extends BaseError {
+
+    public DirectiveExtensionMissingBaseError(DirectiveExtensionDefinition extension) {
+        super(extension,
+                format("The extension '@%s' directive %s is missing its base directive definition",
+                        extension.getName(), lineCol(extension)));
+    }
+}

--- a/src/main/java/graphql/util/Anonymizer.java
+++ b/src/main/java/graphql/util/Anonymizer.java
@@ -896,7 +896,7 @@ public class Anonymizer {
                     GraphQLFieldDefinition graphQLFieldDefinition = assertNotNull(context.getVarFromParents(GraphQLFieldDefinition.class));
                     graphQLArgumentDefinition = graphQLFieldDefinition.getArgument(argument.getName());
                 }
-                GraphQLInputType argumentType = graphQLArgumentDefinition.getType();
+                GraphQLInputType argumentType = assertNotNull(graphQLArgumentDefinition).getType();
                 String newName = assertNotNull(astNodeToNewName.get(argument));
                 Value newValue = replaceValue(argument.getValue(), argumentType, newNames, defaultStringValueCounter, defaultIntValueCounter);
                 return changeNode(context, argument.transform(builder -> builder.name(newName).value(newValue)));

--- a/src/main/java/graphql/util/Anonymizer.java
+++ b/src/main/java/graphql/util/Anonymizer.java
@@ -891,12 +891,16 @@ public class Anonymizer {
                 // An argument is either from a applied query directive or from a field
                 if (context.getVarFromParents(GraphQLDirective.class) != null) {
                     GraphQLDirective directiveDefinition = context.getVarFromParents(GraphQLDirective.class);
-                    graphQLArgumentDefinition = directiveDefinition.getArgument(argument.getName());
+                    graphQLArgumentDefinition = assertNotNull(
+                            directiveDefinition.getArgument(argument.getName()),
+                            "Directive '%s' argument '%s' not found",
+                            directiveDefinition.getName(),
+                            argument.getName());
                 } else {
                     GraphQLFieldDefinition graphQLFieldDefinition = assertNotNull(context.getVarFromParents(GraphQLFieldDefinition.class));
                     graphQLArgumentDefinition = graphQLFieldDefinition.getArgument(argument.getName());
                 }
-                GraphQLInputType argumentType = assertNotNull(graphQLArgumentDefinition).getType();
+                GraphQLInputType argumentType = graphQLArgumentDefinition.getType();
                 String newName = assertNotNull(astNodeToNewName.get(argument));
                 Value newValue = replaceValue(argument.getValue(), argumentType, newNames, defaultStringValueCounter, defaultIntValueCounter);
                 return changeNode(context, argument.transform(builder -> builder.name(newName).value(newValue)));

--- a/src/test/groovy/graphql/Issue2141.groovy
+++ b/src/test/groovy/graphql/Issue2141.groovy
@@ -32,7 +32,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"

--- a/src/test/groovy/graphql/Issue2141.groovy
+++ b/src/test/groovy/graphql/Issue2141.groovy
@@ -36,7 +36,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 "This directive disables error propagation when a non nullable field returns null for the given operation."
 directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION

--- a/src/test/groovy/graphql/archunit/JSpecifyAnnotationsCheck.groovy
+++ b/src/test/groovy/graphql/archunit/JSpecifyAnnotationsCheck.groovy
@@ -68,7 +68,6 @@ class JSpecifyAnnotationsCheck extends Specification {
             "graphql.schema.GraphQLAppliedDirectiveArgument",
             "graphql.schema.GraphQLArgument",
             "graphql.schema.GraphQLCompositeType",
-            "graphql.schema.GraphQLDirective",
             "graphql.schema.GraphQLDirectiveContainer",
             "graphql.schema.GraphQLEnumValueDefinition",
             "graphql.schema.GraphQLFieldDefinition",

--- a/src/test/groovy/graphql/introspection/DirectiveDeprecationIntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/DirectiveDeprecationIntrospectionTest.groovy
@@ -1,0 +1,82 @@
+package graphql.introspection
+
+import graphql.TestUtil
+import graphql.language.AstPrinter
+import graphql.language.DirectiveDefinition
+import spock.lang.Specification
+
+class DirectiveDeprecationIntrospectionTest extends Specification {
+
+    def "introspection hides deprecated directives by default and exposes their metadata on request"() {
+        given:
+        def graphQL = TestUtil.graphQL('''
+            directive @active on FIELD_DEFINITION
+            directive @old @deprecated(reason: "Use @active") on FIELD_DEFINITION
+            type Query {
+                field: String
+            }
+        ''').build()
+
+        when:
+        def result = graphQL.execute('''
+            {
+                __schema {
+                    defaultDirectives: directives {
+                        name
+                    }
+                    allDirectives: directives(includeDeprecated: true) {
+                        name
+                        isDeprecated
+                        deprecationReason
+                        locations
+                    }
+                }
+            }
+        ''')
+
+        then:
+        result.errors.empty
+        !result.data.__schema.defaultDirectives*.name.contains("old")
+        result.data.__schema.defaultDirectives*.name.contains("active")
+
+        and:
+        def old = result.data.__schema.allDirectives.find { it.name == "old" }
+        old.isDeprecated
+        old.deprecationReason == "Use @active"
+        def deprecated = result.data.__schema.allDirectives.find { it.name == "deprecated" }
+        deprecated.locations.contains("DIRECTIVE_DEFINITION")
+    }
+
+    def "the standard introspection query requests deprecated directives"() {
+        expect:
+        IntrospectionQuery.INTROSPECTION_QUERY.contains("directives(includeDeprecated: true)")
+        IntrospectionQuery.INTROSPECTION_QUERY.contains("isDeprecated")
+        IntrospectionQuery.INTROSPECTION_QUERY.contains("deprecationReason")
+
+        and:
+        !IntrospectionQueryBuilder.build(
+                IntrospectionQueryBuilder.Options.defaultOptions().directiveDeprecation(false)
+        ).contains("directives(includeDeprecated: true)")
+    }
+
+    def "introspection results recreate directive deprecation"() {
+        given:
+        def graphQL = TestUtil.graphQL('''
+            directive @old @deprecated(reason: "Use something else") on FIELD_DEFINITION
+            type Query {
+                field: String
+            }
+        ''').build()
+        def result = graphQL.execute(IntrospectionQuery.INTROSPECTION_QUERY)
+
+        when:
+        def document = new IntrospectionResultToSchema().createSchemaDefinition(result)
+        DirectiveDefinition old = document.definitions.find {
+            it instanceof DirectiveDefinition && it.name == "old"
+        }
+
+        then:
+        old.directives*.name == ["deprecated"]
+        AstPrinter.printAstCompact(old).contains('@deprecated(reason:"Use something else")')
+    }
+}

--- a/src/test/groovy/graphql/introspection/DirectiveDeprecationIntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/DirectiveDeprecationIntrospectionTest.groovy
@@ -26,6 +26,7 @@ class DirectiveDeprecationIntrospectionTest extends Specification {
                     }
                     allDirectives: directives(includeDeprecated: true) {
                         name
+                        description
                         isDeprecated
                         deprecationReason
                         locations
@@ -44,6 +45,7 @@ class DirectiveDeprecationIntrospectionTest extends Specification {
         old.isDeprecated
         old.deprecationReason == "Use @active"
         def deprecated = result.data.__schema.allDirectives.find { it.name == "deprecated" }
+        deprecated.description == "Marks an element of a GraphQL schema as no longer supported."
         deprecated.locations.contains("DIRECTIVE_DEFINITION")
     }
 

--- a/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionTest.groovy
@@ -97,10 +97,10 @@ class IntrospectionTest extends Specification {
     }
 
     @See("https://spec.graphql.org/October2021/#sec-Schema-Introspection.Schema-Introspection-Schema")
-    def "Introspection#__DirectiveLocation(GraphQLEnumType) should have 19 distinct values"() {
+    def "Introspection#__DirectiveLocation(GraphQLEnumType) should have 20 distinct values"() {
         given:
         def directiveLocationValues = Introspection.__DirectiveLocation.values
-        def numValues = 19
+        def numValues = 20
 
         expect:
         directiveLocationValues.size() == numValues
@@ -500,7 +500,7 @@ class IntrospectionTest extends Specification {
                 "      types {\n" +
                 "        ...FullType\n" +
                 "      }\n" +
-                "      directives {\n" +
+                "      directives(includeDeprecated: true) {\n" +
                 "        name\n" +
                 "        description\n" +
                 "        locations\n" +
@@ -508,6 +508,8 @@ class IntrospectionTest extends Specification {
                 "          ...InputValue\n" +
                 "        }\n" +
                 "        isRepeatable\n" +
+                "        isDeprecated\n" +
+                "        deprecationReason\n" +
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +

--- a/src/test/groovy/graphql/introspection/IntrospectionWithDirectivesSupportTest.groovy
+++ b/src/test/groovy/graphql/introspection/IntrospectionWithDirectivesSupportTest.groovy
@@ -179,6 +179,56 @@ class IntrospectionWithDirectivesSupportTest extends Specification {
         ]
     }
 
+    def "can find directives applied to directive definitions in introspection"() {
+        def sdl = '''
+            directive @meta(argName: String = "default") on DIRECTIVE_DEFINITION
+            directive @active on FIELD_DEFINITION
+            directive @old @deprecated on FIELD_DEFINITION
+            directive @target @meta(argName: "onDirective") on FIELD_DEFINITION
+
+            type Query {
+                hello: String
+            }
+        '''
+
+        def schema = TestUtil.schema(sdl)
+        schema = new IntrospectionWithDirectivesSupport().apply(schema)
+        def graphql = GraphQL.newGraphQL(schema).build()
+
+        def query = '''
+        {
+            __schema {
+                defaultDirectives: directives {
+                    name
+                }
+                allDirectives: directives(includeDeprecated: true) {
+                    name
+                    appliedDirectives {
+                        name
+                        args {
+                            name
+                            value
+                        }
+                    }
+                }
+            }
+        }
+        '''
+
+        when:
+        def er = graphql.execute(query)
+
+        then:
+        er.errors.isEmpty()
+        !er.data["__schema"]["defaultDirectives"]*.name.contains("old")
+        er.data["__schema"]["defaultDirectives"]*.name.contains("target")
+
+        def allDirectives = er.data["__schema"]["allDirectives"]
+        allDirectives*.name.contains("old")
+        def target = allDirectives.find { directive -> directive["name"] == "target" }
+        target["appliedDirectives"] == [[name: "meta", args: [[name: "argName", value: '"onDirective"']]]]
+    }
+
     def "can set prefixes onto the Applied types"() {
         def sdl = '''
             type Query {

--- a/src/test/groovy/graphql/language/DirectiveDefinitionDirectivesTest.groovy
+++ b/src/test/groovy/graphql/language/DirectiveDefinitionDirectivesTest.groovy
@@ -1,0 +1,99 @@
+package graphql.language
+
+import graphql.parser.Parser
+import spock.lang.Specification
+
+class DirectiveDefinitionDirectivesTest extends Specification {
+
+    def "parses and prints directives on directive definitions and extensions"() {
+        given:
+        def document = new Parser().parseDocument('''
+            directive @tag(value: String) repeatable on DIRECTIVE_DEFINITION
+            directive @target(arg: String) @tag(value: "definition") repeatable on FIELD_DEFINITION
+            extend directive @target @tag(value: "extension")
+        ''')
+
+        when:
+        DirectiveDefinition definition = document.definitions[1]
+        DirectiveExtensionDefinition extension = document.definitions[2]
+
+        then:
+        definition.directives*.name == ["tag"]
+        definition.isRepeatable()
+        extension.directives*.name == ["tag"]
+        AstPrinter.printAstCompact(definition) ==
+                'directive @target(arg:String) @tag(value:"definition") repeatable on FIELD_DEFINITION'
+        AstPrinter.printAstCompact(extension) ==
+                'extend directive @target @tag(value:"extension")'
+    }
+
+    def "deep copy transform and child replacement preserve directive order"() {
+        given:
+        def first = Directive.newDirective().name("first").build()
+        def second = Directive.newDirective().name("second").build()
+        def definition = DirectiveDefinition.newDirectiveDefinition()
+                .name("target")
+                .directive(first)
+                .directive(second)
+                .directiveLocation(DirectiveLocation.newDirectiveLocation().name("FIELD_DEFINITION").build())
+                .build()
+
+        expect:
+        definition.deepCopy().directives*.name == ["first", "second"]
+        definition.transform { it.directives([second, first]) }.directives*.name == ["second", "first"]
+
+        when:
+        def children = NodeChildrenContainer.newNodeChildrenContainer()
+                .children(DirectiveDefinition.CHILD_INPUT_VALUE_DEFINITIONS, definition.inputValueDefinitions)
+                .children(DirectiveDefinition.CHILD_DIRECTIVES, [second, first])
+                .children(DirectiveDefinition.CHILD_DIRECTIVE_LOCATION, definition.directiveLocations)
+                .build()
+
+        then:
+        definition.withNewChildren(children).directives*.name == ["second", "first"]
+    }
+
+    def "directive extension transforms without becoming a base definition"() {
+        given:
+        def extension = DirectiveExtensionDefinition.newDirectiveExtensionDefinition()
+                .name("target")
+                .directive(Directive.newDirective().name("first").build())
+                .build()
+
+        when:
+        def transformed = extension.transformExtension {
+            it.directive(Directive.newDirective().name("second").build())
+        }
+
+        then:
+        transformed instanceof SDLExtensionDefinition
+        transformed.directives*.name == ["first", "second"]
+        transformed.deepCopy() instanceof DirectiveExtensionDefinition
+    }
+
+    def "pretty printer separates applied directives from arguments"() {
+        expect:
+        PrettyAstPrinter.print(
+                'directive @target(arg: String) @tag repeatable on FIELD_DEFINITION',
+                PrettyAstPrinter.PrettyPrinterOptions.defaultOptions
+        ).trim() == 'directive @target(arg: String) @tag repeatable on FIELD_DEFINITION'
+
+        and:
+        PrettyAstPrinter.print(
+                'extend directive @target @z @a',
+                PrettyAstPrinter.PrettyPrinterOptions.defaultOptions
+        ).trim() == 'extend directive @target @z @a'
+    }
+
+    def "AST sorter sorts directives on directive extensions"() {
+        given:
+        def document = new Parser().parseDocument('extend directive @target @z @a')
+
+        when:
+        def sorted = new AstSorter().sort(document)
+        DirectiveExtensionDefinition extension = sorted.definitions[0]
+
+        then:
+        extension.directives*.name == ["a", "z"]
+    }
+}

--- a/src/test/groovy/graphql/schema/FastBuilderTest.groovy
+++ b/src/test/groovy/graphql/schema/FastBuilderTest.groovy
@@ -2368,4 +2368,64 @@ class FastBuilderTest extends Specification {
         !(resolvedApplied.getArgument("color").type instanceof GraphQLTypeReference)
         resolvedApplied.getArgument("color").type == colorEnum
     }
+
+    def "applied directive on directive definition with type-ref enum arg resolves correctly"() {
+        given: "a Color enum type used as the applied directive argument type"
+        def colorEnum = newEnum()
+                .name("Color")
+                .value("RED")
+                .value("GREEN")
+                .build()
+
+        and: "a directive definition that can be applied to directive definitions"
+        def metaDirective = newDirective()
+                .name("meta")
+                .validLocation(Introspection.DirectiveLocation.DIRECTIVE_DEFINITION)
+                .argument(newArgument()
+                        .name("color")
+                        .type(typeRef("Color")))
+                .build()
+
+        and: "an applied directive on another directive definition with an unresolved type ref"
+        def appliedMeta = newAppliedDirective()
+                .name("meta")
+                .argument(newAppliedArgument()
+                        .name("color")
+                        .type(typeRef("Color"))
+                        .valueLiteral(new EnumValue("GREEN"))
+                        .build())
+                .build()
+
+        and: "a directive definition with the applied directive"
+        def targetDirective = newDirective()
+                .name("target")
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION)
+                .withAppliedDirective(appliedMeta)
+                .build()
+
+        and: "a query type"
+        def queryType = newObject()
+                .name("Query")
+                .field(newFieldDefinition()
+                        .name("field")
+                        .type(GraphQLString))
+                .build()
+
+        when: "building with FastBuilder and validation enabled"
+        def schema = new GraphQLSchema.FastBuilder(
+                GraphQLCodeRegistry.newCodeRegistry(), queryType, null, null)
+                .addType(colorEnum)
+                .additionalDirective(metaDirective)
+                .additionalDirective(targetDirective)
+                .withValidation(true)
+                .build()
+
+        then: "schema builds successfully and the applied directive arg type is resolved"
+        schema != null
+        def resolvedTarget = schema.getDirective("target")
+        def resolvedApplied = resolvedTarget.getAppliedDirective("meta")
+        resolvedApplied != null
+        !(resolvedApplied.getArgument("color").type instanceof GraphQLTypeReference)
+        resolvedApplied.getArgument("color").type == colorEnum
+    }
 }

--- a/src/test/groovy/graphql/schema/FastBuilderTest.groovy
+++ b/src/test/groovy/graphql/schema/FastBuilderTest.groovy
@@ -2428,4 +2428,94 @@ class FastBuilderTest extends Specification {
         !(resolvedApplied.getArgument("color").type instanceof GraphQLTypeReference)
         resolvedApplied.getArgument("color").type == colorEnum
     }
+
+    def "legacy directive on directive definition with type-ref enum arg resolves correctly"() {
+        given: "a Color enum type used as the legacy directive argument type"
+        def colorEnum = newEnum()
+                .name("Color")
+                .value("RED")
+                .value("GREEN")
+                .build()
+
+        and: "a legacy directive on another directive definition with an unresolved type ref"
+        def legacyMeta = newDirective()
+                .name("meta")
+                .validLocation(Introspection.DirectiveLocation.DIRECTIVE_DEFINITION)
+                .argument(newArgument()
+                        .name("color")
+                        .type(typeRef("Color"))
+                        .valueLiteral(new EnumValue("GREEN")))
+                .build()
+
+        and: "a directive definition with the legacy directive"
+        def targetDirective = newDirective()
+                .name("target")
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION)
+                .withDirective(legacyMeta)
+                .build()
+
+        and: "a query type"
+        def queryType = newObject()
+                .name("Query")
+                .field(newFieldDefinition()
+                        .name("field")
+                        .type(GraphQLString))
+                .build()
+
+        when: "building with FastBuilder"
+        def schema = new GraphQLSchema.FastBuilder(
+                GraphQLCodeRegistry.newCodeRegistry(), queryType, null, null)
+                .addType(colorEnum)
+                .additionalDirective(targetDirective)
+                .build()
+
+        then: "schema builds successfully and the legacy directive arg type is resolved"
+        schema != null
+        def resolvedTarget = schema.getDirective("target")
+        def resolvedLegacy = resolvedTarget.getDirective("meta")
+        resolvedLegacy != null
+        !(resolvedLegacy.getArgument("color").type instanceof GraphQLTypeReference)
+        resolvedLegacy.getArgument("color").type == colorEnum
+    }
+
+    def "legacy directive on object type with type-ref enum arg resolves correctly"() {
+        given: "a Color enum type used as the legacy directive argument type"
+        def colorEnum = newEnum()
+                .name("Color")
+                .value("RED")
+                .value("GREEN")
+                .build()
+
+        and: "a legacy directive on an object type with an unresolved type ref"
+        def legacyMeta = newDirective()
+                .name("meta")
+                .validLocation(Introspection.DirectiveLocation.OBJECT)
+                .argument(newArgument()
+                        .name("color")
+                        .type(typeRef("Color"))
+                        .valueLiteral(new EnumValue("GREEN")))
+                .build()
+
+        and: "a query type with the legacy directive"
+        def queryType = newObject()
+                .name("Query")
+                .withDirective(legacyMeta)
+                .field(newFieldDefinition()
+                        .name("field")
+                        .type(GraphQLString))
+                .build()
+
+        when: "building with FastBuilder"
+        def schema = new GraphQLSchema.FastBuilder(
+                GraphQLCodeRegistry.newCodeRegistry(), queryType, null, null)
+                .addType(colorEnum)
+                .build()
+
+        then: "schema builds successfully and the legacy directive arg type is resolved"
+        schema != null
+        def resolvedLegacy = schema.queryType.getDirective("meta")
+        resolvedLegacy != null
+        !(resolvedLegacy.getArgument("color").type instanceof GraphQLTypeReference)
+        resolvedLegacy.getArgument("color").type == colorEnum
+    }
 }

--- a/src/test/groovy/graphql/schema/diffing/SchemaDiffingTest.groovy
+++ b/src/test/groovy/graphql/schema/diffing/SchemaDiffingTest.groovy
@@ -30,18 +30,18 @@ class SchemaDiffingTest extends Specification {
         schemaGraph.getVerticesByType(SchemaGraph.SCHEMA).size() == 1
         schemaGraph.getVerticesByType(SchemaGraph.OBJECT).size() == 7
         schemaGraph.getVerticesByType(SchemaGraph.ENUM).size() == 2
-        schemaGraph.getVerticesByType(SchemaGraph.ENUM_VALUE).size() == 27
+        schemaGraph.getVerticesByType(SchemaGraph.ENUM_VALUE).size() == 28
         schemaGraph.getVerticesByType(SchemaGraph.INTERFACE).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.UNION).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.SCALAR).size() == 2
-        schemaGraph.getVerticesByType(SchemaGraph.FIELD).size() == 40
-        schemaGraph.getVerticesByType(SchemaGraph.ARGUMENT).size() == 11
+        schemaGraph.getVerticesByType(SchemaGraph.FIELD).size() == 42
+        schemaGraph.getVerticesByType(SchemaGraph.ARGUMENT).size() == 12
         schemaGraph.getVerticesByType(SchemaGraph.INPUT_FIELD).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.INPUT_OBJECT).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.DIRECTIVE).size() == 7
         schemaGraph.getVerticesByType(SchemaGraph.APPLIED_ARGUMENT).size() == 0
         schemaGraph.getVerticesByType(SchemaGraph.APPLIED_DIRECTIVE).size() == 0
-        schemaGraph.size() == 97
+        schemaGraph.size() == 101
 
     }
 
@@ -1592,5 +1592,3 @@ class SchemaDiffingTest extends Specification {
     }
 
 }
-
-

--- a/src/test/groovy/graphql/schema/diffing/ana/EditOperationAnalyzerAppliedDirectivesTest.groovy
+++ b/src/test/groovy/graphql/schema/diffing/ana/EditOperationAnalyzerAppliedDirectivesTest.groovy
@@ -10,6 +10,7 @@ import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveArgume
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveArgumentRename
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveArgumentValueModification
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveDeletion
+import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveDirectiveLocation
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveDirectiveArgumentLocation
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveEnumLocation
 import static graphql.schema.diffing.ana.SchemaDifference.AppliedDirectiveEnumValueLocation
@@ -479,6 +480,143 @@ class EditOperationAnalyzerAppliedDirectivesTest extends Specification {
         detail[0].argumentName == "arg1"
         detail[0].oldValue == '"foo"'
         detail[0].newValue == '"bar"'
+    }
+
+    def "applied directive added directive definition"() {
+        given:
+        def oldSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        def newSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 @d(arg: "foo") on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        when:
+        def changes = calcDiff(oldSdl, newSdl)
+        then:
+        changes.directiveDifferences["d2"] instanceof DirectiveModification
+        def appliedDirective = (changes.directiveDifferences["d2"] as DirectiveModification).getDetails(AppliedDirectiveAddition)
+        def location = appliedDirective[0].locationDetail as AppliedDirectiveDirectiveLocation
+        location.directiveDefinitionName == "d2"
+        location.directiveName == "d"
+        appliedDirective[0].name == "d"
+    }
+
+    def "applied directive deleted directive definition"() {
+        given:
+        def oldSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 @d(arg: "foo") on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        def newSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        when:
+        def changes = calcDiff(oldSdl, newSdl)
+        then:
+        changes.directiveDifferences["d2"] instanceof DirectiveModification
+        def appliedDirective = (changes.directiveDifferences["d2"] as DirectiveModification).getDetails(AppliedDirectiveDeletion)
+        def location = appliedDirective[0].locationDetail as AppliedDirectiveDirectiveLocation
+        location.directiveDefinitionName == "d2"
+        location.directiveName == "d"
+        appliedDirective[0].name == "d"
+    }
+
+    def "applied directive argument value changed directive definition"() {
+        given:
+        def oldSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 @d(arg: "foo") on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        def newSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 @d(arg: "bar") on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        when:
+        def changes = calcDiff(oldSdl, newSdl)
+        then:
+        changes.directiveDifferences["d2"] instanceof DirectiveModification
+        def detail = (changes.directiveDifferences["d2"] as DirectiveModification).getDetails(AppliedDirectiveArgumentValueModification)
+        def location = detail[0].locationDetail as AppliedDirectiveDirectiveLocation
+        location.directiveDefinitionName == "d2"
+        location.directiveName == "d"
+        detail[0].argumentName == "arg"
+        detail[0].oldValue == '"foo"'
+        detail[0].newValue == '"bar"'
+    }
+
+    def "applied directive argument added directive definition"() {
+        given:
+        def oldSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 @d on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        def newSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 @d(arg: "foo") on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        when:
+        def changes = calcDiff(oldSdl, newSdl)
+        then:
+        changes.directiveDifferences["d2"] instanceof DirectiveModification
+        def appliedDirectiveArgumentAddition = (changes.directiveDifferences["d2"] as DirectiveModification).getDetails(AppliedDirectiveArgumentAddition)
+        def location = appliedDirectiveArgumentAddition[0].locationDetail as AppliedDirectiveDirectiveLocation
+        location.directiveDefinitionName == "d2"
+        location.directiveName == "d"
+        appliedDirectiveArgumentAddition[0].argumentName == "arg"
+    }
+
+    def "applied directive argument deleted directive definition"() {
+        given:
+        def oldSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 @d(arg: "foo") on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        def newSdl = '''
+        directive @d(arg:String) on DIRECTIVE_DEFINITION
+        directive @d2 @d on FIELD_DEFINITION
+        type Query {
+            foo: String
+        }
+        '''
+        when:
+        def changes = calcDiff(oldSdl, newSdl)
+        then:
+        changes.directiveDifferences["d2"] instanceof DirectiveModification
+        def appliedDirectiveArgumentDeletion = (changes.directiveDifferences["d2"] as DirectiveModification).getDetails(AppliedDirectiveArgumentDeletion)
+        def location = appliedDirectiveArgumentDeletion[0].locationDetail as AppliedDirectiveDirectiveLocation
+        location.directiveDefinitionName == "d2"
+        location.directiveName == "d"
+        appliedDirectiveArgumentDeletion[0].argumentName == "arg"
     }
 
 

--- a/src/test/groovy/graphql/schema/idl/DirectivesOnDirectiveDefinitionsTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/DirectivesOnDirectiveDefinitionsTest.groovy
@@ -1,0 +1,240 @@
+package graphql.schema.idl
+
+import graphql.TestUtil
+import graphql.introspection.Introspection
+import graphql.language.DirectiveExtensionDefinition
+import graphql.language.StringValue
+import graphql.schema.GraphQLAppliedDirective
+import graphql.schema.GraphQLDirective
+import graphql.schema.idl.errors.DirectiveExtensionDirectiveRedefinitionError
+import graphql.schema.idl.errors.DirectiveExtensionMissingBaseError
+import graphql.schema.idl.errors.DirectiveIllegalLocationError
+import graphql.schema.idl.errors.DirectiveIllegalReferenceError
+import graphql.schema.idl.errors.DirectiveUndeclaredError
+import graphql.schema.idl.errors.SchemaProblem
+import spock.lang.Specification
+
+class DirectivesOnDirectiveDefinitionsTest extends Specification {
+
+    def "registry stores merges exposes and removes directive extensions"() {
+        given:
+        def baseRegistry = new SchemaParser().parse('''
+            directive @meta repeatable on DIRECTIVE_DEFINITION
+            directive @target on FIELD_DEFINITION
+        ''')
+        def extensionRegistry = new SchemaParser().parse('''
+            extend directive @target @meta
+            extend directive @target @meta
+        ''')
+
+        when:
+        baseRegistry.merge(extensionRegistry)
+        def extensions = baseRegistry.directiveExtensions()["target"]
+        def secondExtension = extensions[1]
+
+        then:
+        extensions.size() == 2
+        baseRegistry.readOnly().directiveExtensions()["target"] == extensions
+        baseRegistry.parseOrder.inOrder[""].findAll { it instanceof DirectiveExtensionDefinition }.size() == 2
+
+        when:
+        baseRegistry.remove(extensions[0])
+
+        then:
+        baseRegistry.directiveExtensions()["target"].size() == 1
+
+        when:
+        baseRegistry.remove(secondExtension)
+        baseRegistry.remove(secondExtension)
+
+        then:
+        !baseRegistry.directiveExtensions().containsKey("target")
+
+        when:
+        baseRegistry.add(secondExtension)
+        baseRegistry.remove("target", secondExtension)
+
+        then:
+        !baseRegistry.directiveExtensions().containsKey("target")
+    }
+
+    def "schema generation combines definition and extension directives in order"() {
+        given:
+        def schema = TestUtil.schema('''
+            directive @meta(value: String!) repeatable on DIRECTIVE_DEFINITION
+            directive @target @meta(value: "definition") on FIELD_DEFINITION
+            extend directive @target @meta(value: "first extension")
+            extend directive @target @meta(value: "second extension")
+
+            type Query {
+                field: String
+            }
+        ''')
+
+        when:
+        def target = schema.getDirective("target")
+
+        then:
+        target.appliedDirectives*.name == ["meta", "meta", "meta"]
+        target.getAppliedDirectives("meta")*.getArgument("value")*.argumentValue*.value*.value ==
+                ["definition", "first extension", "second extension"]
+        target.definition.directives*.name == ["meta"]
+        target.extensionDefinitions.size() == 2
+
+        and:
+        new SchemaPrinter().print(target) ==
+                'directive @target @meta(value : "definition") @meta(value : "first extension") @meta(value : "second extension") on FIELD_DEFINITION'
+    }
+
+    def "programmatic directive definitions are applied-directive containers and can be deprecated"() {
+        given:
+        def applied = GraphQLAppliedDirective.newDirective().name("meta").build()
+        def extension = DirectiveExtensionDefinition.newDirectiveExtensionDefinition().name("target").build()
+        def legacy = GraphQLDirective.newDirective()
+                .name("legacy")
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION)
+                .build()
+        def legacyBuilder = GraphQLDirective.newDirective()
+                .name("legacyBuilder")
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION)
+        def appliedBuilder = GraphQLAppliedDirective.newDirective().name("metaBuilder")
+
+        when:
+        def directive = GraphQLDirective.newDirective()
+                .name("target")
+                .validLocation(Introspection.DirectiveLocation.FIELD_DEFINITION)
+                .withDirectives(legacy)
+                .withDirective(legacyBuilder)
+                .withAppliedDirectives(applied)
+                .withAppliedDirective(appliedBuilder)
+                .extensionDefinitions([extension])
+                .deprecate("Use @replacement")
+                .build()
+
+        then:
+        directive.hasAppliedDirective("meta")
+        directive.getAppliedDirective("metaBuilder")
+        directive.directivesByName.keySet() == ["legacy", "legacyBuilder"] as Set
+        directive.getDirective("legacyBuilder")
+        directive.isDeprecated()
+        directive.deprecationReason == "Use @replacement"
+        directive.extensionDefinitions == [extension]
+        directive.copy().appliedDirectives*.name == ["meta", "metaBuilder"]
+        new SchemaPrinter().print(directive).contains('@deprecated(reason : "Use @replacement")')
+        directive.transform { it.clearDirectives() }.appliedDirectives.empty
+    }
+
+    def "deprecated is valid on directive definitions and uses the default reason"() {
+        given:
+        def schema = TestUtil.schema('''
+            directive @old @deprecated on FIELD_DEFINITION
+            type Query {
+                field: String
+            }
+        ''')
+
+        expect:
+        schema.getDirective("old").deprecated
+        schema.getDirective("old").deprecationReason == "No longer supported"
+        graphql.Directives.DeprecatedDirective.validLocations()
+                .contains(Introspection.DirectiveLocation.DIRECTIVE_DEFINITION)
+    }
+
+    def "repeatable directives may be applied across a definition and extensions"() {
+        expect:
+        TestUtil.schema('''
+            directive @meta repeatable on DIRECTIVE_DEFINITION
+            directive @target @meta on FIELD_DEFINITION
+            extend directive @target @meta
+            extend directive @target @meta
+            type Query {
+                field: String
+            }
+        ''').getDirective("target").getAppliedDirectives("meta").size() == 3
+    }
+
+    def "invalid directive definition applications are rejected - #name"() {
+        when:
+        schema(sdl)
+
+        then:
+        def problem = thrown(SchemaProblem)
+        problem.errors.any { errorType.isInstance(it) }
+
+        where:
+        name                         | errorType                                     | sdl
+        "unknown directive"          | DirectiveUndeclaredError                      | '''
+            directive @target @unknown on FIELD_DEFINITION
+            type Query { field: String }
+        '''
+        "illegal location"           | DirectiveIllegalLocationError                 | '''
+            directive @meta on OBJECT
+            directive @target @meta on FIELD_DEFINITION
+            type Query { field: String }
+        '''
+        "extension without base"     | DirectiveExtensionMissingBaseError            | '''
+            directive @meta on DIRECTIVE_DEFINITION
+            extend directive @missing @meta
+            type Query { field: String }
+        '''
+        "non-repeatable application" | DirectiveExtensionDirectiveRedefinitionError  | '''
+            directive @meta on DIRECTIVE_DEFINITION
+            directive @target @meta on FIELD_DEFINITION
+            extend directive @target @meta
+            type Query { field: String }
+        '''
+    }
+
+    def "directive reference cycles are rejected - #name"() {
+        when:
+        schema(sdl)
+
+        then:
+        def problem = thrown(SchemaProblem)
+        problem.errors.any { it instanceof DirectiveIllegalReferenceError }
+        problem.errors.find { it instanceof DirectiveIllegalReferenceError }.message.contains(expectedPath)
+
+        where:
+        name                    | expectedPath        | sdl
+        "direct self cycle"     | "'self'"            | '''
+            directive @self @self on DIRECTIVE_DEFINITION
+            type Query { field: String }
+        '''
+        "definition cycle"      | "a -> b -> a"       | '''
+            directive @a @b on DIRECTIVE_DEFINITION
+            directive @b @a on DIRECTIVE_DEFINITION
+            type Query { field: String }
+        '''
+        "extension cycle"       | "a -> b -> a"       | '''
+            directive @a on DIRECTIVE_DEFINITION
+            directive @b on DIRECTIVE_DEFINITION
+            extend directive @a @b
+            extend directive @b @a
+            type Query { field: String }
+        '''
+        "input type cycle"      | "loop -> LoopInput" | '''
+            directive @loop(arg: LoopInput) on INPUT_FIELD_DEFINITION
+            input LoopInput {
+                field: String @loop
+            }
+            type Query { field: String }
+        '''
+        "type-led cycle"        | "b -> YInput -> XInput -> b" | '''
+            directive @a(arg: XInput) on FIELD_DEFINITION
+            directive @b(arg: YInput) on INPUT_OBJECT
+            input XInput @b {
+                field: String
+            }
+            input YInput {
+                nested: XInput
+            }
+            type Query { field: String }
+        '''
+    }
+
+    private static void schema(String sdl) {
+        def registry = new SchemaParser().parse(sdl)
+        def wiring = RuntimeWiring.newRuntimeWiring().build()
+        new SchemaGenerator().makeExecutableSchema(registry, wiring)
+    }
+}

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -974,7 +974,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -1161,7 +1161,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -1268,7 +1268,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -1347,7 +1347,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -1455,7 +1455,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -1552,7 +1552,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -1703,7 +1703,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -1948,7 +1948,7 @@ type Query {
         def result = new SchemaPrinter(printOptions).print(schema)
 
         then:
-        result == '''"Marks the field, argument, input field or enum value as deprecated"
+        result == '''"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -2250,7 +2250,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -2488,7 +2488,7 @@ directive @include(
 "This directive disables error propagation when a non nullable field returns null for the given operation."
 directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -2620,7 +2620,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -2868,7 +2868,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
@@ -3067,7 +3067,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"

--- a/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaPrinterTest.groovy
@@ -978,7 +978,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 directive @enumTypeDirective on ENUM
 
@@ -1165,7 +1165,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 "This directive disables error propagation when a non nullable field returns null for the given operation."
 directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
@@ -1272,7 +1272,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 directive @example on FIELD_DEFINITION
 
@@ -1351,7 +1351,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 directive @example on FIELD_DEFINITION
 
@@ -1459,7 +1459,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 "This directive disables error propagation when a non nullable field returns null for the given operation."
 directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
@@ -1556,7 +1556,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 "This directive disables error propagation when a non nullable field returns null for the given operation."
 directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
@@ -1707,7 +1707,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 directive @directive1 on SCALAR
 
@@ -1952,7 +1952,7 @@ type Query {
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 type Query {
   fieldX: String @deprecated(reason : "No longer supported")
@@ -2254,7 +2254,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 "This directive disables error propagation when a non nullable field returns null for the given operation."
 directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
@@ -2492,7 +2492,7 @@ directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTI
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 "This directive allows results to be deferred during execution"
 directive @defer(
@@ -2624,7 +2624,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 " custom directive 'example' description 1"
 # custom directive 'example' comment 1
@@ -2872,7 +2872,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 " custom directive 'example' description 1"
 directive @example on ENUM_VALUE
@@ -3071,7 +3071,7 @@ directive @defer(
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 "This directive disables error propagation when a non nullable field returns null for the given operation."
 directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION

--- a/src/test/groovy/graphql/util/AnonymizerTest.groovy
+++ b/src/test/groovy/graphql/util/AnonymizerTest.groovy
@@ -753,7 +753,7 @@ directive @Directive1(argument1: String! = "stringValue4") repeatable on SCHEMA 
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"
-  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+  ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION | DIRECTIVE_DEFINITION
 
 interface Interface1 @Directive1(argument1 : "stringValue12") {
   field2: String

--- a/src/test/groovy/graphql/util/AnonymizerTest.groovy
+++ b/src/test/groovy/graphql/util/AnonymizerTest.groovy
@@ -749,7 +749,7 @@ type Object1 {
 
 directive @Directive1(argument1: String! = "stringValue4") repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"

--- a/src/test/resources/large-schema-1.graphqls
+++ b/src/test/resources/large-schema-1.graphqls
@@ -15,7 +15,7 @@ directive @skip(
     if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"

--- a/src/test/resources/large-schema-federated-2.graphqls
+++ b/src/test/resources/large-schema-federated-2.graphqls
@@ -6,7 +6,7 @@ directive @defer(
     label: String
   ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"

--- a/src/test/resources/many-fragments.graphqls
+++ b/src/test/resources/many-fragments.graphqls
@@ -25,7 +25,7 @@ directive @Directive8(argument7: Enum3!) on FIELD_DEFINITION
 
 directive @Directive9(argument8: String!) on OBJECT
 
-"Marks the field, argument, input field or enum value as deprecated"
+"Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
     "The reason for the deprecation"
     reason: String! = "No longer supported"


### PR DESCRIPTION
## Summary

- support applied directives and directive extensions across SDL parsing, AST handling, registries, schema generation, and printing
- expose directive deprecation and `DIRECTIVE_DEFINITION` through runtime schema APIs and introspection
- validate missing bases, non-repeatable applications, illegal locations, and direct/indirect reference cycles

Implements the merged specification change from graphql/graphql-spec#1206.

## Testing

- `JAVA_HOME=/home/andreas_marek/.jdks/jdk-25.0.2 ./gradlew test jacocoTestReport` (5,735 tests)
- `JAVA_HOME=/home/andreas_marek/.jdks/jdk-25.0.2 ./gradlew testng` (190 tests)
- `JAVA_HOME=/home/andreas_marek/.jdks/jdk-25.0.2 ./gradlew check -x test -x testng`
- local PR coverage-gate comparison: no per-class regressions