### PR TITLE
Backport 26.1: parser cleanup

### DIFF
--- a/src/main/java/graphql/parser/StringValueParsing.java
+++ b/src/main/java/graphql/parser/StringValueParsing.java
@@ -6,9 +6,6 @@ import graphql.i18n.I18n;
 import graphql.language.SourceLocation;
 
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Contains parsing code for the StringValue types in the grammar
@@ -44,45 +41,25 @@ public class StringValueParsing {
                 }
             }
         }
-        List<String> lineList = new ArrayList<>(Arrays.asList(lines));
-        if (commonIndent != null) {
-            for (int i = 0; i < lineList.size(); i++) {
-                String line = lineList.get(i);
-                if (i == 0) {
-                    continue;
-                }
-                if (line.length() > commonIndent) {
-                    line = line.substring(commonIndent);
-                    lineList.set(i, line);
-                }
-            }
+        int firstLine = 0;
+        while (firstLine < lines.length && containsOnlyWhiteSpace(lines[firstLine])) {
+            firstLine++;
         }
-        while (!lineList.isEmpty()) {
-            String line = lineList.get(0);
-            if (containsOnlyWhiteSpace(line)) {
-                lineList.remove(0);
-            } else {
-                break;
-            }
+        int lastLine = lines.length;
+        while (lastLine > firstLine && containsOnlyWhiteSpace(lines[lastLine - 1])) {
+            lastLine--;
         }
-        while (!lineList.isEmpty()) {
-            int endIndex = lineList.size() - 1;
-            String line = lineList.get(endIndex);
-            if (containsOnlyWhiteSpace(line)) {
-                lineList.remove(endIndex);
-            } else {
-                break;
+
+        StringBuilder formatted = new StringBuilder(rawValue.length());
+        for (int i = firstLine; i < lastLine; i++) {
+            String line = lines[i];
+            if (commonIndent != null && i > 0 && line.length() > commonIndent) {
+                line = line.substring(commonIndent);
             }
-        }
-        StringBuilder formatted = new StringBuilder();
-        for (int i = 0; i < lineList.size(); i++) {
-            String line = lineList.get(i);
-            if (i == 0) {
-                formatted.append(line);
-            } else {
-                formatted.append("\n");
-                formatted.append(line);
+            if (i > firstLine) {
+                formatted.append('\n');
             }
+            formatted.append(line);
         }
         return formatted.toString();
     }

--- a/src/test/groovy/graphql/parser/StringValueParsingTest.groovy
+++ b/src/test/groovy/graphql/parser/StringValueParsingTest.groovy
@@ -2,6 +2,7 @@ package graphql.parser
 
 import graphql.i18n.I18n
 import graphql.language.SourceLocation
+import graphql.language.StringValue
 import spock.lang.Specification
 
 import static java.util.Arrays.asList
@@ -225,5 +226,27 @@ L 3'''
 L 2
 L 3'''
         parsed == expected
+    }
+
+    def "removes large runs of leading and trailing blank lines"() {
+        given:
+        def input = "\n".repeat(20_000) + "    value" + "\n  ".repeat(20_000)
+
+        when:
+        String parsed = StringValueParsing.removeIndentation(input)
+
+        then:
+        parsed == "value"
+    }
+
+    def "full parser handles block strings with many leading and trailing blank lines"() {
+        given:
+        def input = '"""' + "\n".repeat(20_000) + "    value" + "\n  ".repeat(20_000) + '"""'
+
+        when:
+        StringValue parsed = Parser.parseValue(input)
+
+        then:
+        parsed.getValue() == "value"
     }
 }


### PR DESCRIPTION
Backport of #4442 to the `26.x` maintenance branch.

The original commit applies without changes.

Summary:
- makes block string indentation removal linear by retaining an index window over the split lines
- avoids repeated removal from the front of an array-backed list
- adds focused coverage for large runs of leading and trailing blank lines

Testing:
- `./gradlew test --tests graphql.parser.StringValueParsingTest` (15 tests)
- `./gradlew check -x test -x testng javadoc`