### PR TITLE
Backport 26.1: Mark InstrumentationState callback params as @Nullable

### DIFF
--- a/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java
@@ -12,6 +12,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperat
 import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.validation.ValidationError;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -85,7 +86,7 @@ public class MaxQueryComplexityInstrumentation extends SimplePerformantInstrumen
     }
 
     @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, InstrumentationState rawState) {
+    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, @Nullable InstrumentationState rawState) {
         State state = ofState(rawState);
         // for API backwards compatibility reasons we capture the validation parameters, so we can put them into QueryComplexityInfo
         state.instrumentationValidationParameters.set(parameters);
@@ -93,7 +94,7 @@ public class MaxQueryComplexityInstrumentation extends SimplePerformantInstrumen
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters instrumentationExecuteOperationParameters, InstrumentationState rawState) {
+    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters instrumentationExecuteOperationParameters, @Nullable InstrumentationState rawState) {
         State state = ofState(rawState);
         QueryComplexityCalculator queryComplexityCalculator = newQueryComplexityCalculator(instrumentationExecuteOperationParameters.getExecutionContext());
         int totalComplexity = queryComplexityCalculator.calculate();

--- a/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
+++ b/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java
@@ -49,7 +49,7 @@ public class MaxQueryDepthInstrumentation extends SimplePerformantInstrumentatio
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
+    public InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, @Nullable InstrumentationState state) {
         QueryTraverser queryTraverser = newQueryTraverser(parameters.getExecutionContext());
         int depth = queryTraverser.reducePreOrder((env, acc) -> Math.max(getPathLength(env.getParentEnvironment()), acc), 0);
         if (depth > maxDepth) {

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -67,21 +67,30 @@ public class ChainedInstrumentation implements Instrumentation {
         return instrumentations;
     }
 
-    private <T> @Nullable InstrumentationContext<T> chainedCtx(InstrumentationState state, BiFunction<Instrumentation, InstrumentationState, InstrumentationContext<T>> mapper) {
+    /**
+     * Chained instrumentation always materializes a {@link ChainedInstrumentationState} via
+     * {@link #createStateAsync(InstrumentationCreateStateParameters)}. Callback {@code state} is still
+     * {@link Nullable} to match the optional-state contract of {@link Instrumentation}.
+     */
+    private static ChainedInstrumentationState asChainedState(@Nullable InstrumentationState state) {
+        return (ChainedInstrumentationState) assertNotNull(state);
+    }
+
+    private <T> @Nullable InstrumentationContext<T> chainedCtx(@Nullable InstrumentationState state, BiFunction<Instrumentation, InstrumentationState, InstrumentationContext<T>> mapper) {
         // if we have zero or 1 instrumentations (and 1 is the most common), then we can avoid an object allocation
         // of the ChainedInstrumentationContext since it won't be needed
         if (instrumentations.isEmpty()) {
             return SimpleInstrumentationContext.noOp();
         }
-        ChainedInstrumentationState chainedInstrumentationState = (ChainedInstrumentationState) state;
+        ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         if (instrumentations.size() == 1) {
             return mapper.apply(instrumentations.get(0), chainedInstrumentationState.getState(0));
         }
         return new ChainedInstrumentationContext<>(chainedMapAndDropNulls(chainedInstrumentationState, mapper));
     }
 
-    private <T> T chainedInstrument(InstrumentationState state, T input, ChainedInstrumentationFunction<Instrumentation, InstrumentationState, T, T> mapper) {
-        ChainedInstrumentationState chainedInstrumentationState = (ChainedInstrumentationState) state;
+    private <T> T chainedInstrument(@Nullable InstrumentationState state, T input, ChainedInstrumentationFunction<Instrumentation, InstrumentationState, T, T> mapper) {
+        ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         for (int i = 0; i < instrumentations.size(); i++) {
             Instrumentation instrumentation = instrumentations.get(i);
             InstrumentationState specificState = chainedInstrumentationState.getState(i);
@@ -90,8 +99,8 @@ public class ChainedInstrumentation implements Instrumentation {
         return input;
     }
 
-    protected <T> ImmutableList<T> chainedMapAndDropNulls(InstrumentationState state, BiFunction<Instrumentation, InstrumentationState, T> mapper) {
-        ChainedInstrumentationState chainedInstrumentationState = (ChainedInstrumentationState) state;
+    protected <T> ImmutableList<T> chainedMapAndDropNulls(@Nullable InstrumentationState state, BiFunction<Instrumentation, InstrumentationState, T> mapper) {
+        ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         ImmutableList.Builder<T> result = ImmutableList.builderWithExpectedSize(instrumentations.size());
         for (int i = 0; i < instrumentations.size(); i++) {
             Instrumentation instrumentation = instrumentations.get(i);
@@ -104,8 +113,8 @@ public class ChainedInstrumentation implements Instrumentation {
         return result.build();
     }
 
-    protected void chainedConsume(InstrumentationState state, BiConsumer<Instrumentation, InstrumentationState> stateConsumer) {
-        ChainedInstrumentationState chainedInstrumentationState = (ChainedInstrumentationState) state;
+    protected void chainedConsume(@Nullable InstrumentationState state, BiConsumer<Instrumentation, InstrumentationState> stateConsumer) {
+        ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         for (int i = 0; i < instrumentations.size(); i++) {
             Instrumentation instrumentation = instrumentations.get(i);
             InstrumentationState specificState = chainedInstrumentationState.getState(i);
@@ -119,39 +128,39 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginExecution(parameters, specificState));
     }
 
 
     @Override
-    public @Nullable InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginParse(parameters, specificState));
     }
 
 
     @Override
-    public @Nullable InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginValidation(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginExecuteOperation(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Void> beginReactiveResults(InstrumentationReactiveResultsParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Void> beginReactiveResults(InstrumentationReactiveResultsParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginReactiveResults(parameters, specificState));
     }
 
     @Override
-    public @Nullable ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
+    public @Nullable ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, @Nullable InstrumentationState state) {
         if (instrumentations.isEmpty()) {
             return ExecutionStrategyInstrumentationContext.NOOP;
         }
         BiFunction<Instrumentation, InstrumentationState, ExecutionStrategyInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginExecutionStrategy(parameters, specificState);
-        ChainedInstrumentationState chainedInstrumentationState = (ChainedInstrumentationState) state;
+        ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         if (instrumentations.size() == 1) {
             return mapper.apply(instrumentations.get(0), chainedInstrumentationState.getState(0));
         }
@@ -159,12 +168,12 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @Override
-    public @Nullable ExecuteObjectInstrumentationContext beginExecuteObject(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
+    public @Nullable ExecuteObjectInstrumentationContext beginExecuteObject(InstrumentationExecutionStrategyParameters parameters, @Nullable InstrumentationState state) {
         if (instrumentations.isEmpty()) {
             return ExecuteObjectInstrumentationContext.NOOP;
         }
         BiFunction<Instrumentation, InstrumentationState, ExecuteObjectInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginExecuteObject(parameters, specificState);
-        ChainedInstrumentationState chainedInstrumentationState = (ChainedInstrumentationState) state;
+        ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         if (instrumentations.size() == 1) {
             return mapper.apply(instrumentations.get(0), chainedInstrumentationState.getState(0));
         }
@@ -173,33 +182,33 @@ public class ChainedInstrumentation implements Instrumentation {
 
     @ExperimentalApi
     @Override
-    public @Nullable InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginDeferredField(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginSubscribedFieldEvent(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldExecution(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldExecution(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginFieldExecution(parameters, specificState));
     }
 
     @SuppressWarnings("deprecation")
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginFieldFetch(parameters, specificState));
     }
 
     @Override
-    public @Nullable FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public @Nullable FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         if (instrumentations.isEmpty()) {
             return FieldFetchingInstrumentationContext.NOOP;
         }
         BiFunction<Instrumentation, InstrumentationState, FieldFetchingInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginFieldFetching(parameters, specificState);
-        ChainedInstrumentationState chainedInstrumentationState = (ChainedInstrumentationState) state;
+        ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         if (instrumentations.size() == 1) {
             return mapper.apply(instrumentations.get(0), chainedInstrumentationState.getState(0));
         }
@@ -208,47 +217,47 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginFieldCompletion(parameters, specificState));
     }
 
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldListCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldListCompletion(InstrumentationFieldCompleteParameters parameters, @Nullable InstrumentationState state) {
         return chainedCtx(state, (instrumentation, specificState) -> instrumentation.beginFieldListCompletion(parameters, specificState));
     }
 
     @Override
-    public ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return chainedInstrument(state, executionInput, (instrumentation, specificState, accumulator) -> instrumentation.instrumentExecutionInput(accumulator, parameters, specificState));
     }
 
     @Override
-    public DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return chainedInstrument(state, documentAndVariables, (instrumentation, specificState, accumulator) ->
                 instrumentation.instrumentDocumentAndVariables(accumulator, parameters, specificState));
     }
 
     @Override
-    public GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return chainedInstrument(state, schema, (instrumentation, specificState, accumulator) ->
                 instrumentation.instrumentSchema(accumulator, parameters, specificState));
     }
 
     @Override
-    public ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return chainedInstrument(state, executionContext, (instrumentation, specificState, accumulator) ->
                 instrumentation.instrumentExecutionContext(accumulator, parameters, specificState));
     }
 
     @Override
-    public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         return chainedInstrument(state, dataFetcher, (Instrumentation instrumentation, InstrumentationState specificState, DataFetcher<?> accumulator) ->
                 instrumentation.instrumentDataFetcher(accumulator, parameters, specificState));
     }
 
     @Override
-    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         ImmutableList<Map.Entry<Instrumentation, InstrumentationState>> entries = chainedMapAndDropNulls(state, AbstractMap.SimpleEntry::new);
         CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(entries, (entry, prevResults) -> {
             Instrumentation instrumentation = entry.getKey();
@@ -414,4 +423,3 @@ public class ChainedInstrumentation implements Instrumentation {
 
 
 }
-

--- a/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/ChainedInstrumentation.java
@@ -76,7 +76,7 @@ public class ChainedInstrumentation implements Instrumentation {
         return (ChainedInstrumentationState) assertNotNull(state);
     }
 
-    private <T> @Nullable InstrumentationContext<T> chainedCtx(@Nullable InstrumentationState state, BiFunction<Instrumentation, InstrumentationState, InstrumentationContext<T>> mapper) {
+    private <T> @Nullable InstrumentationContext<T> chainedCtx(@Nullable InstrumentationState state, BiFunction<Instrumentation, @Nullable InstrumentationState, InstrumentationContext<T>> mapper) {
         // if we have zero or 1 instrumentations (and 1 is the most common), then we can avoid an object allocation
         // of the ChainedInstrumentationContext since it won't be needed
         if (instrumentations.isEmpty()) {
@@ -89,23 +89,23 @@ public class ChainedInstrumentation implements Instrumentation {
         return new ChainedInstrumentationContext<>(chainedMapAndDropNulls(chainedInstrumentationState, mapper));
     }
 
-    private <T> T chainedInstrument(@Nullable InstrumentationState state, T input, ChainedInstrumentationFunction<Instrumentation, InstrumentationState, T, T> mapper) {
+    private <T> T chainedInstrument(@Nullable InstrumentationState state, T input, ChainedInstrumentationFunction<Instrumentation, T, T> mapper) {
         ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         for (int i = 0; i < instrumentations.size(); i++) {
             Instrumentation instrumentation = instrumentations.get(i);
-            InstrumentationState specificState = chainedInstrumentationState.getState(i);
+            @Nullable InstrumentationState specificState = chainedInstrumentationState.getState(i);
             input = mapper.apply(instrumentation, specificState, input);
         }
         return input;
     }
 
-    protected <T> ImmutableList<T> chainedMapAndDropNulls(@Nullable InstrumentationState state, BiFunction<Instrumentation, InstrumentationState, T> mapper) {
+    protected <T> ImmutableList<T> chainedMapAndDropNulls(@Nullable InstrumentationState state, BiFunction<Instrumentation, @Nullable InstrumentationState, T> mapper) {
         ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         ImmutableList.Builder<T> result = ImmutableList.builderWithExpectedSize(instrumentations.size());
         for (int i = 0; i < instrumentations.size(); i++) {
             Instrumentation instrumentation = instrumentations.get(i);
-            InstrumentationState specificState = chainedInstrumentationState.getState(i);
-            T value = mapper.apply(instrumentation, specificState);
+            @Nullable InstrumentationState specificState = chainedInstrumentationState.getState(i);
+            @Nullable T value = mapper.apply(instrumentation, specificState);
             if (value != null) {
                 result.add(value);
             }
@@ -113,11 +113,11 @@ public class ChainedInstrumentation implements Instrumentation {
         return result.build();
     }
 
-    protected void chainedConsume(@Nullable InstrumentationState state, BiConsumer<Instrumentation, InstrumentationState> stateConsumer) {
+    protected void chainedConsume(@Nullable InstrumentationState state, BiConsumer<Instrumentation, @Nullable InstrumentationState> stateConsumer) {
         ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         for (int i = 0; i < instrumentations.size(); i++) {
             Instrumentation instrumentation = instrumentations.get(i);
-            InstrumentationState specificState = chainedInstrumentationState.getState(i);
+            @Nullable InstrumentationState specificState = chainedInstrumentationState.getState(i);
             stateConsumer.accept(instrumentation, specificState);
         }
     }
@@ -159,7 +159,7 @@ public class ChainedInstrumentation implements Instrumentation {
         if (instrumentations.isEmpty()) {
             return ExecutionStrategyInstrumentationContext.NOOP;
         }
-        BiFunction<Instrumentation, InstrumentationState, ExecutionStrategyInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginExecutionStrategy(parameters, specificState);
+        BiFunction<Instrumentation, @Nullable InstrumentationState, ExecutionStrategyInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginExecutionStrategy(parameters, specificState);
         ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         if (instrumentations.size() == 1) {
             return mapper.apply(instrumentations.get(0), chainedInstrumentationState.getState(0));
@@ -172,7 +172,7 @@ public class ChainedInstrumentation implements Instrumentation {
         if (instrumentations.isEmpty()) {
             return ExecuteObjectInstrumentationContext.NOOP;
         }
-        BiFunction<Instrumentation, InstrumentationState, ExecuteObjectInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginExecuteObject(parameters, specificState);
+        BiFunction<Instrumentation, @Nullable InstrumentationState, ExecuteObjectInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginExecuteObject(parameters, specificState);
         ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         if (instrumentations.size() == 1) {
             return mapper.apply(instrumentations.get(0), chainedInstrumentationState.getState(0));
@@ -207,7 +207,7 @@ public class ChainedInstrumentation implements Instrumentation {
         if (instrumentations.isEmpty()) {
             return FieldFetchingInstrumentationContext.NOOP;
         }
-        BiFunction<Instrumentation, InstrumentationState, FieldFetchingInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginFieldFetching(parameters, specificState);
+        BiFunction<Instrumentation, @Nullable InstrumentationState, FieldFetchingInstrumentationContext> mapper = (instrumentation, specificState) -> instrumentation.beginFieldFetching(parameters, specificState);
         ChainedInstrumentationState chainedInstrumentationState = asChainedState(state);
         if (instrumentations.size() == 1) {
             return mapper.apply(instrumentations.get(0), chainedInstrumentationState.getState(0));
@@ -252,16 +252,16 @@ public class ChainedInstrumentation implements Instrumentation {
 
     @Override
     public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
-        return chainedInstrument(state, dataFetcher, (Instrumentation instrumentation, InstrumentationState specificState, DataFetcher<?> accumulator) ->
+        return chainedInstrument(state, dataFetcher, (Instrumentation instrumentation, @Nullable InstrumentationState specificState, DataFetcher<?> accumulator) ->
                 instrumentation.instrumentDataFetcher(accumulator, parameters, specificState));
     }
 
     @Override
     public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
-        ImmutableList<Map.Entry<Instrumentation, InstrumentationState>> entries = chainedMapAndDropNulls(state, AbstractMap.SimpleEntry::new);
+        ImmutableList<Map.Entry<Instrumentation, @Nullable InstrumentationState>> entries = chainedMapAndDropNulls(state, AbstractMap.SimpleEntry::new);
         CompletableFuture<List<ExecutionResult>> resultsFuture = Async.eachSequentially(entries, (entry, prevResults) -> {
             Instrumentation instrumentation = entry.getKey();
-            InstrumentationState specificState = entry.getValue();
+            @Nullable InstrumentationState specificState = entry.getValue();
             ExecutionResult lastResult = !prevResults.isEmpty() ? prevResults.get(prevResults.size() - 1) : executionResult;
             return instrumentation.instrumentExecutionResult(lastResult, parameters, specificState);
         });
@@ -269,21 +269,21 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     static class ChainedInstrumentationState implements InstrumentationState {
-        private final List<InstrumentationState> instrumentationStates;
+        private final List<@Nullable InstrumentationState> instrumentationStates;
 
-        private ChainedInstrumentationState(List<InstrumentationState> instrumentationStates) {
+        private ChainedInstrumentationState(List<@Nullable InstrumentationState> instrumentationStates) {
             this.instrumentationStates = instrumentationStates;
         }
 
-        private InstrumentationState getState(int index) {
+        private @Nullable InstrumentationState getState(int index) {
             return instrumentationStates.get(index);
         }
 
         private static CompletableFuture<InstrumentationState> combineAll(List<Instrumentation> instrumentations, InstrumentationCreateStateParameters parameters) {
-            Async.CombinedBuilder<InstrumentationState> builder = Async.ofExpectedSize(instrumentations.size());
+            Async.CombinedBuilder<@Nullable InstrumentationState> builder = Async.ofExpectedSize(instrumentations.size());
             for (Instrumentation instrumentation : instrumentations) {
                 // state can be null including the CF so handle that
-                CompletableFuture<InstrumentationState> stateCF = Async.orNullCompletedFuture(instrumentation.createStateAsync(parameters));
+                CompletableFuture<@Nullable InstrumentationState> stateCF = Async.<@Nullable InstrumentationState>orNullCompletedFuture(instrumentation.createStateAsync(parameters));
                 builder.add(stateCF);
             }
             return builder.await().thenApply(ChainedInstrumentationState::new);
@@ -417,8 +417,8 @@ public class ChainedInstrumentation implements Instrumentation {
     }
 
     @FunctionalInterface
-    private interface ChainedInstrumentationFunction<I, S, V, R> {
-        R apply(I instrumentation, S state, V value);
+    private interface ChainedInstrumentationFunction<I, V, R> {
+        R apply(I instrumentation, @Nullable InstrumentationState state, V value);
     }
 
 

--- a/src/main/java/graphql/execution/instrumentation/Instrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/Instrumentation.java
@@ -73,12 +73,13 @@ public interface Instrumentation {
      * This is called right at the start of query execution, and it's the first step in the instrumentation chain.
      *
      * @param parameters the parameters to this step
-     * @param state      the state created during the call to {@link #createStateAsync(InstrumentationCreateStateParameters)}
+     * @param state      the state created during the call to {@link #createStateAsync(InstrumentationCreateStateParameters)},
+     *                   or {@code null} when createState/createStateAsync returns null
      *
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -91,7 +92,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -104,7 +105,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -117,7 +118,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -132,7 +133,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<Void> beginReactiveResults(InstrumentationReactiveResultsParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<Void> beginReactiveResults(InstrumentationReactiveResultsParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -146,7 +147,7 @@ public interface Instrumentation {
      * @return a nullable {@link ExecutionStrategyInstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
+    default ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, @Nullable InstrumentationState state) {
         return ExecutionStrategyInstrumentationContext.NOOP;
     }
 
@@ -160,7 +161,7 @@ public interface Instrumentation {
      * @return a nullable {@link ExecutionStrategyInstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default ExecuteObjectInstrumentationContext beginExecuteObject(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
+    default ExecuteObjectInstrumentationContext beginExecuteObject(InstrumentationExecutionStrategyParameters parameters, @Nullable InstrumentationState state) {
         return ExecuteObjectInstrumentationContext.NOOP;
     }
 
@@ -176,7 +177,7 @@ public interface Instrumentation {
      */
     @ExperimentalApi
     @Nullable
-    default InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -189,7 +190,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -202,7 +203,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<Object> beginFieldExecution(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<Object> beginFieldExecution(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -219,7 +220,7 @@ public interface Instrumentation {
      */
     @Deprecated(since = "2024-04-18")
     @Nullable
-    default InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -239,7 +240,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    default FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         InstrumentationContext<Object> ctx = beginFieldFetch(parameters, state);
         return FieldFetchingInstrumentationContext.adapter(ctx);
     }
@@ -253,7 +254,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -266,7 +267,7 @@ public interface Instrumentation {
      * @return a nullable {@link InstrumentationContext} object that will be called back when the step ends (assuming it's not null)
      */
     @Nullable
-    default InstrumentationContext<Object> beginFieldListCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+    default InstrumentationContext<Object> beginFieldListCompletion(InstrumentationFieldCompleteParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
@@ -281,7 +282,7 @@ public interface Instrumentation {
      * @return a non-null instrumented ExecutionInput, the default is to return to the same object
      */
     @NonNull
-    default ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    default ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return executionInput;
     }
 
@@ -295,7 +296,7 @@ public interface Instrumentation {
      * @return a non-null instrumented DocumentAndVariables, the default is to return to the same objects
      */
     @NonNull
-    default DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    default DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return documentAndVariables;
     }
 
@@ -310,7 +311,7 @@ public interface Instrumentation {
      * @return a non-null instrumented GraphQLSchema, the default is to return to the same object
      */
     @NonNull
-    default GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    default GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return schema;
     }
 
@@ -325,7 +326,7 @@ public interface Instrumentation {
      * @return a non-null instrumented ExecutionContext, the default is to return to the same object
      */
     @NonNull
-    default ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    default ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return executionContext;
     }
 
@@ -342,7 +343,7 @@ public interface Instrumentation {
      * @return a non-null instrumented DataFetcher, the default is to return to the same object
      */
     @NonNull
-    default DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    default DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         return dataFetcher;
     }
 
@@ -356,7 +357,7 @@ public interface Instrumentation {
      * @return a new execution result completable future
      */
     @NonNull
-    default CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    default CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return CompletableFuture.completedFuture(executionResult);
     }
 }

--- a/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
@@ -51,78 +51,78 @@ public class NoContextChainedInstrumentation extends ChainedInstrumentation {
         super(instrumentations);
     }
 
-    private <T> @Nullable T runAll(InstrumentationState state, BiConsumer<Instrumentation, InstrumentationState> stateConsumer) {
+    private <T> @Nullable T runAll(@Nullable InstrumentationState state, BiConsumer<Instrumentation, InstrumentationState> stateConsumer) {
         chainedConsume(state, stateConsumer);
         return null;
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginExecution(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginParse(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginValidation(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginExecuteOperation(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Void> beginReactiveResults(InstrumentationReactiveResultsParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Void> beginReactiveResults(InstrumentationReactiveResultsParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginReactiveResults(parameters, specificState));
     }
 
     @Override
-    public @Nullable ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
+    public @Nullable ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginExecutionStrategy(parameters, specificState));
     }
 
     @Override
-    public @Nullable ExecuteObjectInstrumentationContext beginExecuteObject(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
+    public @Nullable ExecuteObjectInstrumentationContext beginExecuteObject(InstrumentationExecutionStrategyParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginExecuteObject(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginDeferredField(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginDeferredField(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginSubscribedFieldEvent(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldExecution(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldExecution(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginFieldExecution(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginFieldFetch(parameters, specificState));
     }
 
     @Override
-    public @Nullable FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public @Nullable FieldFetchingInstrumentationContext beginFieldFetching(InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginFieldFetching(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginFieldCompletion(parameters, specificState));
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldListCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldListCompletion(InstrumentationFieldCompleteParameters parameters, @Nullable InstrumentationState state) {
         return runAll(state, (instrumentation, specificState) -> instrumentation.beginFieldListCompletion(parameters, specificState));
     }
 

--- a/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/NoContextChainedInstrumentation.java
@@ -51,7 +51,7 @@ public class NoContextChainedInstrumentation extends ChainedInstrumentation {
         super(instrumentations);
     }
 
-    private <T> @Nullable T runAll(@Nullable InstrumentationState state, BiConsumer<Instrumentation, InstrumentationState> stateConsumer) {
+    private <T> @Nullable T runAll(@Nullable InstrumentationState state, BiConsumer<Instrumentation, @Nullable InstrumentationState> stateConsumer) {
         chainedConsume(state, stateConsumer);
         return null;
     }

--- a/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/SimplePerformantInstrumentation.java
@@ -58,87 +58,87 @@ public class SimplePerformantInstrumentation implements Instrumentation {
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public @Nullable InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public @Nullable InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public @Nullable ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
+    public @Nullable ExecutionStrategyInstrumentationContext beginExecutionStrategy(InstrumentationExecutionStrategyParameters parameters, @Nullable InstrumentationState state) {
         return ExecutionStrategyInstrumentationContext.NOOP;
     }
 
     @Override
-    public @Nullable ExecuteObjectInstrumentationContext beginExecuteObject(InstrumentationExecutionStrategyParameters parameters, InstrumentationState state) {
+    public @Nullable ExecuteObjectInstrumentationContext beginExecuteObject(InstrumentationExecutionStrategyParameters parameters, @Nullable InstrumentationState state) {
         return ExecuteObjectInstrumentationContext.NOOP;
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginSubscribedFieldEvent(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldExecution(InstrumentationFieldParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldExecution(InstrumentationFieldParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldCompletion(InstrumentationFieldCompleteParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public @Nullable InstrumentationContext<Object> beginFieldListCompletion(InstrumentationFieldCompleteParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<Object> beginFieldListCompletion(InstrumentationFieldCompleteParameters parameters, @Nullable InstrumentationState state) {
         return noOp();
     }
 
     @Override
-    public ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public ExecutionInput instrumentExecutionInput(ExecutionInput executionInput, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return executionInput;
     }
 
     @Override
-    public DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public DocumentAndVariables instrumentDocumentAndVariables(DocumentAndVariables documentAndVariables, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return documentAndVariables;
     }
 
     @Override
-    public GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public GraphQLSchema instrumentSchema(GraphQLSchema schema, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return schema;
     }
 
     @Override
-    public ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return executionContext;
     }
 
     @Override
-    public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, InstrumentationState state) {
+    public DataFetcher<?> instrumentDataFetcher(DataFetcher<?> dataFetcher, InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState state) {
         return dataFetcher;
     }
 
     @Override
-    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
+    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState state) {
         return CompletableFuture.completedFuture(executionResult);
     }
 }

--- a/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/fieldvalidation/FieldValidationInstrumentation.java
@@ -40,7 +40,7 @@ public class FieldValidationInstrumentation extends SimplePerformantInstrumentat
     }
 
     @Override
-    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, InstrumentationState state) {
+    public @Nullable InstrumentationContext<ExecutionResult> beginExecuteOperation(InstrumentationExecuteOperationParameters parameters, @Nullable InstrumentationState state) {
         List<GraphQLError> errors = FieldValidationSupport.validateFieldsAndArguments(fieldValidation, parameters.getExecutionContext());
         if (errors != null && !errors.isEmpty()) {
             throw new AbortExecutionException(errors);

--- a/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
+++ b/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java
@@ -78,7 +78,7 @@ public class TracingInstrumentation extends SimplePerformantInstrumentation {
     }
 
     @Override
-    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState rawState) {
+    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters, @Nullable InstrumentationState rawState) {
         Map<Object, Object> currentExt = executionResult.getExtensions();
 
         TracingSupport tracingSupport = ofState(rawState);
@@ -89,21 +89,21 @@ public class TracingInstrumentation extends SimplePerformantInstrumentation {
     }
 
     @Override
-    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, InstrumentationState rawState) {
+    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters, @Nullable InstrumentationState rawState) {
         TracingSupport tracingSupport = ofState(rawState);
         TracingSupport.TracingContext ctx = tracingSupport.beginField(parameters.getEnvironment(), parameters.isTrivialDataFetcher());
         return whenCompleted((result, t) -> ctx.onEnd());
     }
 
     @Override
-    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, InstrumentationState rawState) {
+    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters, @Nullable InstrumentationState rawState) {
         TracingSupport tracingSupport = ofState(rawState);
         TracingSupport.TracingContext ctx = tracingSupport.beginParse();
         return whenCompleted((result, t) -> ctx.onEnd());
     }
 
     @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, InstrumentationState rawState) {
+    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters, @Nullable InstrumentationState rawState) {
         TracingSupport tracingSupport = ofState(rawState);
         TracingSupport.TracingContext ctx = tracingSupport.beginValidation();
         return whenCompleted((result, t) -> ctx.onEnd());

--- a/src/test/groovy/graphql/execution/instrumentation/InstrumentationStateNullabilityTest.groovy
+++ b/src/test/groovy/graphql/execution/instrumentation/InstrumentationStateNullabilityTest.groovy
@@ -1,0 +1,47 @@
+package graphql.execution.instrumentation
+
+import graphql.GraphQL
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import spock.lang.Specification
+
+class InstrumentationStateNullabilityTest extends Specification {
+
+    def "stateless Kotlin instrumentation executes with null state"() {
+        given:
+        def fixtureClass = Class.forName("graphql.execution.instrumentation.KotlinStatelessInstrumentation")
+        def instrumentation = fixtureClass.getDeclaredConstructor().newInstance() as Instrumentation
+        def typeRegistry = new SchemaParser().parse("""
+            type Query {
+              hello: String
+            }
+        """)
+        def schema = new SchemaGenerator().makeExecutableSchema(typeRegistry, RuntimeWiring.MOCKED_WIRING)
+        def graphQL = GraphQL.newGraphQL(schema).instrumentation(instrumentation).build()
+
+        when:
+        def result = graphQL.execute("{ hello }")
+
+        then:
+        result.errors.isEmpty()
+        fixtureClass.getMethod("getSeenStates").invoke(instrumentation) == [null]
+    }
+
+    def "Kotlin chained instrumentation receives nullable child state"() {
+        given:
+        def fixtureClass = Class.forName("graphql.execution.instrumentation.KotlinChainedInstrumentation")
+        def instrumentation = fixtureClass
+                .getDeclaredConstructor(Instrumentation)
+                .newInstance(SimplePerformantInstrumentation.INSTANCE) as ChainedInstrumentation
+        def state = instrumentation.createStateAsync(null).join()
+
+        when:
+        def childState = fixtureClass
+                .getMethod("consumeChildState", InstrumentationState)
+                .invoke(instrumentation, state)
+
+        then:
+        childState == null
+    }
+}

--- a/src/test/kotlin/graphql/execution/instrumentation/KotlinInstrumentationStateFixtures.kt
+++ b/src/test/kotlin/graphql/execution/instrumentation/KotlinInstrumentationStateFixtures.kt
@@ -1,0 +1,26 @@
+package graphql.execution.instrumentation
+
+import graphql.ExecutionResult
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
+
+class KotlinStatelessInstrumentation : SimplePerformantInstrumentation() {
+    val seenStates = mutableListOf<InstrumentationState?>()
+
+    override fun beginExecution(
+        parameters: InstrumentationExecutionParameters,
+        state: InstrumentationState?,
+    ): InstrumentationContext<ExecutionResult> {
+        seenStates.add(state)
+        return SimpleInstrumentationContext.noOp()
+    }
+}
+
+class KotlinChainedInstrumentation(
+    instrumentation: Instrumentation,
+) : ChainedInstrumentation(instrumentation) {
+    fun consumeChildState(state: InstrumentationState?): InstrumentationState? {
+        var observedState: InstrumentationState? = null
+        chainedConsume(state) { _, childState -> observedState = childState }
+        return observedState
+    }
+}


### PR DESCRIPTION
Backport of #4435 to the `26.x` maintenance branch.

## Summary

- mark instrumentation callback `InstrumentationState` parameters as `@Nullable`, matching the existing optional-state runtime contract
- propagate nullable child states through `ChainedInstrumentation` and `NoContextChainedInstrumentation`
- cover the Kotlin-facing signatures with compile fixtures exercised by Spock
- retain the existing `26.x` field-fetching implementation while applying the nullability fix

This backports the fix for #4433. Kotlin implementations overriding these callbacks must declare the state parameter as `InstrumentationState?`.

## Verification

- `./gradlew test --tests graphql.execution.instrumentation.InstrumentationStateNullabilityTest --tests graphql.execution.instrumentation.InstrumentationTest --tests graphql.execution.instrumentation.ChainedInstrumentationStateTest --tests graphql.execution.instrumentation.NoContextChainedInstrumentationTest --tests graphql.execution.instrumentation.TracingInstrumentationTest`
- 28 focused tests passed
- Kotlin compilation and NullAway/ErrorProne checks passed as part of the build