### PR TITLE
Backport 26.1: Fix input cycle validation for non-null lists

### DIFF
--- a/src/main/java/graphql/schema/validation/NoUnbrokenInputCycles.java
+++ b/src/main/java/graphql/schema/validation/NoUnbrokenInputCycles.java
@@ -6,7 +6,6 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLSchemaElement;
 import graphql.schema.GraphQLType;
@@ -63,17 +62,11 @@ public class NoUnbrokenInputCycles extends GraphQLTypeVisitorStub {
     }
 
     private GraphQLType unwrapNonNull(GraphQLNonNull type) {
-        if (isList(type.getWrappedType())) {
-            //we only care about [type!]! i.e. non-null lists of non-nulls
-            GraphQLList listType = (GraphQLList) type.getWrappedType();
-            if (isNonNull(listType.getWrappedType())) {
-                return unwrapAll(listType.getWrappedType());
-            } else {
-                return type.getWrappedType();
-            }
-        } else {
-            return unwrapAll(type.getWrappedType());
+        GraphQLType wrappedType = type.getWrappedType();
+        if (isList(wrappedType)) {
+            return wrappedType;
         }
+        return unwrapAll(wrappedType);
     }
 
     private String getErrorMessage(List<String> path) {

--- a/src/test/groovy/graphql/schema/validation/NoUnbrokenInputCyclesTest.groovy
+++ b/src/test/groovy/graphql/schema/validation/NoUnbrokenInputCyclesTest.groovy
@@ -1,9 +1,12 @@
 package graphql.schema.validation
 
+import graphql.TestUtil
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLInputObjectField
 import graphql.schema.GraphQLInputObjectType
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
 import graphql.util.TraverserContext
 import spock.lang.Specification
 
@@ -42,5 +45,52 @@ class NoUnbrokenInputCyclesTest extends Specification {
         new NoUnbrokenInputCycles().visitGraphQLFieldDefinition(field, context)
         then:
         errorCollector.containsValidationError(SchemaValidationErrorType.UnbrokenInputCycle)
+    }
+
+    def "input object cycles through a non-null list are allowed"() {
+        def sdl = """
+            input Example {
+                self: [Example!]!
+                value: String
+            }
+
+            type Query {
+                example(example: Example): String
+            }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "longer input object cycles through a non-null list are allowed"() {
+        def sdl = """
+            input Foo {
+                bar: Bar!
+            }
+
+            input Bar {
+                baz: Baz!
+            }
+
+            input Baz {
+                foos: [Foo!]!
+            }
+
+            type Query {
+                foo(foo: Foo): String
+            }
+        """
+
+        when:
+        def registry = new SchemaParser().parse(sdl)
+        new SchemaGenerator().makeExecutableSchema(registry, TestUtil.getMockRuntimeWiring())
+
+        then:
+        noExceptionThrown()
     }
 }


### PR DESCRIPTION
Backport of #4386 to the `26.x` maintenance branch.

## Summary
- treat non-null list input fields as breaking unbroken input cycles
- add SDL regression coverage for #4214

## Verification
- Confirmed the new regression test fails on current master with: `[self!] forms an unsatisfiable cycle`
- ./gradlew test --tests graphql.schema.validation.NoUnbrokenInputCyclesTest
- ./gradlew test --tests 'graphql.schema.validation.*'

Fixes #4214