### PR TITLE
Backport 26.1: Fix subscription alternative call context cleanup

### DIFF
--- a/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/DataLoaderDispatchStrategy.java
@@ -65,6 +65,10 @@ public interface DataLoaderDispatchStrategy {
 
     }
 
+    default void subscriptionEventExecutionDone(AlternativeCallContext alternativeCallContext) {
+
+    }
+
     default void finishedFetching(ExecutionContext executionContext, ExecutionStrategyParameters newParameters) {
 
     }

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -14,6 +14,7 @@ import graphql.TypeMismatchError;
 import graphql.UnresolvedTypeError;
 import graphql.execution.directives.QueryDirectives;
 import graphql.execution.directives.QueryDirectivesImpl;
+import graphql.execution.incremental.AlternativeCallContext;
 import graphql.execution.incremental.DeferredExecutionSupport;
 import graphql.execution.incremental.IncrementalExecutionContextKeys;
 import graphql.execution.instrumentation.ExecuteObjectInstrumentationContext;
@@ -457,7 +458,7 @@ public abstract class ExecutionStrategy {
                     .parentType(parentType)
                     .selectionSet(fieldCollector)
                     .queryDirectives(queryDirectives)
-                    .deferredCallContext(parameters.getDeferredCallContext())
+                    .alternativeCallContext(parameters.getAlternativeCallContext())
                     .level(parameters.getPath().getLevel())
                     .build();
         });
@@ -1122,18 +1123,20 @@ public abstract class ExecutionStrategy {
         return FpKit.intraThreadMemoize(() -> createExecutionStepInfo(executionContext, parameters, fieldDef, null));
     }
 
