### PR TITLE
Backport to 26.1: Fix nullable bound on DataFetcherResult.newResult

### DIFF
--- a/src/main/java/graphql/execution/DataFetcherResult.java
+++ b/src/main/java/graphql/execution/DataFetcherResult.java
@@ -171,7 +171,7 @@ public class DataFetcherResult<T extends @Nullable Object> {
      *
      * @return a new builder
      */
-    public static <T> Builder<T> newResult() {
+    public static <T extends @Nullable Object> Builder<T> newResult() {
         return new Builder<>();
     }
 

--- a/src/test/kotlin/graphql/execution/DataFetcherResultKotlinInteropTest.kt
+++ b/src/test/kotlin/graphql/execution/DataFetcherResultKotlinInteropTest.kt
@@ -1,0 +1,9 @@
+package graphql.execution
+
+class DataFetcherResultKotlinInteropTest {
+    fun nullableNewResultFactoryCompiles(): DataFetcherResult<String?> {
+        return DataFetcherResult.newResult<String?>()
+            .data(null)
+            .build()
+    }
+}


### PR DESCRIPTION
Backport of #4418 to the `26.x` maintenance branch.

Summary:
- Adds the missing nullable generic bound to the zero-argument `DataFetcherResult.newResult()` factory method.
- Allows Kotlin callers under JSpecify null-marked semantics to use nullable result types.
- Adds a regression source for Kotlin nullable type interoperability.

Problem:
- `DataFetcherResult` and its `Builder` allow nullable type parameters.
- The zero-argument `newResult()` method declared an unbounded `T`.
- Kotlin therefore interpreted the factory method type parameter as non-null and rejected nullable types.

Testing:
- `./gradlew compileTestKotlin` failed before the Java change with `Type argument is not within its bounds` for `DataFetcherResult.newResult<String?>()`.
- `./gradlew compileTestKotlin` passed after the change.
- `./gradlew test --tests graphql.execution.DataFetcherResultTest` passed: 26 tests.
- `./gradlew check -x test -x testng` passed.
- `./gradlew javadoc` passed.
- `./gradlew testng` passed: 190 tests.
- `./gradlew test` was run locally on Windows and failed in unrelated `graphql.parser.MultiSourceReaderTest.can combine files`; the failure reproduces when that test is run alone and appears tied to local checkout line endings for `src/test/resources/multisource/a.txt` (`w/crlf`).

Issue:
Fixes #4364