### PR TITLE
Backport to 26.1: Fix covariance checks for SDL type extensions

### DIFF
--- a/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
+++ b/src/main/java/graphql/schema/idl/TypeDefinitionRegistry.java
@@ -37,9 +37,9 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static graphql.Assert.assertNotNull;
 import static graphql.schema.idl.SchemaExtensionsChecker.defineOperationDefs;
@@ -719,18 +719,7 @@ public class TypeDefinitionRegistry implements Serializable {
     public List<ImplementingTypeDefinition> getAllImplementationsOf(InterfaceTypeDefinition targetInterface) {
         return ImmutableKit.filter(
                 getTypes(ImplementingTypeDefinition.class),
-                implementingTypeDefinition -> {
-                    List<Type<?>> implementsList = implementingTypeDefinition.getImplements();
-                    for (Type iFace : implementsList) {
-                        InterfaceTypeDefinition interfaceTypeDef = getTypeOrNull(iFace, InterfaceTypeDefinition.class);
-                        if (interfaceTypeDef != null) {
-                            if (interfaceTypeDef.getName().equals(targetInterface.getName())) {
-                                return true;
-                            }
-                        }
-                    }
-                    return false;
-                });
+                implementingTypeDefinition -> implementsInterface(implementingTypeDefinition, targetInterface));
     }
 
     /**
@@ -765,37 +754,42 @@ public class TypeDefinitionRegistry implements Serializable {
         if (!isObjectTypeOrInterface(possibleType)) {
             return false;
         }
-        TypeDefinition targetObjectTypeDef = Objects.requireNonNull(getTypeOrNull(possibleType));
-        TypeDefinition abstractTypeDef = Objects.requireNonNull(getTypeOrNull(abstractType));
+        TypeDefinition possibleTypeDef = assertNotNull(getTypeOrNull(possibleType));
+        TypeDefinition abstractTypeDef = assertNotNull(getTypeOrNull(abstractType));
         if (abstractTypeDef instanceof UnionTypeDefinition) {
-            List<Type> memberTypes = ((UnionTypeDefinition) abstractTypeDef).getMemberTypes();
-            for (Type memberType : memberTypes) {
-                ObjectTypeDefinition checkType = getTypeOrNull(memberType, ObjectTypeDefinition.class);
-                if (checkType != null) {
-                    if (checkType.getName().equals(targetObjectTypeDef.getName())) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        } else {
-            InterfaceTypeDefinition iFace = (InterfaceTypeDefinition) abstractTypeDef;
-            for (TypeDefinition<?> t : types.values()) {
-                if (t instanceof ImplementingTypeDefinition) {
-                    if (t.getName().equals(targetObjectTypeDef.getName())) {
-                        ImplementingTypeDefinition<?> itd = (ImplementingTypeDefinition<?>) t;
-
-                        for (Type implementsType : itd.getImplements()) {
-                            TypeDefinition<?> matchingInterface = types.get(typeName(implementsType));
-                            if (matchingInterface != null && matchingInterface.getName().equals(iFace.getName())) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-            return false;
+            return isUnionMember((UnionTypeDefinition) abstractTypeDef, possibleTypeDef);
         }
+        return implementsInterface(
+                (ImplementingTypeDefinition<?>) possibleTypeDef,
+                (InterfaceTypeDefinition) abstractTypeDef);
+    }
+
+    private boolean implementsInterface(
+            ImplementingTypeDefinition<?> implementingType,
+            InterfaceTypeDefinition targetInterface) {
+        return Stream.concat(
+                        Stream.of(implementingType),
+                        getImplementingTypeExtensions(implementingType).stream())
+                .flatMap(type -> type.getImplements().stream())
+                .map(TypeInfo::typeName)
+                .anyMatch(targetInterface.getName()::equals);
+    }
+
+    private List<? extends ImplementingTypeDefinition<?>> getImplementingTypeExtensions(
+            ImplementingTypeDefinition<?> implementingType) {
+        if (implementingType instanceof InterfaceTypeDefinition) {
+            return interfaceTypeExtensions.getOrDefault(implementingType.getName(), List.of());
+        }
+        return objectTypeExtensions.getOrDefault(implementingType.getName(), List.of());
+    }
+
+    private boolean isUnionMember(UnionTypeDefinition unionType, TypeDefinition<?> possibleType) {
+        return Stream.concat(
+                        unionType.getMemberTypes().stream(),
+                        unionTypeExtensions.getOrDefault(unionType.getName(), List.of()).stream()
+                                .flatMap(extension -> extension.getMemberTypes().stream()))
+                .map(TypeInfo::typeName)
+                .anyMatch(possibleType.getName()::equals);
     }
 
     /**

--- a/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/SchemaTypeCheckerTest.groovy
@@ -1337,6 +1337,171 @@ class SchemaTypeCheckerTest extends Specification {
 
     }
 
+    def "covariant object type implemented through an extension is supported"() {
+        def spec = '''
+            type Query {
+              base: Base
+            }
+
+            interface Pet {
+              id: ID
+            }
+
+            type Dog {
+              id: ID
+            }
+
+            extend type Dog implements Pet
+
+            type Base {
+              foo: String
+            }
+
+            interface PetContainer {
+              pet: Pet
+            }
+
+            extend type Base implements PetContainer {
+              pet: Dog
+            }
+        '''
+
+        def result = check(spec, ["Pet", "PetContainer"])
+
+        expect:
+        result.isEmpty()
+    }
+
+    def "covariant interface type implemented through an extension is supported"() {
+        def spec = '''
+            type Query {
+              base: Base
+            }
+
+            interface Pet {
+              id: ID
+            }
+
+            interface WorkingPet {
+              id: ID
+            }
+
+            extend interface WorkingPet implements Pet
+
+            interface PetContainer {
+              pet: Pet
+            }
+
+            type Base implements PetContainer {
+              pet: WorkingPet
+            }
+        '''
+
+        def result = check(spec, ["Pet", "WorkingPet", "PetContainer"])
+
+        expect:
+        result.isEmpty()
+    }
+
+    def "covariant union member added through an extension is supported"() {
+        def spec = '''
+            type Query {
+              base: Base
+            }
+
+            type Cat {
+              id: ID
+            }
+
+            type Dog {
+              id: ID
+            }
+
+            union Pets = Cat
+
+            extend union Pets = Dog
+
+            interface PetContainer {
+              pet: Pets
+            }
+
+            type Base implements PetContainer {
+              pet: Dog
+            }
+        '''
+
+        def result = check(spec, ["Pets", "PetContainer"])
+
+        expect:
+        result.isEmpty()
+    }
+
+    def "wrapped covariant object type implemented through an extension is supported"() {
+        def spec = '''
+            type Query {
+              base: Base
+            }
+
+            interface Pet {
+              id: ID
+            }
+
+            type Dog {
+              id: ID
+            }
+
+            extend type Dog implements Pet
+
+            interface PetContainer {
+              pets: [Pet]!
+            }
+
+            type Base implements PetContainer {
+              pets: [Dog!]!
+            }
+        '''
+
+        def result = check(spec, ["Pet", "PetContainer"])
+
+        expect:
+        result.isEmpty()
+    }
+
+    def "unrelated type remains invalid when other interface relationships use extensions"() {
+        def spec = '''
+            type Query {
+              base: Base
+            }
+
+            interface Pet {
+              id: ID
+            }
+
+            interface Vehicle {
+              id: ID
+            }
+
+            type Car {
+              id: ID
+            }
+
+            extend type Car implements Vehicle
+
+            interface PetContainer {
+              pet: Pet
+            }
+
+            type Base implements PetContainer {
+              pet: Car
+            }
+        '''
+
+        def result = check(spec, ["Pet", "Vehicle", "PetContainer"])
+
+        expect:
+        errorContaining(result, "has tried to redefine field 'pet' defined via interface 'PetContainer'")
+    }
+
     def "deviant covariant object types are detected"() {
 
         def spec = '''

--- a/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
+++ b/src/test/groovy/graphql/schema/idl/TypeDefinitionRegistryTest.groovy
@@ -469,6 +469,87 @@ class TypeDefinitionRegistryTest extends Specification {
 
         '''
 
+    def extensionRelationships = '''
+            interface Pet {
+              id: ID
+            }
+
+            interface WorkingPet {
+              id: ID
+            }
+
+            extend interface WorkingPet implements Pet
+
+            type Dog {
+              id: ID
+            }
+
+            extend type Dog implements Pet
+
+            type Cat {
+              id: ID
+            }
+
+            union Pets = Cat
+
+            extend union Pets = Dog
+        '''
+
+    def "possible type detection includes interface implementations from extensions for #typeOfReg registry"() {
+        when:
+        def registry = registry(extensionRelationships, typeOfReg)
+
+        then:
+        registry.isPossibleType(type("Pet"), type("Dog"))
+        registry.isPossibleType(type("Pet"), type("WorkingPet"))
+        !registry.isPossibleType(type("Pet"), type("Cat"))
+
+        where:
+        typeOfReg << ["mutable", "immutable"]
+    }
+
+    def "possible type detection includes union members from extensions for #typeOfReg registry"() {
+        when:
+        def registry = registry(extensionRelationships, typeOfReg)
+
+        then:
+        registry.isPossibleType(type("Pets"), type("Cat"))
+        registry.isPossibleType(type("Pets"), type("Dog"))
+        !registry.isPossibleType(type("Pets"), type("WorkingPet"))
+
+        where:
+        typeOfReg << ["mutable", "immutable"]
+    }
+
+    def "subtype detection unwraps types implemented through extensions for #typeOfReg registry"() {
+        when:
+        def registry = registry(extensionRelationships, typeOfReg)
+
+        then:
+        registry.isSubTypeOf(nonNullType("Dog"), type("Pet"))
+        registry.isSubTypeOf(listType(type("Dog")), listType(type("Pet")))
+        registry.isSubTypeOf(
+                listType(nonNullType(listType(type("Dog")))),
+                listType(nonNullType(listType(type("Pet")))))
+        !registry.isSubTypeOf(type("Cat"), type("Pet"))
+
+        where:
+        typeOfReg << ["mutable", "immutable"]
+    }
+
+    def "implementation lookup includes relationships from extensions for #typeOfReg registry"() {
+        when:
+        def registry = registry(extensionRelationships, typeOfReg)
+        def pet = registry.getTypeOrNull("Pet", InterfaceTypeDefinition.class)
+
+        then:
+        registry.getAllImplementationsOf(pet)*.name == ["WorkingPet", "Dog"]
+        registry.getImplementationsOf(pet)*.name == ["Dog"]
+
+        where:
+        typeOfReg << ["mutable", "immutable"]
+    }
+
     def "test possible type detection #typeOfReg"() {
         given:
         TypeDefinitionRegistry mutableReg = parse(animalia)
@@ -504,6 +585,14 @@ class TypeDefinitionRegistryTest extends Specification {
         typeOfReg   | _
         "mutable"   | _
         "immutable" | _
+    }
+
+    private static TypeDefinitionRegistry registry(String spec, String typeOfRegistry) {
+        def registry = parse(spec)
+        if (typeOfRegistry == "immutable") {
+            return registry.readOnly()
+        }
+        return registry
     }
 
 


### PR DESCRIPTION
Backport of #4420 to the `26.x` maintenance branch.

## Problem

GraphQL Java incorrectly rejected valid covariant field return types when the subtype relationship was introduced by an SDL extension rather than declared on the base type.

### Object extension example

In this schema, `Dog` implements `Pet` through an extension. Returning `Dog` for a field declared as `Pet` is valid covariance:

```graphql
type Query {
  base: Base
}

interface Pet {
  id: ID
}

type Dog {
  id: ID
}

extend type Dog implements Pet

type Base {
  foo: String
}

interface PetContainer {
  pet: Pet
}

extend type Base implements PetContainer {
  pet: Dog
}
```

The schema was incorrectly rejected because the covariance check only inspected the base definition of `Dog` and did not see `extend type Dog implements Pet`.

### Interface extension example

The same problem affected interfaces inheriting from other interfaces through extensions:

```graphql
type Query {
  base: Base
}

interface Pet {
  id: ID
}

interface WorkingPet {
  id: ID
}

extend interface WorkingPet implements Pet

interface PetContainer {
  pet: Pet
}

type Base implements PetContainer {
  pet: WorkingPet
}
```

`WorkingPet` is a valid covariant return type for `Pet`, but the extension-based relationship was previously ignored.

### Union extension example

Union members introduced through extensions were also missed:

```graphql
type Query {
  base: Base
}

type Cat {
  id: ID
}

type Dog {
  id: ID
}

union Pets = Cat

extend union Pets = Dog

interface PetContainer {
  pet: Pets
}

type Base implements PetContainer {
  pet: Dog
}
```

`Dog` is a valid subtype of `Pets`, but the previous check only inspected members declared on the base union.

## Summary

`TypeDefinitionRegistry` stores base SDL definitions and extension definitions separately. This change makes the registry use the logical base-plus-extension relationships when:

- checking whether an object or interface is a possible type of an interface
- checking whether an object is a possible type of a union
- checking covariant field return types, including nested list and non-null wrappers
- finding object and interface implementations of an interface

This matches graphql-js behavior. graphql-js materializes extensions into its schema types before subtype checks; GraphQL Java retains separate AST definitions and now combines them when answering the equivalent registry queries.

## Wrapped covariance

The same relationship is preserved while recursively checking list and non-null wrappers:

```graphql
type Query {
  base: Base
}

interface Pet {
  id: ID
}

type Dog {
  id: ID
}

extend type Dog implements Pet

interface PetContainer {
  pets: [Pet]!
}

type Base implements PetContainer {
  pets: [Dog!]!
}
```

`[Dog!]!` remains a valid subtype of `[Pet]!`.

## Unrelated types remain invalid

Extension relationships are matched by their declared interface and do not make unrelated types compatible:

```graphql
type Query {
  base: Base
}

interface Pet {
  id: ID
}

interface Vehicle {
  id: ID
}

type Car {
  id: ID
}

extend type Car implements Vehicle

interface PetContainer {
  pet: Pet
}

type Base implements PetContainer {
  pet: Car
}
```

This schema is still rejected because `Car` implements `Vehicle`, not `Pet`.