-    // Errors that result from the execution of deferred fields are kept in the deferred context only.
+    // Errors in alternative execution paths are kept in the alternative call context.
     private static void addErrorToRightContext(GraphQLError error, ExecutionStrategyParameters parameters, ExecutionContext executionContext) {
-        if (parameters.getDeferredCallContext() != null) {
-            parameters.getDeferredCallContext().addError(error);
+        AlternativeCallContext alternativeCallContext = parameters.getAlternativeCallContext();
+        if (alternativeCallContext != null) {
+            alternativeCallContext.addError(error);
         } else {
             executionContext.addError(error);
         }
     }
 
     private static void addErrorsToRightContext(List<GraphQLError> errors, ExecutionStrategyParameters parameters, ExecutionContext executionContext) {
-        if (parameters.getDeferredCallContext() != null) {
-            parameters.getDeferredCallContext().addErrors(errors);
+        AlternativeCallContext alternativeCallContext = parameters.getAlternativeCallContext();
+        if (alternativeCallContext != null) {
+            alternativeCallContext.addErrors(errors);
         } else {
             executionContext.addErrors(errors);
         }

--- a/src/main/java/graphql/execution/ExecutionStrategyParameters.java
+++ b/src/main/java/graphql/execution/ExecutionStrategyParameters.java
@@ -77,29 +77,25 @@ public class ExecutionStrategyParameters {
     }
 
     /**
+     * Returns the alternative call context if this execution is scoped to an alternative execution path.
+     * This is used for deferred fragment execution and subscription event execution.
+     * @return the alternative call context or null if execution is not scoped to an alternative execution path
+     */
+    @Nullable
+    @Internal
+    public AlternativeCallContext getAlternativeCallContext() {
+        return alternativeCallContext;
+    }
+
+    /**
      * Returns the deferred call context if we're in the scope of a deferred call.
-     * A new DeferredCallContext is created for each @defer block, and is passed down to all fields within the deferred call.
-     *
-     * <pre>
-     *     query {
-     *        ... @defer {
-     *            field1 {        # new DeferredCallContext created here
-     *                field1a     # DeferredCallContext passed down to this field
-     *            }
-     *        }
-     *
-     *        ... @defer {
-     *            field2          # new DeferredCallContext created here
-     *        }
-     *     }
-     * </pre>
      *
      * @return the deferred call context or null if we're not in the scope of a deferred call
      */
     @Nullable
     @Internal
     public AlternativeCallContext getDeferredCallContext() {
-        return alternativeCallContext;
+        return getAlternativeCallContext();
     }
 
     /**
@@ -293,9 +289,13 @@ public class ExecutionStrategyParameters {
             return this;
         }
 
-        public Builder deferredCallContext(AlternativeCallContext alternativeCallContext) {
+        public Builder alternativeCallContext(AlternativeCallContext alternativeCallContext) {
             this.alternativeCallContext = alternativeCallContext;
             return this;
+        }
+
+        public Builder deferredCallContext(AlternativeCallContext alternativeCallContext) {
+            return alternativeCallContext(alternativeCallContext);
         }
 
         public ExecutionStrategyParameters build() {

--- a/src/main/java/graphql/execution/NonNullableFieldValidator.java
+++ b/src/main/java/graphql/execution/NonNullableFieldValidator.java
@@ -50,8 +50,8 @@ public class NonNullableFieldValidator {
 
                 NonNullableFieldWasNullException nonNullException = new NonNullableFieldWasNullException(executionStepInfo, path);
                 final GraphQLError error = new NonNullableFieldWasNullError(nonNullException);
-                if(parameters.getDeferredCallContext() != null) {
-                    parameters.getDeferredCallContext().addError(error);
+                if(parameters.getAlternativeCallContext() != null) {
+                    parameters.getAlternativeCallContext().addError(error);
                 } else {
                     executionContext.addError(error, path);
                 }

--- a/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SubscriptionExecutionStrategy.java
@@ -180,14 +180,20 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
         ));
 
 
-        executionContext.getDataLoaderDispatcherStrategy().newSubscriptionExecution(newParameters.getDeferredCallContext());
+        AlternativeCallContext alternativeCallContext = assertNotNull(
+                newParameters.getAlternativeCallContext(),
+                "alternativeCallContext must not be null");
+        executionContext.getDataLoaderDispatcherStrategy().newSubscriptionExecution(alternativeCallContext);
         Object fetchedValue = unboxPossibleDataFetcherResult(newExecutionContext, newParameters, eventPayload);
         FieldValueInfo fieldValueInfo = completeField(newExecutionContext, newParameters, fetchedValue);
-        executionContext.getDataLoaderDispatcherStrategy().subscriptionEventCompletionDone(newParameters.getDeferredCallContext());
+        executionContext.getDataLoaderDispatcherStrategy().subscriptionEventCompletionDone(alternativeCallContext);
         CompletableFuture<ExecutionResult> overallResult = fieldValueInfo
                 .getFieldValueFuture()
-                .thenApply(val -> new ExecutionResultImpl(val, assertNotNull(newParameters.getDeferredCallContext(), "deferredCallContext must not be null").getErrors()))
-                .thenApply(executionResult -> wrapWithRootFieldName(newParameters, executionResult));
+                .thenApply(val -> new ExecutionResultImpl(val, alternativeCallContext.getErrors()))
+                .thenApply(executionResult -> wrapWithRootFieldName(newParameters, executionResult))
+                .whenComplete((executionResult, throwable) -> {
+                    executionContext.getDataLoaderDispatcherStrategy().subscriptionEventExecutionDone(alternativeCallContext);
+                });
 
         // dispatch instrumentation so they can know about each subscription event
         subscribedFieldCtx.onDispatched();
@@ -230,7 +236,7 @@ public class SubscriptionExecutionStrategy extends ExecutionStrategy {
                     .path(fieldPath)
                     .nonNullFieldValidator(nonNullableFieldValidator);
             if (newCallContext) {
-                builder.deferredCallContext(new AlternativeCallContext(1, 1));
+                builder.alternativeCallContext(new AlternativeCallContext(1, 1));
             }
         });
 

--- a/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
+++ b/src/main/java/graphql/execution/incremental/DeferredExecutionSupport.java
@@ -155,7 +155,7 @@ public interface DeferredExecutionSupport {
                     {
                         MergedSelectionSet mergedSelectionSet = MergedSelectionSet.newMergedSelectionSet().subFields(fields).build();
                         ResultPath path = parameters.getPath().segment(currentField.getResultKey());
-                        builder.deferredCallContext(alternativeCallContext)
+                        builder.alternativeCallContext(alternativeCallContext)
                                 .field(currentField)
                                 .fields(mergedSelectionSet)
                                 .path(path)

--- a/src/main/java/graphql/execution/instrumentation/dataloader/ExhaustedDataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/ExhaustedDataLoaderDispatchStrategy.java
@@ -174,11 +174,16 @@ public class ExhaustedDataLoaderDispatchStrategy implements DataLoaderDispatchSt
     }
 
     @Override
+    public void subscriptionEventExecutionDone(AlternativeCallContext alternativeCallContext) {
+        alternativeCallContextMap.remove(alternativeCallContext);
+    }
+
+    @Override
     public void deferFieldFetched(ExecutionStrategyParameters parameters) {
         CallStack callStack = getCallStack(parameters);
         int deferredFragmentRootFieldsCompleted = callStack.deferredFragmentRootFieldsCompleted.incrementAndGet();
-        Assert.assertNotNull(parameters.getDeferredCallContext());
-        if (deferredFragmentRootFieldsCompleted == parameters.getDeferredCallContext().getFields()) {
+        Assert.assertNotNull(parameters.getAlternativeCallContext());
+        if (deferredFragmentRootFieldsCompleted == parameters.getAlternativeCallContext().getFields()) {
             decrementObjectRunningAndMaybeDispatch(callStack);
         }
     }
@@ -195,7 +200,7 @@ public class ExhaustedDataLoaderDispatchStrategy implements DataLoaderDispatchSt
     }
 
     private CallStack getCallStack(ExecutionStrategyParameters parameters) {
-        return getCallStack(parameters.getDeferredCallContext());
+        return getCallStack(parameters.getAlternativeCallContext());
     }
 
     private CallStack getCallStack(@Nullable AlternativeCallContext alternativeCallContext) {
@@ -281,4 +286,3 @@ public class ExhaustedDataLoaderDispatchStrategy implements DataLoaderDispatchSt
 
 
 }
-

--- a/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategy.java
+++ b/src/main/java/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategy.java
@@ -362,8 +362,8 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
                              Supplier<DataFetchingEnvironment> dataFetchingEnvironment) {
         CallStack callStack = getCallStack(executionStrategyParameters);
         int level = executionStrategyParameters.getPath().getLevel();
-        AlternativeCallContext deferredCallContext = executionStrategyParameters.getDeferredCallContext();
-        if (level == 1 || (deferredCallContext != null && level == deferredCallContext.getStartLevel())) {
+        AlternativeCallContext alternativeCallContext = executionStrategyParameters.getAlternativeCallContext();
+        if (level == 1 || (alternativeCallContext != null && level == alternativeCallContext.getStartLevel())) {
             int happenedFirstLevelFetchCount = callStack.happenedFirstLevelFetchCount.incrementAndGet();
             if (happenedFirstLevelFetchCount == callStack.expectedFirstLevelFetchCount) {
                 callStack.dispatchedLevels.add(level);
@@ -396,19 +396,24 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
     }
 
     @Override
+    public void subscriptionEventExecutionDone(AlternativeCallContext alternativeCallContext) {
+        alternativeCallContextMap.remove(alternativeCallContext);
+    }
+
+    @Override
     public void deferredOnFieldValue(String resultKey, FieldValueInfo fieldValueInfo, Throwable throwable, ExecutionStrategyParameters parameters) {
         CallStack callStack = getCallStack(parameters);
         int deferredFragmentRootFieldsCompleted = callStack.deferredFragmentRootFieldsCompleted.incrementAndGet();
-        Assert.assertNotNull(parameters.getDeferredCallContext());
-        if (deferredFragmentRootFieldsCompleted == parameters.getDeferredCallContext().getFields()) {
-            onCompletionFinished(parameters.getDeferredCallContext().getStartLevel() - 1, callStack);
+        Assert.assertNotNull(parameters.getAlternativeCallContext());
+        if (deferredFragmentRootFieldsCompleted == parameters.getAlternativeCallContext().getFields()) {
+            onCompletionFinished(parameters.getAlternativeCallContext().getStartLevel() - 1, callStack);
         }
 
     }
 
 
     private CallStack getCallStack(ExecutionStrategyParameters parameters) {
-        return getCallStack(parameters.getDeferredCallContext());
+        return getCallStack(parameters.getAlternativeCallContext());
     }
 
     private CallStack getCallStack(@Nullable AlternativeCallContext alternativeCallContext) {
@@ -520,4 +525,3 @@ public class PerLevelDataLoaderDispatchStrategy implements DataLoaderDispatchStr
 
 
 }
-

--- a/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironmentImpl.java
@@ -458,9 +458,13 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
             return this;
         }
 
-        public Builder deferredCallContext(AlternativeCallContext alternativeCallContext) {
+        public Builder alternativeCallContext(AlternativeCallContext alternativeCallContext) {
             this.alternativeCallContext = alternativeCallContext;
             return this;
+        }
+
+        public Builder deferredCallContext(AlternativeCallContext alternativeCallContext) {
+            return alternativeCallContext(alternativeCallContext);
         }
 
         public DataFetchingEnvironment build() {
@@ -499,8 +503,12 @@ public class DataFetchingEnvironmentImpl implements DataFetchingEnvironment {
             return dataLoaderDispatchStrategy;
         }
 
-        public AlternativeCallContext getDeferredCallContext() {
+        public AlternativeCallContext getAlternativeCallContext() {
             return alternativeCallContext;
+        }
+
+        public AlternativeCallContext getDeferredCallContext() {
+            return getAlternativeCallContext();
         }
 
         public Profiler getProfiler() {

--- a/src/main/java/graphql/schema/DataLoaderWithContext.java
+++ b/src/main/java/graphql/schema/DataLoaderWithContext.java
@@ -68,11 +68,11 @@ public class DataLoaderWithContext<K, V> extends DelegatingDataLoader<K, V> {
         DataFetchingEnvironmentImpl dfeImpl = (DataFetchingEnvironmentImpl) dfe;
         DataFetchingEnvironmentImpl.DFEInternalState dfeInternalState = (DataFetchingEnvironmentImpl.DFEInternalState) dfeImpl.toInternal();
         if (dfeInternalState.getDataLoaderDispatchStrategy() instanceof PerLevelDataLoaderDispatchStrategy) {
-            AlternativeCallContext alternativeCallContext = dfeInternalState.getDeferredCallContext();
+            AlternativeCallContext alternativeCallContext = dfeInternalState.getAlternativeCallContext();
             int level = dfeImpl.getLevel();
             ((PerLevelDataLoaderDispatchStrategy) dfeInternalState.dataLoaderDispatchStrategy).newDataLoaderInvocation(level, delegate, alternativeCallContext);
         } else if (dfeInternalState.getDataLoaderDispatchStrategy() instanceof ExhaustedDataLoaderDispatchStrategy) {
-            AlternativeCallContext alternativeCallContext = dfeInternalState.getDeferredCallContext();
+            AlternativeCallContext alternativeCallContext = dfeInternalState.getAlternativeCallContext();
             ((ExhaustedDataLoaderDispatchStrategy) dfeInternalState.dataLoaderDispatchStrategy).newDataLoaderInvocation(alternativeCallContext);
         }
     }

--- a/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/SubscriptionExecutionStrategyTest.groovy
@@ -11,8 +11,9 @@ import graphql.TestUtil
 import graphql.TypeMismatchError
 import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.LegacyTestingInstrumentation
-import graphql.execution.instrumentation.dataloader.DataLoaderDispatchingContextKeys
 import graphql.execution.instrumentation.ModernTestingInstrumentation
+import graphql.execution.instrumentation.SimplePerformantInstrumentation
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatchingContextKeys
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.pubsub.CapturingSubscriber
 import graphql.execution.pubsub.FlowMessagePublisher
@@ -36,6 +37,7 @@ import spock.lang.Unroll
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
 
@@ -830,6 +832,16 @@ class SubscriptionExecutionStrategyTest extends Specification {
         def dataLoader = DataLoaderFactory.newDataLoader("dogsNameLoader", batchLoader)
         DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry()
         dataLoaderRegistry.register("dogsNameLoader", dataLoader)
+        AtomicReference<ExecutionContext> capturedExecutionContext = new AtomicReference<>()
+        def instrumentation = Spy(SimplePerformantInstrumentation) {
+            instrumentExecutionContext(_, _, _) >> {
+                ExecutionContext executionContext,
+                InstrumentationExecutionParameters parameters,
+                InstrumentationState state ->
+                    capturedExecutionContext.set(executionContext)
+                    executionContext
+            }
+        }
 
         DataFetcher dogsNameDF = { env ->
             println "dogsNameDF called"
@@ -857,6 +869,7 @@ class SubscriptionExecutionStrategyTest extends Specification {
                 .dataLoaderRegistry(dataLoaderRegistry)
                 .build()
         def graphQL = GraphQL.newGraphQL(schema)
+                .instrumentation(instrumentation)
                 .build()
 
         if (exhaustedStrategy) {
@@ -878,9 +891,16 @@ class SubscriptionExecutionStrategyTest extends Specification {
         events[0].data == ["newDogs": [[name: "Luna"], [name: "Skipper"]]]
         events[1].data == ["newDogs": [[name: "Luna"], [name: "Skipper"]]]
         events[2].data == ["newDogs": [[name: "Luna"], [name: "Skipper"]]]
+        alternativeCallContextMap(capturedExecutionContext.get().dataLoaderDispatcherStrategy).size() == 0
 
         where:
         exhaustedStrategy << [false, true]
+    }
+
+    private Map alternativeCallContextMap(DataLoaderDispatchStrategy dataLoaderDispatchStrategy) {
+        def field = dataLoaderDispatchStrategy.class.getDeclaredField("alternativeCallContextMap")
+        field.accessible = true
+        field.get(dataLoaderDispatchStrategy) as Map
     }
 
 

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/ExhaustedDataLoaderDispatchStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/ExhaustedDataLoaderDispatchStrategyTest.groovy
@@ -18,6 +18,7 @@ import graphql.schema.GraphQLSchema
 import org.dataloader.BatchLoader
 import org.dataloader.DataLoaderFactory
 import org.dataloader.DataLoaderRegistry
+import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.concurrent.CompletableFuture
@@ -242,6 +243,23 @@ class ExhaustedDataLoaderDispatchStrategyTest extends Specification {
         batchLoaderInvocations.get() == 1
     }
 
+    @Issue("https://github.com/graphql-java/graphql-java/issues/4314")
+    def "subscription event call stacks are removed after execution is done"() {
+        given:
+        setupStrategy(simpleBatchLoader())
+
+        when:
+        3.times {
+            def alternativeCallContext = new AlternativeCallContext(1, 1)
+            strategy.newSubscriptionExecution(alternativeCallContext)
+            strategy.subscriptionEventCompletionDone(alternativeCallContext)
+            strategy.subscriptionEventExecutionDone(alternativeCallContext)
+        }
+
+        then:
+        alternativeCallContextMap().size() == 0
+    }
+
     def "startComplete and stopComplete affect dispatch"() {
         given:
         setupStrategy(simpleBatchLoader())
@@ -279,7 +297,7 @@ class ExhaustedDataLoaderDispatchStrategyTest extends Specification {
                 .source(new Object())
                 .fields(graphql.execution.MergedSelectionSet.newMergedSelectionSet().build())
                 .nonNullFieldValidator(new NonNullableFieldValidator(executionContext))
-                .deferredCallContext(deferCtx)
+                .alternativeCallContext(deferCtx)
                 .build()
 
         when:
@@ -429,5 +447,11 @@ class ExhaustedDataLoaderDispatchStrategyTest extends Specification {
         then:
         completed
         roundCount.get() == 2
+    }
+
+    private Map alternativeCallContextMap() {
+        def field = ExhaustedDataLoaderDispatchStrategy.getDeclaredField("alternativeCallContextMap")
+        field.accessible = true
+        field.get(strategy) as Map
     }
 }

--- a/src/test/groovy/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategyTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/dataloader/PerLevelDataLoaderDispatchStrategyTest.groovy
@@ -16,9 +16,11 @@ import graphql.execution.NonNullableFieldValidator
 import graphql.execution.ResultPath
 import graphql.execution.ValueUnboxer
 import graphql.execution.instrumentation.SimplePerformantInstrumentation
+import graphql.execution.incremental.AlternativeCallContext
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import org.dataloader.DataLoaderRegistry
+import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.concurrent.CountDownLatch
@@ -58,6 +60,20 @@ class PerLevelDataLoaderDispatchStrategyTest extends Specification {
                 .engineRunningState(new EngineRunningState(ei, Profiler.NO_OP))
         executionContext = builder.build()
         strategy = new PerLevelDataLoaderDispatchStrategy(executionContext)
+    }
+
+    @Issue("https://github.com/graphql-java/graphql-java/issues/4314")
+    def "subscription event call stacks are removed after execution is done"() {
+        when:
+        3.times {
+            def alternativeCallContext = new AlternativeCallContext(1, 1)
+            strategy.newSubscriptionExecution(alternativeCallContext)
+            strategy.subscriptionEventCompletionDone(alternativeCallContext)
+            strategy.subscriptionEventExecutionDone(alternativeCallContext)
+        }
+
+        then:
+        alternativeCallContextMap().size() == 0
     }
 
     private ExecutionStrategyParameters paramsAtLevel(int level) {
@@ -178,5 +194,11 @@ class PerLevelDataLoaderDispatchStrategyTest extends Specification {
 
         then:
         strategy.initialCallStack.get(0).happenedCompletionFinishedCount > 0
+    }
+
+    private Map alternativeCallContextMap() {
+        def field = PerLevelDataLoaderDispatchStrategy.getDeclaredField("alternativeCallContextMap")
+        field.accessible = true
+        field.get(strategy) as Map
     }
 }


### PR DESCRIPTION
Backport of #4384 to the `26.x` maintenance branch.

26.x compatibility: this backport retains the existing `getDeferredCallContext()` and `deferredCallContext(...)` method names as delegating aliases for the renamed alternative-call-context APIs.

## Summary
- add a post-event data loader dispatch lifecycle callback to release subscription event call stacks after the event result completes
- clean up alternative call context naming so it covers both deferred execution and subscription event execution
- add regression coverage for per-level and exhausted dispatch strategies plus subscription integration coverage

Fixes #4314

## Verification
- ./gradlew test (5603 tests, 8 skipped)

Note: an initial non-clean full-suite run failed in JMHForkArchRuleTest due stale build output; after `./gradlew clean test --tests graphql.archunit.JMHForkArchRuleTest` passed, a clean full `./gradlew test` passed.