### PR TITLE
Remove dependency annotations from shaded classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -379,6 +379,11 @@ def annotationsToRemoveFromShadedJar = [
         'Lcom/google/j2objc/annotations/Weak;',
         'Ljavax/annotation/meta/TypeQualifierNickname;',
 ] as Set<String>
+def graphqlJavaAnnotationDescriptorPrefix = 'Lgraphql/'
+def shadedDependencyAnnotationDescriptorPrefixes = [
+        'Lgraphql/com/google/',
+        'Lgraphql/org/antlr/',
+]
 
 /**
  * Expands the shaded JAR into a clean working directory and removes any
@@ -452,21 +457,26 @@ assemble.dependsOn buildNewJar
 
 /**
  * Scans every class in the completed published JAR with ASM and fails if any
- * configured annotation remains in a declaration or parameter invisible
- * annotation attribute. It also verifies that GraphQL Java's own
- * {@code graphql.Contract} annotation was preserved by the selective cleanup.
+ * configured annotation remains, or if an unknown external annotation appears,
+ * in a declaration or parameter invisible annotation attribute. GraphQL Java
+ * annotations are allowed, while annotations in relocated dependency namespaces
+ * are still considered external. The task also verifies that
+ * {@code graphql.Contract} was preserved by the selective cleanup.
  */
 tasks.register('verifyShadedClassAnnotations') {
     group = 'verification'
-    description = 'Verify selected invisible annotations are absent from the published jar'
+    description = 'Verify only GraphQL Java invisible annotations remain in the published jar'
     dependsOn buildNewJar
 
     def shadedJar = layout.buildDirectory.file("libs/graphql-java-${project.version}.jar")
     inputs.file(shadedJar)
     inputs.property('annotationsToRemove', annotationsToRemoveFromShadedJar.toList().sort())
+    inputs.property('graphqlJavaAnnotationPrefix', graphqlJavaAnnotationDescriptorPrefix)
+    inputs.property('shadedDependencyAnnotationPrefixes', shadedDependencyAnnotationDescriptorPrefixes)
 
     doLast {
-        def offendingAnnotations = []
+        def annotationsThatShouldHaveBeenRemoved = []
+        def unexpectedExternalAnnotations = []
         boolean graphqlContractFound = false
 
         new java.util.jar.JarFile(shadedJar.get().asFile).withCloseable { jarFile ->
@@ -480,7 +490,13 @@ tasks.register('verifyShadedClassAnnotations') {
                 invisibleAnnotationLists(classNode).each { annotations ->
                     annotations.each { annotation ->
                         if (annotationsToRemoveFromShadedJar.contains(annotation.desc)) {
-                            offendingAnnotations.add("${entry.name}: ${annotation.desc}")
+                            annotationsThatShouldHaveBeenRemoved.add("${entry.name}: ${annotation.desc}")
+                        } else {
+                            boolean isGraphQLJavaAnnotation = annotation.desc.startsWith(graphqlJavaAnnotationDescriptorPrefix) &&
+                                    !shadedDependencyAnnotationDescriptorPrefixes.any { annotation.desc.startsWith(it) }
+                            if (!isGraphQLJavaAnnotation) {
+                                unexpectedExternalAnnotations.add("${entry.name}: ${annotation.desc}")
+                            }
                         }
                         if (annotation.desc == 'Lgraphql/Contract;') {
                             graphqlContractFound = true
@@ -490,11 +506,18 @@ tasks.register('verifyShadedClassAnnotations') {
             }
         }
 
-        if (!offendingAnnotations.isEmpty()) {
-            throw new GradleException("Found annotations that should have been removed:\n${offendingAnnotations.join('\n')}")
+        def verificationErrors = []
+        if (!annotationsThatShouldHaveBeenRemoved.isEmpty()) {
+            verificationErrors.add("Found annotations that should have been removed:\n${annotationsThatShouldHaveBeenRemoved.join('\n')}")
+        }
+        if (!unexpectedExternalAnnotations.isEmpty()) {
+            verificationErrors.add("Found unexpected external invisible annotations; add them to annotationsToRemoveFromShadedJar:\n${unexpectedExternalAnnotations.join('\n')}")
         }
         if (!graphqlContractFound) {
-            throw new GradleException('graphql.Contract was removed from the shaded jar')
+            verificationErrors.add('graphql.Contract was removed from the shaded jar')
+        }
+        if (!verificationErrors.isEmpty()) {
+            throw new GradleException(verificationErrors.join('\n\n'))
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,9 @@ def guavaVersion = '32.1.2-jre'
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 group = 'com.graphql-java'
 
+def plainJarDir = layout.buildDirectory.dir('intermediates/plain-jar')
+def shadowJarDir = layout.buildDirectory.dir('intermediates/shadow-jar')
+
 gradle.buildFinished { buildResult ->
     println "*******************************"
     println "*"
@@ -199,6 +202,11 @@ repositories {
 }
 
 jar {
+    // The regular Java JAR is an input to the shading pipeline, not a
+    // publishable artifact. Keep it out of build/libs so it cannot be mistaken
+    // for the final GraphQL Java JAR.
+    archiveClassifier.set('plain')
+    destinationDirectory.set(plainJarDir)
     from "LICENSE.md"
     from "src/main/antlr/Graphql.g4"
     from "src/main/antlr/GraphqlOperation.g4"
@@ -207,6 +215,20 @@ jar {
     manifest {
         attributes('Automatic-Module-Name': 'com.graphqljava')
     }
+}
+
+shadow {
+    // GraphQL Java has additional post-processing after shadowJar. Do not let
+    // Shadow expose its intermediate artifact through the Java component or
+    // add it directly to assemble; buildFinalJar owns both responsibilities.
+    addShadowVariantIntoJavaComponent.set(false)
+    addShadowJarToAssembleLifecycle.set(false)
+
+    // The shadow runtime variant is disabled below because it would expose the
+    // uncleaned intermediate JAR. It therefore has no need for a target JVM
+    // attribute. Disabling this also prevents Shadow's afterEvaluate hook from
+    // trying to mutate that configuration after it has become non-consumable.
+    addTargetJvmVersionAttribute.set(false)
 }
 
 dependencies {
@@ -260,7 +282,10 @@ dependencies {
 
 shadowJar {
     minimize()
-    archiveClassifier.set('')
+    // This is deliberately an intermediate artifact. The only unclassified
+    // binary JAR is produced by buildFinalJar after cleanup.
+    archiveClassifier.set('shadow')
+    destinationDirectory.set(shadowJarDir)
     configurations = [project.configurations.compileClasspath]
     relocate('com.google.common', 'graphql.com.google.common') {
         include 'com.google.common.collect.*'
@@ -364,8 +389,8 @@ jmh {
 }
 
 
-def extractedShadowJarDir = layout.buildDirectory.dir("extract")
-def annotationCleanedShadowJarDir = layout.buildDirectory.dir("annotation-cleaned")
+def extractedShadowJarDir = layout.buildDirectory.dir('intermediates/shadow-jar-extracted')
+def annotationCleanedShadowJarDir = layout.buildDirectory.dir('intermediates/annotation-cleaned')
 
 // External CLASS-retention annotations referenced by shaded classes. Keep this
 // list explicit so GraphQL Java's own invisible annotations remain untouched.
@@ -432,30 +457,50 @@ tasks.register('cleanShadedClassAnnotations', Sync) {
 }
 
 /**
- * Reassembles the published GraphQL Java JAR from the annotation-cleaned
- * directory, retaining the manifest produced for the shaded JAR.
+ * Produces the sole unclassified GraphQL Java binary JAR directly from the
+ * annotation-cleaned directory, retaining the manifest produced by Bnd for
+ * the shaded JAR.
  *
- * The temporary archive is renamed over the normal project JAR so publication
- * continues to use the existing unclassified artifact name.
+ * The regular jar and shadowJar tasks write explicitly named intermediates to
+ * build/intermediates. This task alone owns the final build/libs path so Gradle
+ * can accurately track it and no earlier pipeline stage can overwrite it.
  */
-task buildNewJar(type: Jar) {
+def buildFinalJar = tasks.register('buildFinalJar', Jar) {
+    group = 'build'
     description = 'Build the published jar from cleaned shaded class files'
-    from annotationCleanedShadowJarDir
-    archiveFileName = "graphql-java-tmp.jar"
-    destinationDirectory = file("${project.buildDir}/libs")
+    dependsOn cleanShadedClassAnnotations
+
+    from(annotationCleanedShadowJarDir) {
+        exclude 'META-INF/MANIFEST.MF'
+    }
+    archiveClassifier.set('')
+    destinationDirectory.set(layout.buildDirectory.dir('libs'))
     manifest {
         from annotationCleanedShadowJarDir.map { it.file("META-INF/MANIFEST.MF") }
     }
-    def projectVersion = version
-    doLast {
-        delete("build/libs/graphql-java-${projectVersion}.jar")
-        file("build/libs/graphql-java-tmp.jar").renameTo(file("build/libs/graphql-java-${projectVersion}.jar"))
-    }
 }
 
-buildNewJar.dependsOn cleanShadedClassAnnotations
+assemble.dependsOn buildFinalJar
 
-assemble.dependsOn buildNewJar
+// The Java component is the source of the main Maven publication. Replace the
+// regular jar artifact on both variants with buildFinalJar so local consumers,
+// project dependencies, signing, and publication all resolve the same cleaned
+// binary. Shadow's optional Java variant is disabled above for the same reason.
+configurations.named('apiElements') {
+    outgoing.artifacts.clear()
+    outgoing.artifact(buildFinalJar)
+}
+configurations.named('runtimeElements') {
+    outgoing.artifacts.clear()
+    outgoing.artifact(buildFinalJar)
+}
+// Shadow creates this configuration independently of its optional Java
+// component variant. Make it non-consumable so dependency resolution cannot
+// select the uncleaned intermediate; shadowJar remains available only as an
+// explicitly invoked internal pipeline task.
+configurations.named('shadowRuntimeElements') {
+    canBeConsumed = false
+}
 
 /**
  * Scans every class in the completed published JAR with ASM and fails if any
@@ -465,12 +510,12 @@ assemble.dependsOn buildNewJar
  * also verifies that {@code graphql.Contract} was preserved by the selective
  * cleanup.
  */
-tasks.register('verifyShadedClassAnnotations') {
+def verifyShadedClassAnnotations = tasks.register('verifyShadedClassAnnotations') {
     group = 'verification'
     description = 'Verify invisible annotations are bundled or removed from the published jar'
-    dependsOn buildNewJar
+    dependsOn buildFinalJar
 
-    def shadedJar = layout.buildDirectory.file("libs/graphql-java-${project.version}.jar")
+    def shadedJar = buildFinalJar.flatMap { it.archiveFile }
     inputs.file(shadedJar)
     inputs.property('annotationsToRemove', annotationsToRemoveFromShadedJar.toList().sort())
 
@@ -527,15 +572,15 @@ tasks.register('verifyShadedClassAnnotations') {
  * inspect the shaded ImmutableList signature; {@code -Xlint:classfile -Werror}
  * turns dangling annotation references into a build failure.
  */
-tasks.register('compileShadedJarConsumer', JavaCompile) {
+def compileShadedJarConsumer = tasks.register('compileShadedJarConsumer', JavaCompile) {
     group = 'verification'
     description = 'Compile a consumer against the shaded jar with class-file warnings treated as errors'
-    dependsOn buildNewJar
+    dependsOn buildFinalJar
 
     source fileTree('src/test/compiler') {
         include '**/*.java'
     }
-    classpath = files(layout.buildDirectory.file("libs/graphql-java-${project.version}.jar"))
+    classpath = files(buildFinalJar.flatMap { it.archiveFile })
     destinationDirectory = layout.buildDirectory.dir('classes/shaded-jar-consumer')
     options.release = 11
     options.compilerArgs.addAll(['-Xlint:classfile', '-Werror'])
@@ -955,8 +1000,8 @@ publishing {
                 // the Gradle ANTLR plugin. `1ac98bf` can be reverted and this comment removed once
                 // that issue is fixed and Gradle upgraded. See https://goo.gl/L92KiF and https://goo.gl/FY0PVR.
                 //
-                // Removing antlr4-runtime and guava because the classes we want to use are "shaded" into the jar itself
-                // via the shadowJar task
+                // Removing antlr4-runtime and guava because the classes we want to use are shaded and cleaned into the
+                // final jar produced by buildFinalJar.
                 def pomNode = asNode()
                 pomNode.dependencies.'*'.findAll() {
                     it.artifactId.text() == 'antlr4' || it.artifactId.text() == 'antlr4-runtime' || it.artifactId.text() == 'guava'
@@ -1012,10 +1057,20 @@ signing {
     sign publishing.publications
 }
 
+// Signing must read the same verified final artifact that is published. This
+// explicit dependency also makes direct invocation of the signing task safe.
+tasks.named('signGraphqlJavaPublication') {
+    dependsOn verifyShadedClassAnnotations
+}
 
-// all publish tasks depend on the build task
+// Remote publication retains the existing full-build requirement. Both remote
+// and Maven Local publication additionally depend on artifact verification so
+// neither path can publish a plain, raw-shadowed, or uncleaned binary JAR.
 tasks.withType(PublishToMavenRepository) {
-    dependsOn build
+    dependsOn build, verifyShadedClassAnnotations
+}
+tasks.withType(PublishToMavenLocal) {
+    dependsOn verifyShadedClassAnnotations
 }
 
 // Only publish Maven POM, disable default Gradle modules file

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ import aQute.bnd.gradle.BundleTaskExtension
 import net.ltgt.gradle.errorprone.CheckSeverity
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.tree.ClassNode
 
 import java.text.SimpleDateFormat
 
@@ -55,6 +58,76 @@ def makeDevelopmentVersion(parts) {
     def version = String.join("-", parts)
     println "created development version: $version"
     return version
+}
+
+static private List<List> invisibleAnnotationLists(ClassNode classNode) {
+    def annotationLists = []
+    if (classNode.invisibleAnnotations != null) {
+        annotationLists.add(classNode.invisibleAnnotations)
+    }
+    classNode.fields.each { field ->
+        if (field.invisibleAnnotations != null) {
+            annotationLists.add(field.invisibleAnnotations)
+        }
+    }
+    classNode.methods.each { method ->
+        if (method.invisibleAnnotations != null) {
+            annotationLists.add(method.invisibleAnnotations)
+        }
+        method.invisibleParameterAnnotations?.each { annotations ->
+            if (annotations != null) {
+                annotationLists.add(annotations)
+            }
+        }
+    }
+    classNode.recordComponents?.each { recordComponent ->
+        if (recordComponent.invisibleAnnotations != null) {
+            annotationLists.add(recordComponent.invisibleAnnotations)
+        }
+    }
+    return annotationLists
+}
+
+static private int removeListedInvisibleAnnotations(ClassNode classNode, Set<String> annotationsToRemove) {
+    int removedAnnotationCount = 0
+    invisibleAnnotationLists(classNode).each { annotations ->
+        int originalSize = annotations.size()
+        annotations.removeAll { annotation -> annotationsToRemove.contains(annotation.desc) }
+        removedAnnotationCount += originalSize - annotations.size()
+    }
+
+    classNode.methods.each { method ->
+        if (method.invisibleParameterAnnotations == null) return
+        if (!method.invisibleParameterAnnotations.every { it == null || it.isEmpty() }) return
+
+        method.invisibleParameterAnnotations = null
+        method.invisibleAnnotableParameterCount = 0
+    }
+    return removedAnnotationCount
+}
+
+static private Map<String, Integer> rewriteClassFiles(File directory, Closure<Integer> rewriteClass) {
+    int modifiedClassCount = 0
+    int modificationCount = 0
+
+    directory.eachFileRecurse(groovy.io.FileType.FILES) { file ->
+        if (!file.name.endsWith('.class')) return
+
+        byte[] originalBytes = file.bytes
+        def reader = new ClassReader(originalBytes)
+        def classNode = new ClassNode()
+        reader.accept(classNode, 0)
+
+        int classModificationCount = rewriteClass.call(classNode)
+        if (classModificationCount == 0) return
+
+        def writer = new ClassWriter(reader, 0)
+        classNode.accept(writer)
+        file.bytes = writer.toByteArray()
+        modifiedClassCount++
+        modificationCount += classModificationCount
+    }
+    return [modifiedClassCount: modifiedClassCount, modificationCount: modificationCount]
 }
 
 def getDevelopmentVersion() {
@@ -284,21 +357,62 @@ jmh {
 }
 
 
-task extractWithoutGuava(type: Copy) {
-    from({ zipTree({ "build/libs/graphql-java-${project.version}.jar" }) }) {
+def extractedShadowJarDir = layout.buildDirectory.dir("extract")
+def annotationCleanedShadowJarDir = layout.buildDirectory.dir("annotation-cleaned")
+
+// External CLASS-retention annotations referenced by shaded classes. Keep this
+// list explicit so GraphQL Java's own invisible annotations remain untouched.
+def annotationsToRemoveFromShadedJar = [
+        'Lcom/google/common/annotations/Beta;',
+        'Lcom/google/common/annotations/GwtCompatible;',
+        'Lcom/google/common/annotations/GwtIncompatible;',
+        'Lcom/google/common/annotations/J2ktIncompatible;',
+        'Lcom/google/common/annotations/VisibleForTesting;',
+        'Lcom/google/errorprone/annotations/CanIgnoreReturnValue;',
+        'Lcom/google/errorprone/annotations/CompatibleWith;',
+        'Lcom/google/errorprone/annotations/DoNotCall;',
+        'Lcom/google/errorprone/annotations/ForOverride;',
+        'Lcom/google/errorprone/annotations/InlineMe;',
+        'Lcom/google/errorprone/annotations/InlineMeValidationDisabled;',
+        'Lcom/google/errorprone/annotations/concurrent/GuardedBy;',
+        'Lcom/google/j2objc/annotations/RetainedWith;',
+        'Lcom/google/j2objc/annotations/Weak;',
+        'Ljavax/annotation/meta/TypeQualifierNickname;',
+] as Set<String>
+
+task extractWithoutGuava(type: Sync) {
+    from({ zipTree(tasks.named('shadowJar').get().archiveFile) }) {
         exclude('/com/**')
     }
-    into layout.buildDirectory.dir("extract")
+    into extractedShadowJarDir
 }
 
-extractWithoutGuava.dependsOn jar
+extractWithoutGuava.dependsOn shadowJar
+
+tasks.register('cleanShadedClassAnnotations', Sync) {
+    description = 'Remove selected invisible annotations from shaded class files'
+    dependsOn extractWithoutGuava
+
+    from extractedShadowJarDir
+    into annotationCleanedShadowJarDir
+    inputs.property('annotationsToRemove', annotationsToRemoveFromShadedJar.toList().sort())
+
+    doLast {
+        def outputDir = annotationCleanedShadowJarDir.get().asFile
+        def result = rewriteClassFiles(outputDir) { classNode ->
+            removeListedInvisibleAnnotations(classNode, annotationsToRemoveFromShadedJar)
+        }
+
+        logger.lifecycle("Removed ${result.modificationCount} invisible annotations; modified ${result.modifiedClassCount} shaded class files")
+    }
+}
 
 task buildNewJar(type: Jar) {
-    from layout.buildDirectory.dir("extract")
+    from annotationCleanedShadowJarDir
     archiveFileName = "graphql-java-tmp.jar"
     destinationDirectory = file("${project.buildDir}/libs")
     manifest {
-        from file("build/extract/META-INF/MANIFEST.MF")
+        from annotationCleanedShadowJarDir.map { it.file("META-INF/MANIFEST.MF") }
     }
     def projectVersion = version
     doLast {
@@ -307,9 +421,68 @@ task buildNewJar(type: Jar) {
     }
 }
 
-buildNewJar.dependsOn extractWithoutGuava
+buildNewJar.dependsOn cleanShadedClassAnnotations
 
-shadowJar.finalizedBy extractWithoutGuava, buildNewJar
+assemble.dependsOn buildNewJar
+
+tasks.register('verifyShadedClassAnnotations') {
+    group = 'verification'
+    description = 'Verify selected invisible annotations are absent from the published jar'
+    dependsOn buildNewJar
+
+    def shadedJar = layout.buildDirectory.file("libs/graphql-java-${project.version}.jar")
+    inputs.file(shadedJar)
+    inputs.property('annotationsToRemove', annotationsToRemoveFromShadedJar.toList().sort())
+
+    doLast {
+        def offendingAnnotations = []
+        boolean graphqlContractFound = false
+
+        new java.util.jar.JarFile(shadedJar.get().asFile).withCloseable { jarFile ->
+            jarFile.entries().each { entry ->
+                if (entry.directory || !entry.name.endsWith('.class')) return
+
+                byte[] classBytes = jarFile.getInputStream(entry).withCloseable { it.bytes }
+                def classNode = new ClassNode()
+                new ClassReader(classBytes).accept(classNode, 0)
+
+                invisibleAnnotationLists(classNode).each { annotations ->
+                    annotations.each { annotation ->
+                        if (annotationsToRemoveFromShadedJar.contains(annotation.desc)) {
+                            offendingAnnotations.add("${entry.name}: ${annotation.desc}")
+                        }
+                        if (annotation.desc == 'Lgraphql/Contract;') {
+                            graphqlContractFound = true
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!offendingAnnotations.isEmpty()) {
+            throw new GradleException("Found annotations that should have been removed:\n${offendingAnnotations.join('\n')}")
+        }
+        if (!graphqlContractFound) {
+            throw new GradleException('graphql.Contract was removed from the shaded jar')
+        }
+    }
+}
+
+tasks.register('compileShadedJarConsumer', JavaCompile) {
+    group = 'verification'
+    description = 'Compile a consumer against the shaded jar with class-file warnings treated as errors'
+    dependsOn buildNewJar
+
+    source fileTree('src/test/compiler') {
+        include '**/*.java'
+    }
+    classpath = files(layout.buildDirectory.file("libs/graphql-java-${project.version}.jar"))
+    destinationDirectory = layout.buildDirectory.dir('classes/shaded-jar-consumer')
+    options.release = 11
+    options.compilerArgs.addAll(['-Xlint:classfile', '-Werror'])
+}
+
+check.dependsOn verifyShadedClassAnnotations, compileShadedJarConsumer
 
 
 // --- TestNG TCK skip verification ---
@@ -623,14 +796,8 @@ tasks.register('markGeneratedEqualsHashCode') {
 
         def ANNOTATION = 'Lgraphql/coverage/Generated;'
 
-        dest.eachFileRecurse(groovy.io.FileType.FILES) { file ->
-            if (!file.name.endsWith('.class')) return
-
-            def bytes = file.bytes
-            def classNode = new org.objectweb.asm.tree.ClassNode()
-            new org.objectweb.asm.ClassReader(bytes).accept(classNode, 0)
-
-            boolean modified = false
+        rewriteClassFiles(dest) { classNode ->
+            int addedAnnotationCount = 0
             for (method in classNode.methods) {
                 if ((method.name == 'equals' && method.desc == '(Ljava/lang/Object;)Z') ||
                         (method.name == 'hashCode' && method.desc == '()I')) {
@@ -639,16 +806,11 @@ tasks.register('markGeneratedEqualsHashCode') {
                     }
                     if (!method.invisibleAnnotations.any { it.desc == ANNOTATION }) {
                         method.invisibleAnnotations.add(new org.objectweb.asm.tree.AnnotationNode(ANNOTATION))
-                        modified = true
+                        addedAnnotationCount++
                     }
                 }
             }
-
-            if (modified) {
-                def writer = new org.objectweb.asm.ClassWriter(0)
-                classNode.accept(writer)
-                file.bytes = writer.toByteArray()
-            }
+            return addedAnnotationCount
         }
     }
 }
@@ -801,5 +963,3 @@ tasks.withType(PublishToMavenRepository) {
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,13 @@ static private int removeListedInvisibleAnnotations(ClassNode classNode, Set<Str
     return removedAnnotationCount
 }
 
+static private String classEntryForAnnotationDescriptor(String descriptor) {
+    if (!descriptor.startsWith('L') || !descriptor.endsWith(';')) {
+        throw new GradleException("Invalid annotation descriptor: ${descriptor}")
+    }
+    return descriptor.substring(1, descriptor.length() - 1) + '.class'
+}
+
 static private Map<String, Integer> rewriteClassFiles(File directory, Closure<Integer> rewriteClass) {
     int modifiedClassCount = 0
     int modificationCount = 0
@@ -379,11 +386,6 @@ def annotationsToRemoveFromShadedJar = [
         'Lcom/google/j2objc/annotations/Weak;',
         'Ljavax/annotation/meta/TypeQualifierNickname;',
 ] as Set<String>
-def graphqlJavaAnnotationDescriptorPrefix = 'Lgraphql/'
-def shadedDependencyAnnotationDescriptorPrefixes = [
-        'Lgraphql/com/google/',
-        'Lgraphql/org/antlr/',
-]
 
 /**
  * Expands the shaded JAR into a clean working directory and removes any
@@ -457,26 +459,24 @@ assemble.dependsOn buildNewJar
 
 /**
  * Scans every class in the completed published JAR with ASM and fails if any
- * configured annotation remains, or if an unknown external annotation appears,
- * in a declaration or parameter invisible annotation attribute. GraphQL Java
- * annotations are allowed, while annotations in relocated dependency namespaces
- * are still considered external. The task also verifies that
- * {@code graphql.Contract} was preserved by the selective cleanup.
+ * configured annotation remains, or if an invisible annotation references an
+ * annotation class that is not bundled in the JAR. This allows both GraphQL
+ * Java annotations and resolvable relocated dependency annotations. The task
+ * also verifies that {@code graphql.Contract} was preserved by the selective
+ * cleanup.
  */
 tasks.register('verifyShadedClassAnnotations') {
     group = 'verification'
-    description = 'Verify only GraphQL Java invisible annotations remain in the published jar'
+    description = 'Verify invisible annotations are bundled or removed from the published jar'
     dependsOn buildNewJar
 
     def shadedJar = layout.buildDirectory.file("libs/graphql-java-${project.version}.jar")
     inputs.file(shadedJar)
     inputs.property('annotationsToRemove', annotationsToRemoveFromShadedJar.toList().sort())
-    inputs.property('graphqlJavaAnnotationPrefix', graphqlJavaAnnotationDescriptorPrefix)
-    inputs.property('shadedDependencyAnnotationPrefixes', shadedDependencyAnnotationDescriptorPrefixes)
 
     doLast {
         def annotationsThatShouldHaveBeenRemoved = []
-        def unexpectedExternalAnnotations = []
+        def unresolvableAnnotations = []
         boolean graphqlContractFound = false
 
         new java.util.jar.JarFile(shadedJar.get().asFile).withCloseable { jarFile ->
@@ -492,10 +492,9 @@ tasks.register('verifyShadedClassAnnotations') {
                         if (annotationsToRemoveFromShadedJar.contains(annotation.desc)) {
                             annotationsThatShouldHaveBeenRemoved.add("${entry.name}: ${annotation.desc}")
                         } else {
-                            boolean isGraphQLJavaAnnotation = annotation.desc.startsWith(graphqlJavaAnnotationDescriptorPrefix) &&
-                                    !shadedDependencyAnnotationDescriptorPrefixes.any { annotation.desc.startsWith(it) }
-                            if (!isGraphQLJavaAnnotation) {
-                                unexpectedExternalAnnotations.add("${entry.name}: ${annotation.desc}")
+                            def annotationClassEntry = classEntryForAnnotationDescriptor(annotation.desc)
+                            if (jarFile.getJarEntry(annotationClassEntry) == null) {
+                                unresolvableAnnotations.add("${entry.name}: ${annotation.desc}")
                             }
                         }
                         if (annotation.desc == 'Lgraphql/Contract;') {
@@ -510,8 +509,8 @@ tasks.register('verifyShadedClassAnnotations') {
         if (!annotationsThatShouldHaveBeenRemoved.isEmpty()) {
             verificationErrors.add("Found annotations that should have been removed:\n${annotationsThatShouldHaveBeenRemoved.join('\n')}")
         }
-        if (!unexpectedExternalAnnotations.isEmpty()) {
-            verificationErrors.add("Found unexpected external invisible annotations; add them to annotationsToRemoveFromShadedJar:\n${unexpectedExternalAnnotations.join('\n')}")
+        if (!unresolvableAnnotations.isEmpty()) {
+            verificationErrors.add("Found invisible annotations whose types are not bundled; add them to annotationsToRemoveFromShadedJar:\n${unresolvableAnnotations.join('\n')}")
         }
         if (!graphqlContractFound) {
             verificationErrors.add('graphql.Contract was removed from the shaded jar')

--- a/build.gradle
+++ b/build.gradle
@@ -380,7 +380,15 @@ def annotationsToRemoveFromShadedJar = [
         'Ljavax/annotation/meta/TypeQualifierNickname;',
 ] as Set<String>
 
+/**
+ * Expands the shaded JAR into a clean working directory and removes any
+ * unrelocated dependency classes that remain under {@code com/**}.
+ *
+ * The annotation cleanup must consume this output rather than the regular
+ * {@code jar} output because dependency classes only exist after shadowing.
+ */
 task extractWithoutGuava(type: Sync) {
+    description = 'Extract the shaded jar without unrelocated dependency classes'
     from({ zipTree(tasks.named('shadowJar').get().archiveFile) }) {
         exclude('/com/**')
     }
@@ -389,6 +397,15 @@ task extractWithoutGuava(type: Sync) {
 
 extractWithoutGuava.dependsOn shadowJar
 
+/**
+ * Copies the extracted shaded JAR into a separate output directory and uses
+ * ASM to remove the explicitly configured annotations from declaration-level
+ * {@code RuntimeInvisibleAnnotations} and
+ * {@code RuntimeInvisibleParameterAnnotations} attributes.
+ *
+ * Other invisible annotations, runtime-visible annotations, and invisible
+ * type annotations are deliberately preserved.
+ */
 tasks.register('cleanShadedClassAnnotations', Sync) {
     description = 'Remove selected invisible annotations from shaded class files'
     dependsOn extractWithoutGuava
@@ -407,7 +424,15 @@ tasks.register('cleanShadedClassAnnotations', Sync) {
     }
 }
 
+/**
+ * Reassembles the published GraphQL Java JAR from the annotation-cleaned
+ * directory, retaining the manifest produced for the shaded JAR.
+ *
+ * The temporary archive is renamed over the normal project JAR so publication
+ * continues to use the existing unclassified artifact name.
+ */
 task buildNewJar(type: Jar) {
+    description = 'Build the published jar from cleaned shaded class files'
     from annotationCleanedShadowJarDir
     archiveFileName = "graphql-java-tmp.jar"
     destinationDirectory = file("${project.buildDir}/libs")
@@ -425,6 +450,12 @@ buildNewJar.dependsOn cleanShadedClassAnnotations
 
 assemble.dependsOn buildNewJar
 
+/**
+ * Scans every class in the completed published JAR with ASM and fails if any
+ * configured annotation remains in a declaration or parameter invisible
+ * annotation attribute. It also verifies that GraphQL Java's own
+ * {@code graphql.Contract} annotation was preserved by the selective cleanup.
+ */
 tasks.register('verifyShadedClassAnnotations') {
     group = 'verification'
     description = 'Verify selected invisible annotations are absent from the published jar'
@@ -468,6 +499,12 @@ tasks.register('verifyShadedClassAnnotations') {
     }
 }
 
+/**
+ * Compiles a small Java 11 consumer against only the completed shaded JAR.
+ * Resolving {@code ExecutionContext.getOperationDirectives()} forces javac to
+ * inspect the shaded ImmutableList signature; {@code -Xlint:classfile -Werror}
+ * turns dangling annotation references into a build failure.
+ */
 tasks.register('compileShadedJarConsumer', JavaCompile) {
     group = 'verification'
     description = 'Compile a consumer against the shaded jar with class-file warnings treated as errors'

--- a/src/test/compiler/graphql/execution/ShadedJarConsumer.java
+++ b/src/test/compiler/graphql/execution/ShadedJarConsumer.java
@@ -1,0 +1,9 @@
+package graphql.execution;
+
+public class ShadedJarConsumer {
+
+    public Object getOperationDirectives(ExecutionContext executionContext) {
+        var operationDirectives = executionContext.getOperationDirectives();
+        return operationDirectives;
+    }
+}

--- a/src/test/compiler/graphql/execution/ShadedJarConsumer.java
+++ b/src/test/compiler/graphql/execution/ShadedJarConsumer.java
@@ -1,5 +1,13 @@
 package graphql.execution;
 
+/**
+ * Compilation fixture used only by the {@code compileShadedJarConsumer} Gradle task.
+ *
+ * <p>Calling {@link ExecutionContext#getOperationDirectives()} forces javac to inspect the
+ * shaded {@code ImmutableList} in its generic return type. The task compiles this fixture
+ * against the completed JAR with {@code -Xlint:classfile -Werror}, turning unresolved
+ * annotation references in shaded class files into a build failure.</p>
+ */
 public class ShadedJarConsumer {
 
     public Object getOperationDirectives(ExecutionContext executionContext) {


### PR DESCRIPTION
## Summary

- define an explicit list of unbundled CLASS-retention annotations to remove from shaded class files
- add an ASM-powered cleanup stage after shadowing and before final JAR assembly
- preserve invisible annotations whose annotation classes are bundled, including GraphQL Java and relocated dependency annotations
- reject new RuntimeInvisibleAnnotations and RuntimeInvisibleParameterAnnotations whose annotation classes are not bundled and are not in the removal list
- share the class-file rewrite machinery with the existing JaCoCo annotation task
- compile a Java 11 consumer with class-file warnings treated as errors
- make the annotation-cleaned JAR the sole unclassified binary artifact and the sole main artifact used by consumers, signing, and publication

## Artifact pipeline

The regular `jar` and `shadowJar` outputs are internal inputs to the cleanup pipeline. They now have explicit `plain` and `shadow` classifiers and live under `build/intermediates`, outside `build/libs`.

`buildFinalJar` is the only task that writes the unclassified binary JAR to `build/libs`. It consumes the annotation-cleaned class tree directly, so Gradle tracks the actual final archive instead of a temporary archive that is renamed in `doLast`.

The Java API and runtime variants both expose `buildFinalJar`. The Shadow Java variant and assemble hook are disabled, and `shadowRuntimeElements` is non-consumable, so dependency resolution cannot select the uncleaned intermediate. Direct signing, Maven Local publication, and remote publication all depend on verification of the final JAR.

This separation matters because multiple tasks previously owned the same output path. A direct `shadowJar` invocation could overwrite the cleaned JAR while Gradle still considered the cleanup/reassembly tasks up to date. Unique intermediate paths plus a single final producer remove that failure mode.

## Verification

- `./gradlew outgoingVariants`: API and runtime variants expose only `buildFinalJar`; no consumable Shadow variant remains
- `./gradlew clean test assemble verifyShadedClassAnnotations compileShadedJarConsumer`: passed, including 5,737 tests
- `./gradlew check -x test -x testng`: passed
- isolated `publishGraphqlJavaPublicationToMavenLocal`: published only the main, sources, Javadoc, and POM artifacts
- the isolated Maven-local main JAR had the same SHA-256 as the `buildFinalJar` output
- direct `./gradlew jar shadowJar` invocation left the final JAR SHA-256 unchanged

The cleanup currently removes 1,345 annotations from 330 shaded class files.

## Artifact size

Both artifacts were built through their complete publication pipelines with the same fixed `999.0.0-size-test` release version.

| Artifact | Size |
| --- | ---: |
| `origin/master` before removal | 3,878,053 bytes |
| This PR after removal | 3,873,126 bytes |
| Reduction | 4,927 bytes (0.127%) |

The uncompressed JAR contents decrease by 16,152 bytes. Both archives contain 2,394 entries, and their manifests are identical.